### PR TITLE
chore: update flake inputs to latest versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1758543057,
-        "narHash": "sha256-lw3V2jOGYphUFHYQ5oARcb6urlbNpUCLJy1qhsGdUmc=",
+        "lastModified": 1761551821,
+        "narHash": "sha256-N3Zj73TAxclhLGgADbPVwcVrhYIBKUgAxjfQuOXre6s=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "5b236456eb93133c2bd0d60ef35ed63f1c0712f6",
+        "rev": "8f6719274133c5bcc24c058c5a6bcbb3b0cd48b3",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.6.12",
+        "ref": "4.6.19",
         "repo": "brew",
         "type": "github"
       }
@@ -93,11 +93,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1761260752,
-        "narHash": "sha256-qO3IZUfqGAWiqaO2P9J2a8epFVS5V8w+ouoam7E+NqY=",
+        "lastModified": 1763062698,
+        "narHash": "sha256-sO7KJi929DtdqvMy+VNwRNE+xa8oSSV92EiUAuCThZQ=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "ac994c82d8a9561534b92461fd210b890a87fc37",
+        "rev": "9efef034e8dbc9469defe9786e93d61b826a52f6",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1761262779,
-        "narHash": "sha256-bfWCiqmgW0gjVHaVIxHRzByF/QlpP5NMlDVsofwVHsA=",
+        "lastModified": 1763062991,
+        "narHash": "sha256-IjIZbXK3NpX1mDHkyTlQsAmmEPW6ndVEvBSwJeK7hms=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "bd60801f6c9fd317d5f12ac418bd4e496eef04bc",
+        "rev": "47a660474d7b642ee3b11aec5c5d2aa7d8e44521",
         "type": "github"
       },
       "original": {
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759509947,
-        "narHash": "sha256-4XifSIHfpJKcCf5bZZRhj8C4aCpjNBaE3kXr02s4rHU=",
+        "lastModified": 1762912391,
+        "narHash": "sha256-4hpBE7bGd24SfD28rzMdUGXsLsNEYxCCrTipFdoqoNM=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "000eadb231812ad6ea6aebd7526974aaf4e79355",
+        "rev": "d76299b2cd01837c4c271a7b5186e3d5d8ebd126",
         "type": "github"
       },
       "original": {
@@ -171,11 +171,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1758598228,
-        "narHash": "sha256-qr60maXGbZ4FX5tejPRI3nr0bnRTnZ3AbbbfO6/6jq4=",
+        "lastModified": 1761927470,
+        "narHash": "sha256-KsFDGRGD8j1R6TvJ4HkebKsh3HXLY0XazanLrhO3wqE=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "f36e5db56e117f7df701ab152d0d2036ea85218c",
+        "rev": "3cae36b3a17b09a66435291619dce8cf2c4728ca",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1761114652,
-        "narHash": "sha256-f/QCJM/YhrV/lavyCVz8iU3rlZun6d+dAiC3H+CDle4=",
+        "lastModified": 1762844143,
+        "narHash": "sha256-SlybxLZ1/e4T2lb1czEtWVzDCVSTvk9WLwGhmxFmBxI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "01f116e4df6a15f4ccdffb1bcd41096869fb385c",
+        "rev": "9da7f1cf7f8a6e2a7cb3001b048546c92a8258b4",
         "type": "github"
       },
       "original": {
@@ -234,11 +234,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1761016216,
-        "narHash": "sha256-G/iC4t/9j/52i/nm+0/4ybBmAF4hzR8CNHC75qEhjHo=",
+        "lastModified": 1762756533,
+        "narHash": "sha256-HiRDeUOD1VLklHeOmaKDzf+8Hb7vSWPVFcWwaTrpm+U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "481cf557888e05d3128a76f14c76397b7d7cc869",
+        "rev": "c2448301fb856e351aab33e64c33a3fc8bcf637d",
         "type": "github"
       },
       "original": {

--- a/targets/drlight/default.nix
+++ b/targets/drlight/default.nix
@@ -13,6 +13,11 @@
     ./hardware-configuration.nix
   ];
 
+  # Temporarily allow insecure lima package until updated
+  nixpkgs.config.permittedInsecurePackages = [
+    "lima-1.0.7"
+  ];
+
   # Ensure the user exists with the desired shell and groups
   users.users.monkey = {
     isNormalUser = true;

--- a/targets/zero/default.nix
+++ b/targets/zero/default.nix
@@ -16,6 +16,11 @@
     ./hardware-configuration.nix
   ];
 
+  # Temporarily allow insecure lima package until updated
+  nixpkgs.config.permittedInsecurePackages = [
+    "lima-1.0.7"
+  ];
+
   # Packages
   environment.systemPackages = with pkgs; [
     vim
@@ -40,7 +45,7 @@
   '';
 
   # Kernel / boot overrides
-  boot.kernelPackages = lib.mkForce pkgs.linuxPackages_6_16;
+  boot.kernelPackages = lib.mkForce pkgs.linuxPackages_6_12;
 
   # Security/runtime
   security.rtkit.enable = true;


### PR DESCRIPTION
## Summary
Update flake inputs to their latest versions and fix compatibility issues.

### Changes
- Updated nixpkgs from Oct 21 to Nov 10
- Updated nixpkgs-unstable from Oct 22 to Nov 11  
- Updated nix-darwin from Oct 3 to Nov 12
- Updated homebrew-core and homebrew-cask from Oct 23 to Nov 13
- Updated nix-homebrew from Sep 23 to Oct 31
- Fixed kernel version in zero target (6.16 → 6.12)
- Temporarily allowed insecure lima-1.0.7 package

### Testing
All flake configurations validated successfully with `nix flake check`.