### PR TITLE
fix: remove invalid --no-commit flag from flake update workflow

### DIFF
--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -77,8 +77,8 @@ jobs:
           # Store current flake.lock for comparison
           cp flake.lock flake.lock.before
 
-          # Try to update without committing to see what changes are available
-          if nix flake update --no-commit; then
+          # Try to update (nix flake update only modifies flake.lock, doesn't commit)
+          if nix flake update; then
             echo "Update process completed successfully"
 
             # Compare old and new flake.lock


### PR DESCRIPTION
## Summary

- Removes the non-existent `--no-commit` flag from `nix flake update` command
- Fixes silent failure that has been occurring since the workflow was created

## Problem

The weekly flake update workflow has been silently failing because `nix flake update --no-commit` returns:

```
error: unrecognised flag '--no-commit'
```

This caused the `if` condition to fail, falling through to report "No flake updates needed" even though updates were available. As a result, `flake.lock` is **44+ days out of date** (last updated Dec 26, 2025).

## Fix

Remove `--no-commit` - the flag doesn't exist and isn't needed since `nix flake update` only modifies `flake.lock` and never commits by itself.

## Validation

After merging, manually trigger the workflow to verify it creates a PR with the pending updates.