### PR TITLE
feat: add helix editor

### DIFF
--- a/bundles.nix
+++ b/bundles.nix
@@ -78,6 +78,7 @@ with pkgs.lib; {
     developer = {
       packages = with pkgs; [
         emacs
+        helix
         clang
         python3
         nodejs


### PR DESCRIPTION
## Summary

- Adds Helix editor to the `developer` role in bundles.nix
- Helix is a post-modern terminal text editor built in Rust with tree-sitter integration, multiple selections, and built-in LSP support

## Changes

- `bundles.nix`: Added `helix` package to developer role packages