### PR TITLE
fix: add SSH commit signing configuration for macOS

### DIFF
--- a/modules/common/users.nix
+++ b/modules/common/users.nix
@@ -67,9 +67,15 @@ with lib; {
                 push.default = "current";
               }
               // lib.optionalAttrs (builtins.elem config.nixpkgs.hostPlatform.system ["aarch64-darwin" "x86_64-darwin"]) {
-                gpg.format = "ssh";
-                gpg.ssh.program = "/Applications/1Password.app/Contents/MacOS/op-ssh-sign";
+                gpg = {
+                  format = "ssh";
+                  ssh = {
+                    program = "/Applications/1Password.app/Contents/MacOS/op-ssh-sign";
+                    allowedSignersFile = "~/.ssh/allowed_signers";
+                  };
+                };
                 commit.gpgsign = true;
+                user.signingkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIIxGvpCUmx1UV3K22/+sWLdRknZmlTmQgckoAUCApF8";
               };
           };
 
@@ -89,6 +95,12 @@ with lib; {
           home.file.".ssh/config".text = lib.optionalString (builtins.elem config.nixpkgs.hostPlatform.system ["aarch64-darwin" "x86_64-darwin"]) ''
             Host *
               IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+          '';
+
+          # Allowed signers file for SSH signature verification
+          # Maps email addresses to trusted SSH public keys for local commit verification
+          home.file.".ssh/allowed_signers".text = lib.optionalString (builtins.elem config.nixpkgs.hostPlatform.system ["aarch64-darwin" "x86_64-darwin"]) ''
+            ${user.email} ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIIxGvpCUmx1UV3K22/+sWLdRknZmlTmQgckoAUCApF8
           '';
 
           # Include shared home-manager modules


### PR DESCRIPTION
## Summary

- Adds `user.signingkey` to git config for SSH-based commit signing with 1Password
- Adds `allowedSignersFile` configuration for local signature verification
- Creates `~/.ssh/allowed_signers` file mapping email to trusted SSH public key

These changes enable proper git commit signing on macOS using 1Password's SSH agent, and allow local verification of signed commits with `git log --show-signature`.