### PR TITLE
refactor: move logseq from creative to workstation role

### DIFF
--- a/bundles/roles/creative/README.md
+++ b/bundles/roles/creative/README.md
@@ -16,8 +16,7 @@ This bundle supports creative workflows including:
 - `ffmpeg` - Video/audio processing
 - `imagemagick` - Image manipulation
 
-### Knowledge Management
-- `logseq` - Note-taking and knowledge graph application
+
 
 ### Content Creation
 - `glow` - Markdown renderer

--- a/bundles/roles/creative/default.nix
+++ b/bundles/roles/creative/default.nix
@@ -10,9 +10,6 @@
     ffmpeg
     imagemagick
 
-    # Note-taking and knowledge management
-    logseq
-
     # Text processing and viewing
     pandoc
   ];

--- a/bundles/roles/workstation/README.md
+++ b/bundles/roles/workstation/README.md
@@ -15,6 +15,9 @@ This bundle supports general computing tasks including:
 ### Communication
 - `slack` - Team communication platform
 
+### Productivity
+- `logseq` - Note-taking and knowledge graph application
+
 ### Networking
 - `trippy` - Network diagnostic tool
 

--- a/bundles/roles/workstation/default.nix
+++ b/bundles/roles/workstation/default.nix
@@ -7,6 +7,7 @@
   # Workstation role bundle - general productivity tools
   environment.systemPackages = with pkgs; [
     # Productivity tools
+    logseq
     slack
     trippy
 


### PR DESCRIPTION
Move Logseq from the creative role bundle to the workstation role bundle.

## Changes
- Remove logseq from bundles/roles/creative/
- Add logseq to bundles/roles/workstation/
- Update README documentation for both bundles

## Impact
- wweaver system: gains logseq
- drlight system: loses logseq  
- MegamanX system: unchanged (has both roles)
- zero system: unchanged

This moves logseq to a more general productivity-focused bundle rather than the creative-specific bundle.