### PR TITLE
fix: remove helix from developer packages

### DIFF
--- a/bundles.nix
+++ b/bundles.nix
@@ -78,7 +78,6 @@ with pkgs.lib; {
     developer = {
       packages = with pkgs; [
         emacs
-        helix
         clang
         python3
         nodejs


### PR DESCRIPTION
## Summary
- Removes helix editor from developer packages bundle

## Changes
- Removed `helix` from the `developer` role packages in `bundles.nix`