### PR TITLE
feat: add llm-client and llm-claude roles to Darwin config

### DIFF
--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -261,8 +261,14 @@ jobs:
           )
 
           # Create labels if they don't exist (ignore errors if they already exist)
-          gh label create "flake-update" --description "Weekly flake dependency updates" --color "0e8a16" --repo ${{ github.repository }} 2>/dev/null || true
-          gh label create "dependencies" --description "Pull requests that update a dependency file" --color "0366d6" --repo ${{ github.repository }} 2>/dev/null || true
+          gh label create "flake-update" \
+            --description "Weekly flake dependency updates" \
+            --color "0e8a16" \
+            --repo ${{ github.repository }} 2>/dev/null || true
+          gh label create "dependencies" \
+            --description "Pull requests that update a dependency file" \
+            --color "0366d6" \
+            --repo ${{ github.repository }} 2>/dev/null || true
 
           # Create PR
           pr_url=$(gh pr create \

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v10
+        uses: DeterminateSystems/nix-installer-action@v21
         with:
           extra-conf: |
             experimental-features = nix-command flakes
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v10
+        uses: DeterminateSystems/nix-installer-action@v21
         with:
           extra-conf: |
             experimental-features = nix-command flakes
@@ -89,7 +89,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v10
+        uses: DeterminateSystems/nix-installer-action@v21
         with:
           extra-conf: |
             experimental-features = nix-command flakes

--- a/flake.nix
+++ b/flake.nix
@@ -162,7 +162,7 @@
         ++ [
           ./os/darwin.nix
           ./modules/home-manager/aerospace.nix
-          (mkBundleModule "darwin" ["developer" "desktop" "workstation" "entertainment" "llm-host"])
+          (mkBundleModule "darwin" ["developer" "desktop" "workstation" "entertainment" "llm-host" "llm-client" "llm-claude"])
           {
             nixpkgs.hostPlatform = "aarch64-darwin";
             system.primaryUser = "monkey";


### PR DESCRIPTION
## Summary
- Add `llm-client` role to Darwin configuration for OpenCode LLM server connection
- Add `llm-claude` role to Darwin configuration for Claude Code integration
- Both roles auto-enable agent-skills bundle

## Test Plan
- [x] Verified NixOS configurations still validate
- [x] Verified Darwin configurations still evaluate
- [x] All cross-platform tests pass