### PR TITLE
feat(aerospace): add keybindings to move workspaces between monitors

### DIFF
--- a/modules/home-manager/aerospace.nix
+++ b/modules/home-manager/aerospace.nix
@@ -63,6 +63,10 @@
         shift-ctrl-alt-5 = "workspace --wrap-around prev";
         shift-ctrl-alt-6 = "workspace --wrap-around next";
         shift-ctrl-alt-equal = "move-node-to-workspace --wrap-around next";
+
+        # Move workspace to monitor
+        shift-ctrl-alt-bracketleft = "move-workspace-to-monitor --wrap-around prev";
+        shift-ctrl-alt-bracketright = "move-workspace-to-monitor --wrap-around next";
       };
 
       on-window-detected = [


### PR DESCRIPTION
## Summary
- Add keyboard shortcuts to move the current workspace to adjacent monitors using `Shift+Ctrl+Alt+[` (previous) and `Shift+Ctrl+Alt+]` (next)
- Both bindings use `--wrap-around` for continuous cycling between monitors

**Note:** Workspaces with `workspace-to-monitor-force-assignment` cannot be moved (e.g., 1.Main, 2.Comms, 3.Dash, 4.Distracted).