### PR TITLE
feat: add mac-app-util input and enable autoUpgrade on NixOS hosts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
     homebrew-core,
     homebrew-cask,
     ...
-  }: let
+  } @ inputs: let
     # Base configuration shared by all systems
     configuration = _: {
       system.configurationRevision = self.rev or self.dirtyRev or null;
@@ -177,6 +177,7 @@
 
     nixosConfigurations."drlight" = nixpkgs.lib.nixosSystem {
       system = "x86_64-linux";
+      specialArgs = {inherit inputs;};
       modules =
         [configuration]
         ++ commonModules
@@ -196,6 +197,7 @@
 
     nixosConfigurations."zero" = nixpkgs.lib.nixosSystem {
       system = "x86_64-linux";
+      specialArgs = {inherit inputs;};
       modules =
         [configuration]
         ++ commonModules

--- a/targets/drlight/default.nix
+++ b/targets/drlight/default.nix
@@ -2,6 +2,7 @@
   _config,
   pkgs,
   _lib,
+  inputs,
   ...
 }:
 # NixOS module for the `drlight` machine.
@@ -38,4 +39,14 @@
   time.timeZone = "America/New_York";
 
   services.openssh.enable = true;
+
+  system.autoUpgrade = {
+    enable = true;
+    flake = inputs.self.outPath;
+    flags = [
+      "-L" # print build logs
+    ];
+    dates = "02:00";
+    randomizedDelaySec = "45min";
+  };
 }

--- a/targets/zero/default.nix
+++ b/targets/zero/default.nix
@@ -2,6 +2,7 @@
   config,
   pkgs,
   lib,
+  inputs,
   ...
 }: {
   # Networking & basic system settings
@@ -201,5 +202,15 @@
     ];
     shell = pkgs.zsh;
     home = "/home/monkey";
+  };
+
+  system.autoUpgrade = {
+    enable = true;
+    flake = inputs.self.outPath;
+    flags = [
+      "-L" # print build logs
+    ];
+    dates = "02:00";
+    randomizedDelaySec = "45min";
   };
 }


### PR DESCRIPTION
## Summary
- Add `mac-app-util` input to flake.nix for macOS system configuration
- Enable `system.autoUpgrade` on NixOS hosts (drlight, zero) for automatic flake updates

## Changes
- flake.nix: Added mac-app-util input
- targets/drlight/default.nix: Added autoUpgrade configuration
- targets/zero/default.nix: Added autoUpgrade configuration