### PR TITLE
feat: add ssh-env to Ghostty shell integration features

### DIFF
--- a/modules/home-manager/development.nix
+++ b/modules/home-manager/development.nix
@@ -28,7 +28,7 @@
       # Keep ghostty running in background for global keybinds
       initial-window = false
       quit-after-last-window-closed = false
-      shell-integration-features = ssh-terminfo
+      shell-integration-features = ssh-env,ssh-terminfo
     '';
   };
 


### PR DESCRIPTION
## Summary
- Add ssh-env to Ghostty shell integration features alongside existing ssh-terminfo
- Enables SSH environment variable preservation for improved remote session experience
- Affects all 4 systems (wweaver, MegamanX, drlight, zero) that use the development module

## Technical Details
- Updated `shell-integration-features` from `ssh-terminfo` to `ssh-env,ssh-terminfo` in alphabetical order
- Configuration applied through home-manager's xdg.configFile mechanism
- All validation checks pass (flake check, NixOS, and Darwin configurations)

## Files Changed
- `modules/home-manager/development.nix`: Line 31 updated

## Impact
This change will be applied to users when they rebuild their Nix configurations with `darwin-rebuild switch` (macOS) or `nixos-rebuild switch` (Linux).