### PR TITLE
feat: manage opencode user config via nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,7 @@
       development.enable = true;
       agent-skills.enable = true;
       onepassword.enable = true;
+      opencode.enable = true;
     };
 
     # Helper for nix-homebrew config

--- a/modules/common/options.nix
+++ b/modules/common/options.nix
@@ -61,6 +61,38 @@ with lib; {
       };
     };
 
+    opencode = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable opencode user configuration management";
+      };
+
+      model = mkOption {
+        type = types.str;
+        default = "opencode/kimi-k2.5-free";
+        description = "Default LLM model for opencode";
+      };
+
+      theme = mkOption {
+        type = types.str;
+        default = "opencode";
+        description = "UI theme for opencode";
+      };
+
+      autoupdate = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Enable automatic updates for opencode";
+      };
+
+      enableBrowserAgents = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable browser automation agents (chrome-devtools, puppeteer-mcp). These agents are only loaded when explicitly invoked to minimize context usage.";
+      };
+    };
+
     onepassword = {
       enable = mkOption {
         type = types.bool;

--- a/modules/common/users.nix
+++ b/modules/common/users.nix
@@ -99,7 +99,8 @@ in {
             [
               ../../modules/home-manager/shell.nix
             ]
-            ++ optional config.myConfig.development.enable ../../modules/home-manager/development.nix;
+            ++ optional config.myConfig.development.enable ../../modules/home-manager/development.nix
+            ++ optional config.myConfig.opencode.enable ../../modules/home-manager/opencode.nix;
         };
       })
       config.myConfig.users);

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -1,0 +1,108 @@
+{
+  config,
+  osConfig,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = osConfig.myConfig.opencode;
+
+  # Base opencode configuration (always present)
+  baseConfig = {
+    "$schema" = "https://opencode.ai/config.json";
+    inherit (cfg) theme model autoupdate;
+    mcp = {
+      devenv = {
+        type = "local";
+        command = ["devenv" "mcp"];
+        enabled = true;
+      };
+    };
+    permission = {
+      bash = {
+        "task *" = "allow";
+        "npx *" = "allow";
+        "npm *" = "allow";
+      };
+    };
+    tools = {
+      devenv = true;
+    };
+  };
+
+  # Browser agents configuration (only when enabled)
+  browserAgentsConfig = mkIf cfg.enableBrowserAgents {
+    mcp = {
+      chrome-devtools = {
+        type = "local";
+        command = ["npx" "-y" "chrome-devtools-mcp@latest"];
+        enabled = true;
+      };
+      puppeteer-mcp = {
+        type = "local";
+        command = ["npx" "-y" "puppeteer-mcp-server"];
+        enabled = true;
+      };
+    };
+    agent = {
+      browser-research = {
+        description = "Agent for browser-based research tasks";
+        prompt = "You are a research assistant with browser automation capabilities. Use headless browsers for background research, visible browsers only when human interaction is needed. Prioritize efficiency and minimal browser windows.";
+        mcp = {
+          chrome-devtools = true;
+          puppeteer-mcp = true;
+        };
+      };
+      browser-debug = {
+        description = "Agent for debugging web applications";
+        prompt = "You are a web debugging assistant. Connect to existing browser instances when possible. Use Chrome DevTools MCP for performance analysis and debugging. Take screenshots and analyze network requests.";
+        mcp = {
+          chrome-devtools = true;
+          puppeteer-mcp = true;
+        };
+      };
+      browser-test = {
+        description = "Agent for automated browser testing";
+        prompt = "You are a browser testing specialist. Use Puppeteer MCP for form interactions, element clicking, and automated workflows. Create headless browsers for background testing.";
+        mcp = {
+          chrome-devtools = true;
+          puppeteer-mcp = true;
+        };
+      };
+    };
+    permission = {
+      bash = {
+        "chrome *" = "allow";
+        "vivaldi *" = "allow";
+      };
+    };
+    tools = {
+      chrome-devtools = true;
+      puppeteer-mcp = true;
+    };
+  };
+
+  # Merge base config with browser agents if enabled
+  finalConfig =
+    if cfg.enableBrowserAgents
+    then
+      lib.recursiveUpdate baseConfig {
+        mcp = {
+          inherit (baseConfig.mcp) devenv;
+          inherit (browserAgentsConfig.mcp) chrome-devtools puppeteer-mcp;
+        };
+        inherit (browserAgentsConfig) agent;
+        permission = {
+          bash = baseConfig.permission.bash // browserAgentsConfig.permission.bash;
+        };
+        tools = baseConfig.tools // browserAgentsConfig.tools;
+      }
+    else baseConfig;
+in {
+  config = mkIf cfg.enable {
+    home.file.".config/opencode/opencode.json" = {
+      text = builtins.toJSON finalConfig;
+    };
+  };
+}

--- a/opencode.json
+++ b/opencode.json
@@ -1,8 +1,5 @@
 {
     "$schema": "https://opencode.ai/config.json",
-    "theme": "opencode",
-    "model": "opencode/kimi-k2.5-free",
-    "autoupdate": true,
     "instructions": ["AGENTS.md", "README.md"],
     "formatter": {
         "alejandra": {
@@ -54,12 +51,8 @@
             "gh org": "ask",
             "gh project": "ask",
             "gh release": "ask",
-            "gh repo": "ask",
-            "task *": "allow"
+            "gh repo": "ask"
         }
-    },
-    "tools": {
-        "run": true
     },
     "lsp": {
         "nixd": {
@@ -89,13 +82,6 @@
                     }
                 }
             }
-        }
-    },
-    "mcp": {
-        "devenv": {
-            "type": "local",
-            "command": ["devenv", "mcp"],
-            "enabled": true
         }
     },
     "share": "manual"


### PR DESCRIPTION
## Summary

This PR migrates opencode configuration management from manual file editing to nix-managed home-manager deployment.

### Changes

- **New module** (`modules/home-manager/opencode.nix`): Manages `~/.config/opencode/opencode.json` via home-manager
- **New options** (`modules/common/options.nix`): Adds `myConfig.opencode.*` configuration options:
  - `enable`: Enable opencode config management
  - `model`: Default LLM model
  - `theme`: UI theme
  - `autoupdate`: Auto-update setting
  - `enableBrowserAgents`: Opt-in for browser automation (minimizes context usage)
- **Updated repo config** (`opencode.json`): Now contains only nix-specific settings (instructions, formatter, commands, LSP)
- **Enabled for all users** (`flake.nix`): Added `opencode.enable = true` to `mkUser` helper

### Key Features

- ✅ `~/.config/opencode/opencode.json` is now a nix-managed symlink
- ✅ Base config includes: model, theme, autoupdate, devenv MCP, basic permissions
- ✅ Browser agents (chrome-devtools, puppeteer-mcp) disabled by default to minimize context
- ✅ Browser agents available via `myConfig.opencode.enableBrowserAgents = true`

### Test Plan

- [x] Run `task test:full` - all configurations validate successfully
- [x] Run `task quality` - all linting/formatting checks pass
- [x] Run `task switch` - configuration applies successfully on macOS
- [x] Verify `~/.config/opencode/opencode.json` is a symlink to nix store

### Migration Notes

The old `~/.config/opencode/opencode.json` has been backed up to `.backup`. The new config excludes browser agents by default. To re-enable them on specific machines, set `myConfig.opencode.enableBrowserAgents = true` in the target configuration.