### PR TITLE
fix: use optionalAttrs instead of optionals for homebrew config merge

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,7 @@
           homebrew =
             bundles.platforms.darwin.config.homebrew or {}
             // lib.mkMerge (map (role: bundles.roles.${role}.config.homebrew or {}) enabledRoles)
-            // (lib.optionals (lib.elem "megamanx_llm_host" enabledRoles) (collectConfig "roles.llms.host" {}).homebrew or {});
+            // (lib.optionalAttrs (lib.elem "megamanx_llm_host" enabledRoles) ((collectConfig "roles.llms.host" {}).homebrew or {}));
         };
       in
         baseConfig // darwinConfig;


### PR DESCRIPTION
## Summary

- Fix `task switch` failure on Darwin machines without the `megamanx_llm_host` role enabled
- Change `lib.optionals` to `lib.optionalAttrs` for proper attribute set merging with the `//` operator

## Problem

The `//` (attribute set merge) operator requires both operands to be attribute sets. Using `lib.optionals` returns a list (empty `[]` when condition is false), causing the error:

```
error: expected a set but found a list: [ ]
```

## Solution

Replace `lib.optionals` with `lib.optionalAttrs` which returns an empty attribute set `{}` when the condition is false, making it compatible with the `//` operator.

## Affected Machines

Only the `wweaver` Darwin machine was affected. `MegamanX` has the role enabled (so condition is always true), and Linux machines don't evaluate the `darwinConfig` block.