### PR TITLE
refactor(aliases): organize aliases by bundle dependency

### DIFF
--- a/bundles.nix
+++ b/bundles.nix
@@ -60,6 +60,11 @@ with lib; {
           gr = "git restore --source";
           grh = "git reset --hard";
           ghv = "gh repo view --web";
+          gclean = "git clean -fd";
+          gkkb = "git checkout -b $(date +\"%Y%m%d%H%M%S\")";
+
+          # Nix tools
+          try = "nix-shell -p";
 
           # Task runner
           t = "task";

--- a/modules/home-manager/aliases.nix
+++ b/modules/home-manager/aliases.nix
@@ -10,8 +10,6 @@ in {
   # This module contains aliases for programs NOT installed in base bundle
 
   home.shellAliases = {
-    # Development tools
-    try = "nix-shell -p";
     # Development tool aliases
     ops =
       if cfg.enable or false
@@ -20,7 +18,5 @@ in {
     # AI assistant aliases
     oc = "opencode";
     kk = "opencode run";
-    # Git aliases
-    gkkb = "git checkout -b $(date +\"%Y%m%d%H%M%S\")";
   };
 }


### PR DESCRIPTION
## Summary
- Move `gclean`, `gkkb`, and `try` aliases to base bundle where they belong with other fundamental tools
- Keep only conditional (`ops`) and developer bundle-specific (`oc`, `kk`) aliases in home-manager
- Consolidate all Git aliases in the base bundle for consistency

## Changes
- **bundles.nix**: Added `gclean`, `gkkb`, and `try` aliases to base bundle
- **modules/home-manager/aliases.nix**: Removed fundamental aliases, keeping only specialized ones

## Rationale
The previous separation was inconsistent - some fundamental Git aliases were in base bundle while others were in home-manager. This reorganization ensures:
- All base tool aliases are in the base bundle
- Home-manager only contains aliases for programs not installed in base bundle or conditional aliases
- Better logical organization and consistency