### PR TITLE
feat: Add moonlight-qt to gaming role bundle

### DIFF
--- a/bundles/roles/gaming/default.nix
+++ b/bundles/roles/gaming/default.nix
@@ -6,6 +6,7 @@
 }: {
   # Gaming role bundle - tools for gaming and entertainment
   environment.systemPackages = with pkgs; [
+    moonlight-qt  # Game streaming client for playing games from remote hosts
     # Gaming platforms will be added here
     # Note: Most gaming applications are platform-specific and handled in platform bundles
   ];


### PR DESCRIPTION
## Summary
- Add moonlight-qt package to the gaming role bundle for game streaming functionality
- Enables playing games from remote hosts through the Moonlight game streaming client
- Expands the gaming bundle capabilities beyond platform-specific gaming applications

## Changes
- Added moonlight-qt to bundles/roles/gaming/default.nix
- Maintains the existing architecture where platform-specific gaming apps are handled in platform bundles
- Includes descriptive comment explaining the purpose of moonlight-qt

## Testing
- Configuration validated with Nix flake checks
- Gaming bundle builds successfully on supported platforms