### PR TITLE
chore(taskfile): platform-aware switch task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,11 +12,13 @@ tasks:
     desc: Perform osx build
     aliases:
       - osx
+    platforms: [darwin]
     cmd: sudo darwin-rebuild switch --flake ./
   build-linux:
     desc: Perform linux based build
     aliases:
       - linux
+    platforms: [linux]
     cmd: sudo nixos-rebuild switch --flake ./
   switch:
     desc: Runs the appropriate switch command for the platform
@@ -24,7 +26,11 @@ tasks:
       - build
       - b
       - s
-    cmd: task build-osx
+    cmds:
+      - cmd: task build-osx
+        platforms: [darwin]
+      - cmd: task build-linux
+        platforms: [linux]
   test:
     desc: Run nix flake check
     aliases:


### PR DESCRIPTION
Make Taskfile switch task platform-aware and DRY by using Taskfile platform filters for macOS and Linux builds.