### PR TITLE
feat(desktop): add super-productivity and refactor git/ssh config

### DIFF
--- a/bundles.nix
+++ b/bundles.nix
@@ -117,6 +117,7 @@ with pkgs.lib; {
       packages = with pkgs;
         [
           logseq
+          super-productivity
         ]
         ++ optional stdenv.isLinux vivaldi;
 

--- a/modules/common/users.nix
+++ b/modules/common/users.nix
@@ -50,13 +50,14 @@ in {
             stateVersion = "25.05";
           };
 
-          programs.git =
-            {
-              userName = user.email;
-              userEmail = user.email;
-            }
-            // lib.optionalAttrs config.myConfig.onepassword.enable {
-              extraConfig = {
+          programs.git = {
+            settings =
+              {
+                user = {
+                  inherit (user) name email;
+                };
+              }
+              // lib.optionalAttrs config.myConfig.onepassword.enable {
                 gpg = lib.mkIf isDarwin {
                   format = "ssh";
                   ssh = {
@@ -67,15 +68,19 @@ in {
                 commit.gpgsign = config.myConfig.onepassword.enableGitSigning;
                 user.signingkey = config.myConfig.onepassword.signingKey;
               };
-            };
+          };
 
           programs.ssh = {
             enable = true;
+            enableDefaultConfig = false;
             includes = user.sshIncludes;
-            extraConfig = lib.optionalString (config.myConfig.onepassword.enableSSHAgent && isDarwin) ''
-              Host *
-                IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
-            '';
+            matchBlocks = lib.optionalAttrs (config.myConfig.onepassword.enableSSHAgent && isDarwin) {
+              "*" = {
+                extraOptions = {
+                  IdentityAgent = "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock";
+                };
+              };
+            };
           };
 
           # Allowed signers file for SSH signature verification


### PR DESCRIPTION
## Summary

- Add **super-productivity** to the desktop bundle for time tracking and task management
- Refactor git configuration to use the `settings` attribute (updated home-manager API)
- Refactor SSH configuration to use `matchBlocks` instead of `extraConfig` for cleaner 1Password SSH agent integration

## Changes

### bundles.nix
- Added `super-productivity` package to the desktop bundle

### modules/common/users.nix
- Migrated `programs.git` from legacy attributes (`userName`, `userEmail`) to `settings.user` block
- Migrated `programs.ssh.extraConfig` to `programs.ssh.matchBlocks` for 1Password SSH agent
- Added `enableDefaultConfig = false` to prevent default SSH config conflicts