### PR TITLE
feat: Add Mealie recipe manager to drlight

### DIFF
--- a/modules/nixos/services.nix
+++ b/modules/nixos/services.nix
@@ -17,4 +17,11 @@
   #   enable = true;
   #   # ... configuration
   # };
+
+  # Mealie recipe manager
+  services.mealie = {
+    enable = true;
+    database.createLocally = true;
+    port = 9000;
+  };
 }

--- a/targets/drlight/default.nix
+++ b/targets/drlight/default.nix
@@ -62,8 +62,11 @@
   '';
 
   # Host/network/time/SSH settings for drlight
-  networking.hostName = "drlight";
-  networking.networkmanager.enable = true;
+  networking = {
+    hostName = "drlight";
+    networkmanager.enable = true;
+    firewall.allowedTCPPorts = [9000];
+  };
   time.timeZone = "America/New_York";
 
   services.openssh.enable = true;


### PR DESCRIPTION
## Summary

Add Mealie recipe manager service to the drlight NixOS configuration.

### Changes
- **Services**: Add Mealie service with local PostgreSQL database creation
- **Firewall**: Open port 9000 for Mealie web interface access  
- **Configuration**: Consolidate networking settings for better code style

### Testing
- All configurations validated with `task test`
- Pre-commit hooks pass (alejandra, deadnix, statix)
- Mealie will be accessible at `http://drlight:9000` after deployment

### Deployment
Run `task build:nixos:drlight` to apply changes to the drlight system.