### PR TITLE
fix(ssh): quote IdentityAgent path to handle spaces

### DIFF
--- a/modules/common/users.nix
+++ b/modules/common/users.nix
@@ -77,7 +77,7 @@ in {
             matchBlocks = lib.optionalAttrs (config.myConfig.onepassword.enableSSHAgent && isDarwin) {
               "*" = {
                 extraOptions = {
-                  IdentityAgent = "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock";
+                  IdentityAgent = "\"~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock\"";
                 };
               };
             };


### PR DESCRIPTION
## Summary
- Adds quotes around the 1Password SSH agent socket path in SSH config
- Fixes handling of the space in `Group Containers` directory name

## Changes
The IdentityAgent path `~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock` contains a space that requires quoting for SSH to properly parse the config.

## Test Plan
- [x] `task test:full` passes - all configurations validated