### PR TITLE
fix: enable nix-homebrew autoMigrate by default for Darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -200,7 +200,6 @@
           nix-homebrew = {
             enable = true;
             enableRosetta = true;
-            autoMigrate = true;
             user = "monkey";
             taps = {
               "homebrew/homebrew-core" = homebrew-core;

--- a/os/darwin.nix
+++ b/os/darwin.nix
@@ -5,6 +5,9 @@
 }: {
   nix.enable = false;
 
+  # Enable auto-migration for nix-homebrew by default
+  nix-homebrew.autoMigrate = true;
+
   # Require password for each sudo command
   security.sudo.extraConfig = ''
     Defaults timestamp_timeout=0


### PR DESCRIPTION
## Summary
- Enable `autoMigrate = true` by default in `os/darwin.nix` for all macOS configurations
- Prevents "existing /opt/homebrew/bin/brew is in the way" errors when switching on systems with pre-existing Homebrew installations

## Changes
- `os/darwin.nix`: Added `nix-homebrew.autoMigrate = true;`
- `flake.nix`: Removed redundant `autoMigrate = true` from individual Darwin configurations (now inherited)