### PR TITLE
Revert flake inputs update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1761551821,
-        "narHash": "sha256-N3Zj73TAxclhLGgADbPVwcVrhYIBKUgAxjfQuOXre6s=",
+        "lastModified": 1758543057,
+        "narHash": "sha256-lw3V2jOGYphUFHYQ5oARcb6urlbNpUCLJy1qhsGdUmc=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "8f6719274133c5bcc24c058c5a6bcbb3b0cd48b3",
+        "rev": "5b236456eb93133c2bd0d60ef35ed63f1c0712f6",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.6.19",
+        "ref": "4.6.12",
         "repo": "brew",
         "type": "github"
       }
@@ -93,11 +93,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1763062698,
-        "narHash": "sha256-sO7KJi929DtdqvMy+VNwRNE+xa8oSSV92EiUAuCThZQ=",
+        "lastModified": 1761260752,
+        "narHash": "sha256-qO3IZUfqGAWiqaO2P9J2a8epFVS5V8w+ouoam7E+NqY=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "9efef034e8dbc9469defe9786e93d61b826a52f6",
+        "rev": "ac994c82d8a9561534b92461fd210b890a87fc37",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1763062991,
-        "narHash": "sha256-IjIZbXK3NpX1mDHkyTlQsAmmEPW6ndVEvBSwJeK7hms=",
+        "lastModified": 1761262779,
+        "narHash": "sha256-bfWCiqmgW0gjVHaVIxHRzByF/QlpP5NMlDVsofwVHsA=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "47a660474d7b642ee3b11aec5c5d2aa7d8e44521",
+        "rev": "bd60801f6c9fd317d5f12ac418bd4e496eef04bc",
         "type": "github"
       },
       "original": {
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762912391,
-        "narHash": "sha256-4hpBE7bGd24SfD28rzMdUGXsLsNEYxCCrTipFdoqoNM=",
+        "lastModified": 1759509947,
+        "narHash": "sha256-4XifSIHfpJKcCf5bZZRhj8C4aCpjNBaE3kXr02s4rHU=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "d76299b2cd01837c4c271a7b5186e3d5d8ebd126",
+        "rev": "000eadb231812ad6ea6aebd7526974aaf4e79355",
         "type": "github"
       },
       "original": {
@@ -171,11 +171,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1761927470,
-        "narHash": "sha256-KsFDGRGD8j1R6TvJ4HkebKsh3HXLY0XazanLrhO3wqE=",
+        "lastModified": 1758598228,
+        "narHash": "sha256-qr60maXGbZ4FX5tejPRI3nr0bnRTnZ3AbbbfO6/6jq4=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "3cae36b3a17b09a66435291619dce8cf2c4728ca",
+        "rev": "f36e5db56e117f7df701ab152d0d2036ea85218c",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1762844143,
-        "narHash": "sha256-SlybxLZ1/e4T2lb1czEtWVzDCVSTvk9WLwGhmxFmBxI=",
+        "lastModified": 1761114652,
+        "narHash": "sha256-f/QCJM/YhrV/lavyCVz8iU3rlZun6d+dAiC3H+CDle4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9da7f1cf7f8a6e2a7cb3001b048546c92a8258b4",
+        "rev": "01f116e4df6a15f4ccdffb1bcd41096869fb385c",
         "type": "github"
       },
       "original": {
@@ -234,11 +234,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1762756533,
-        "narHash": "sha256-HiRDeUOD1VLklHeOmaKDzf+8Hb7vSWPVFcWwaTrpm+U=",
+        "lastModified": 1761016216,
+        "narHash": "sha256-G/iC4t/9j/52i/nm+0/4ybBmAF4hzR8CNHC75qEhjHo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c2448301fb856e351aab33e64c33a3fc8bcf637d",
+        "rev": "481cf557888e05d3128a76f14c76397b7d7cc869",
         "type": "github"
       },
       "original": {

--- a/targets/drlight/default.nix
+++ b/targets/drlight/default.nix
@@ -13,11 +13,6 @@
     ./hardware-configuration.nix
   ];
 
-  # Temporarily allow insecure lima package until updated
-  nixpkgs.config.permittedInsecurePackages = [
-    "lima-1.0.7"
-  ];
-
   # Ensure the user exists with the desired shell and groups
   users.users.monkey = {
     isNormalUser = true;

--- a/targets/zero/default.nix
+++ b/targets/zero/default.nix
@@ -16,11 +16,6 @@
     ./hardware-configuration.nix
   ];
 
-  # Temporarily allow insecure lima package until updated
-  nixpkgs.config.permittedInsecurePackages = [
-    "lima-1.0.7"
-  ];
-
   # Packages
   environment.systemPackages = with pkgs; [
     vim
@@ -45,7 +40,7 @@
   '';
 
   # Kernel / boot overrides
-  boot.kernelPackages = lib.mkForce pkgs.linuxPackages_6_12;
+  boot.kernelPackages = lib.mkForce pkgs.linuxPackages_6_16;
 
   # Security/runtime
   security.rtkit.enable = true;


### PR DESCRIPTION
## Summary
- Reverts the changes from commit "chore: update flake inputs to latest versions (#35)"
- This undoes the recent flake input updates, restoring previous versions