### PR TITLE
refactor(aliases): rename gpo to gpro for clarity

### DIFF
--- a/modules/home-manager/aliases.nix
+++ b/modules/home-manager/aliases.nix
@@ -20,6 +20,6 @@
     kk = "opencode run"; # AI assistant run command
     gkk = "opencode run \"First check if the current branch is the default branch (main/master). If it is, create a new appropriately-named branch based on the changes before committing. Then review all changes, stage them, generate an appropriate commit message, and commit and push the changes\""; # AI-assisted git workflow: creates branch if on default, then review, stage, commit message generation, commit, and push
     gpr = "opencode run \"Check if there's already an open pull request for this branch. If there is, update it with the latest changes. If not, analyze all changes since diverging from the main branch and create a new pull request with an appropriate title and body. After the PR is created or updated, ask me if I want to open it in the browser. Wait for my response. Default to yes if I just press enter. If I say yes or press enter, open the PR in my default browser using 'gh pr view --web'.\""; # AI-assisted pull request creation/update with analysis and PR generation
-    gpo = "gh pr view --web"; # Open current PR in browser
+    gpro = "gh pr view --web"; # Open current PR in browser
   };
 }


### PR DESCRIPTION
## Summary
- Rename the `gpo` shell alias to `gpro` for better naming consistency with related git/PR aliases
- Aligns with the `gpr` naming convention: `gpr` creates PRs, `gpro` (gpr + open) opens them in browser