### PR TITLE
docs: update skills documentation to reflect role-based filtering architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,11 @@ This is a modular Nix Flakes configuration for managing macOS and NixOS systems 
 ├── modules/                    # Reusable Nix configurations
 │   ├── common/                 # Shared configurations (options, users, shell, onepassword)
 │   ├── home-manager/           # User environment modules
+│   │   └── skills/             # Agent skills management
+│   │       ├── install.nix     # Skills installation module
+│   │       ├── manifest.nix    # Skill definitions and role assignments
+│   │       ├── internal/       # Skills defined in this repo
+│   │       └── external/       # Skills adapted from external sources
 │   └── nixos/                  # Linux-specific modules
 ├── targets/                    # Machine-specific configurations
 ├── os/                         # Platform OS configurations
@@ -83,10 +88,18 @@ Run `task --list` for a list of all tasks available and a quick definition
 ## Agent Skills Integration
 
 This repository includes automatic AI agent skills management:
-- Skills auto-install with `opencode` or `claude` bundles
-- Installed to `~/.config/opencode/skills/` and `~/.config/opencode/superpowers/skills/`
+- Skills auto-install when `agent-skills.enable = true` and roles like `developer`, `llm-client`, or `llm-claude` are active
+- Skills are defined in `modules/home-manager/skills/manifest.nix` with role-based filtering
+- Installed to `~/.config/opencode/skills/` via home-manager symlinks
 - Use `task agent-skills:status` to check current state
 - Skills follow Agent Skills specification
+
+### Adding New Skills
+
+1. Create skill directory in `modules/home-manager/skills/internal/skill-name/`
+2. Add `SKILL.md` with frontmatter (`name`, `description`)
+3. Register in `modules/home-manager/skills/manifest.nix` with role assignments
+4. Rebuild system to install
 
 ### Version Control Preference (Jujutsu/jj)
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ A comprehensive, modular Nix Flakes configuration for managing macOS and NixOS s
 ├── modules/                    # Reusable Nix configurations
 │   ├── common/                 # Shared configurations (options, users, shell, onepassword)
 │   ├── home-manager/           # User environment modules
+│   │   └── skills/             # Agent skills management
+│   │       ├── install.nix     # Skills installation module
+│   │       ├── manifest.nix    # Skill definitions and role assignments
+│   │       ├── internal/       # Skills defined in this repo
+│   │       └── external/       # Skills adapted from external sources
 │   └── nixos/                  # Linux-specific modules
 ├── targets/                    # Machine-specific configurations
 ├── os/                         # Platform OS configurations
@@ -118,9 +123,9 @@ This configuration uses 1Password CLI directly for secret management. Secrets ar
 This configuration includes automatic management of AI agent skills for OpenCode and Claude Code integration.
 
 ### Features
-- **Automatic Installation**: Skills install automatically with opencode or claude bundles
-- **Upstream Updates**: Clean update mechanism from superpowers repository
-- **Local Customization**: Override or extend skills in repository
+- **Automatic Installation**: Skills install automatically when `llm-client` or `llm-claude` roles are enabled
+- **Role-Based Filtering**: Skills are assigned to roles and only installed when relevant roles are active
+- **Local Customization**: Define custom skills in `modules/home-manager/skills/internal/`
 - **Cross-Platform**: Works on all configured systems (macOS and NixOS)
 - **Validation**: Skills follow Agent Skills specification compliance
 
@@ -142,9 +147,15 @@ skills-list
 
 ### Configuration
 
-Agent skills are automatically enabled when either `opencode` or `claude` bundles are active. Skills are installed to:
+Agent skills are automatically enabled when `llm-client` or `llm-claude` roles are active (via the `enableAgentSkills` flag in bundles.nix). Skills are installed to:
 - `~/.config/opencode/skills/` - Primary skills directory
-- `~/.config/opencode/superpowers/skills/` - Superpowers compatibility
+
+### Adding Custom Skills
+
+1. Create skill directory: `modules/home-manager/skills/internal/my-skill/`
+2. Add `SKILL.md` with frontmatter (`name`, `description`)
+3. Register in `modules/home-manager/skills/manifest.nix` with role assignments
+4. Rebuild system to install
 
 See [docs/agent-skills.md](docs/agent-skills.md) for detailed documentation.
 

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -8,22 +8,36 @@ This system provides comprehensive management of AI agent skills through Nix, en
 
 ### Module Structure
 ```
-modules/home-manager/agent-skills/
-├── default.nix          # Main module definition
-├── skills.nix           # Skills installation logic
-├── updates.nix          # Update mechanism
-└── skills/              # Skill definitions
-    ├── using-superpowers/
-    ├── brainstorming/
-    └── ...
+modules/home-manager/skills/
+├── install.nix              # Skills installation logic (home-manager module)
+├── manifest.nix             # Skill definitions with role assignments
+├── internal/                # Skills defined in this repository
+│   ├── brainstorming/
+│   ├── debugging/
+│   ├── tdd/
+│   ├── writing-plans/
+│   ├── writing-skills/
+│   ├── verification-before-completion/
+│   ├── receiving-code-review/
+│   ├── requesting-code-review/
+│   └── using-superpowers/
+└── external/                # Skills adapted from external sources
+    └── jj/                  # Jujutsu version control skill
 ```
 
 ### Integration Points
 
-1. **Bundles Integration**: Auto-enabled by opencode/claude bundles
-2. **Home-Manager Integration**: Manages file placement in user home directory
-3. **Update System**: Git-based updates from upstream superpowers
+1. **Bundles Integration**: Auto-enabled by `llm-client` or `llm-claude` roles (via `enableAgentSkills` flag)
+2. **Home-Manager Integration**: Manages file placement in `~/.config/opencode/skills/`
+3. **Role-Based Filtering**: Skills are installed based on enabled roles in `myConfig.skills.enabledRoles`
 4. **Task Integration**: Taskfile commands for common operations
+
+### Configuration Flow
+
+1. `flake.nix` → `mkBundleModule` sets `myConfig.skills.enabledRoles` based on active roles
+2. `modules/common/users.nix` imports `skills/install.nix` when `myConfig.agent-skills.enable` is true
+3. `skills/install.nix` filters `manifest.nix` by enabled roles and creates `home.file` entries
+4. Skills are symlinked to `~/.config/opencode/skills/<skill-name>/`
 
 ## Usage Guide
 
@@ -54,41 +68,104 @@ Lists all installed skills by name.
 ## Customization
 
 ### Adding Custom Skills
-1. Create skill directory: `modules/home-manager/agent-skills/skills/my-skill/`
-2. Add `SKILL.md` with proper frontmatter
-3. Rebuild system: `task build`
-4. Skills will be automatically installed to user directories
+
+1. Create skill directory in `modules/home-manager/skills/internal/my-skill/`
+2. Add `SKILL.md` with proper frontmatter:
+   ```markdown
+   ---
+   name: my-skill
+   description: Brief description of what the skill does
+   ---
+   
+   # Skill Content Here
+   ```
+3. Register in `modules/home-manager/skills/manifest.nix`:
+   ```nix
+   "my-skill" = {
+     description = "Brief description";
+     roles = ["developer"];  # Which roles get this skill
+     source = {
+       type = "internal";
+       path = ./internal/my-skill;
+     };
+     deps = [];  # Other skills this depends on
+   };
+   ```
+4. Rebuild system: `darwin-rebuild switch` or `nixos-rebuild switch`
+
+### Adding External Skills
+
+For skills adapted from other sources:
+
+1. Create directory in `modules/home-manager/skills/external/skill-name/`
+2. Add the skill content
+3. Register in manifest with `type = "internal"` (external fetching not yet implemented)
 
 ### Modifying Existing Skills
-Edit skills in `modules/home-manager/agent-skills/skills/` - changes will be applied on next rebuild.
+
+Edit skills in `modules/home-manager/skills/internal/` or `external/` - changes apply on next rebuild.
+
+## Available Skills
+
+Skills are assigned to roles in `manifest.nix`:
+
+| Skill | Description | Roles |
+|-------|-------------|-------|
+| `brainstorming` | Collaborative design dialogue | developer, creative |
+| `debugging` | Systematic debugging approach | developer |
+| `tdd` | Test-driven development workflow | developer |
+| `writing-plans` | Implementation plan creation | developer |
+| `writing-skills` | Documentation and skill writing | developer, creative |
+| `verification-before-completion` | Pre-completion verification | developer |
+| `receiving-code-review` | Process review feedback | developer, workstation |
+| `requesting-code-review` | Prepare and request reviews | developer, workstation |
+| `using-superpowers` | Access available skills | llm-client, llm-claude |
+| `jj` | Jujutsu version control | developer, llm-client, llm-claude |
 
 ## Troubleshooting
 
 ### Skills Not Found
-1. Check bundle is enabled: `task agent-skills:status`
-2. Verify directories exist: `ls -la ~/.config/opencode/skills/`
-3. Rebuild system: `task build`
 
-### Update Failures
-1. Check internet connectivity
-2. Verify git access to GitHub
-3. Check permissions on skills directories
+1. Verify `agent-skills.enable = true` in your configuration
+2. Check that roles with skills are enabled (e.g., `developer`, `llm-client`)
+3. Rebuild system: `darwin-rebuild switch` or `nixos-rebuild switch`
+4. Verify directories exist: `ls -la ~/.config/opencode/skills/`
+
+### Skills Not Updating After Changes
+
+1. Skills are symlinked from Nix store - must rebuild to apply changes
+2. Run `darwin-rebuild switch` or `nixos-rebuild switch`
 
 ### Specification Violations
+
 1. Run validation: `task agent-skills:validate`
 2. Check frontmatter format in `SKILL.md` files
-3. Ensure directory names match skill names
+3. Ensure directory names match skill names in manifest
 
 ## Development
 
-### Adding New Update Sources
-Modify `modules/home-manager/agent-skills/updates.nix` to add additional upstream repositories.
+### Adding New Roles
 
-### Extending Validation
-Enhance validation logic in `Taskfile.yml` to check for additional requirements.
+To make skills available to a new role:
+
+1. Add the role name to the skill's `roles` list in `manifest.nix`
+2. Skills will automatically install for users with that role enabled
+
+### Skill Dependencies
+
+Skills can declare dependencies on other skills:
+
+```nix
+"my-skill" = {
+  # ...
+  deps = ["brainstorming" "debugging"];  # Will also install these
+};
+```
+
+Dependencies are installed even if the user's roles wouldn't normally include them.
 
 ## Security Considerations
 
 - Skills execute as part of AI assistant - review custom skills carefully
-- Updates fetch from external repository - verify commit hashes
-- Skills have access to system through AI assistant permissions
+- Skills are symlinked from Nix store, providing immutability
+- Changes require explicit rebuild to take effect

--- a/flake.nix
+++ b/flake.nix
@@ -103,6 +103,9 @@
     in {
       config =
         {
+          # Pass enabled roles to skills configuration
+          myConfig.skills.enabledRoles = finalRoles;
+
           environment = {
             systemPackages =
               bundles.roles.base.packages ++ rolePackages ++ bundles.platforms.${system}.packages;

--- a/modules/common/options.nix
+++ b/modules/common/options.nix
@@ -61,6 +61,20 @@ with lib; {
       };
     };
 
+    skills = {
+      enabledRoles = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = "List of enabled roles for skills filtering (set automatically by bundle configuration)";
+      };
+
+      skillsPath = mkOption {
+        type = types.str;
+        default = ".config/opencode/skills";
+        description = "Path relative to home directory where skills are installed";
+      };
+    };
+
     opencode = {
       enable = mkOption {
         type = types.bool;

--- a/modules/common/users.nix
+++ b/modules/common/users.nix
@@ -102,7 +102,8 @@ in {
             ++ optional config.myConfig.development.enable ../../modules/home-manager/development.nix
             ++ optional config.myConfig.opencode.enable ../../modules/home-manager/opencode.nix
             ++ optional config.myConfig.claude-code.enable ../../modules/home-manager/claude-code.nix
-            ++ optional config.myConfig.zellij.enable ../../modules/home-manager/zellij.nix;
+            ++ optional config.myConfig.zellij.enable ../../modules/home-manager/zellij.nix
+            ++ optional config.myConfig.agent-skills.enable ../../modules/home-manager/skills/install.nix;
         };
       })
       config.myConfig.users);

--- a/modules/home-manager/skills/install.nix
+++ b/modules/home-manager/skills/install.nix
@@ -1,10 +1,8 @@
 # Skills installation module
 # Filters skills by enabled roles and installs them to ~/.config/opencode/skills/
 {
-  config,
   osConfig,
   lib,
-  pkgs,
   ...
 }: let
   # Get skills config from OS config
@@ -14,8 +12,8 @@
   # Get all enabled roles from config
   enabledRoles = cfg.enabledRoles or [];
 
-  # Use default path if not specified
-  skillsPath = cfg.skillsPath or "~/.config/opencode/skills";
+  # Use default path if not specified (relative to home directory for home.file)
+  skillsPath = cfg.skillsPath or ".config/opencode/skills";
 
   # Filter skills that match any enabled role
   skillsForRoles = roles:


### PR DESCRIPTION
## Summary

- Updates AGENTS.md, README.md, and docs/agent-skills.md to accurately document the skills module structure
- Documents the role-based filtering system where skills are assigned to roles in manifest.nix
- Adds configuration flow explanation and customization instructions for adding new skills
- Updates troubleshooting section with current architecture details

## Changes

- **AGENTS.md**: Added skills directory structure, skill creation instructions
- **README.md**: Updated features list, configuration section, and added custom skills guide
- **docs/agent-skills.md**: Complete rewrite to document manifest-based architecture, role assignments, and dependency system
- **flake.nix**: Pass enabled roles to skills configuration
- **modules/common/options.nix**: Add skills.enabledRoles and skills.skillsPath options
- **modules/common/users.nix**: Import skills/install.nix when agent-skills enabled
- **modules/home-manager/skills/install.nix**: Minor cleanup