### PR TITLE
feat: add ralph-specs and prd-review skills for Ralph Loop execution

### DIFF
--- a/modules/home-manager/skills/internal/prd-review/SKILL.md
+++ b/modules/home-manager/skills/internal/prd-review/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: prd-review
+description: Display PRD files in human-readable format for review and status tracking
+---
+
+# PRD Review
+
+## Overview
+
+Convert `prd.json` files into human-readable format for review, status tracking, and progress monitoring. Helps humans understand and validate PRDs before and during Ralph execution.
+
+## When to Use
+
+- Reviewing a PRD before starting Ralph
+- Checking progress during Ralph execution
+- Sharing PRD status with team members
+- Validating story structure and dependencies
+
+## Commands
+
+### Full PRD Review
+
+Display complete PRD with all details:
+
+```
+Review the PRD at prd.json in human-readable format
+```
+
+### Status Summary
+
+Quick overview of completion status:
+
+```
+Show PRD status summary for prd.json
+```
+
+### Single Story Detail
+
+Deep dive into one story:
+
+```
+Show details for story US-003 from prd.json
+```
+
+## Output Formats
+
+### Full Review Format
+
+When asked to review a PRD, output in this format:
+
+```markdown
+# PRD: [project]
+
+**Branch:** `[branchName]`
+**Description:** [description]
+
+## Progress
+
+[■■■■■□□□□□] 5/10 stories complete (50%)
+
+## Stories
+
+### ✅ US-001: [title] (Priority 1)
+**Status:** COMPLETE
+
+> [description]
+
+**Acceptance Criteria:**
+- ✅ [criterion 1]
+- ✅ [criterion 2]
+
+**Notes:** [any notes from agent]
+
+---
+
+### 🔄 US-002: [title] (Priority 2)  
+**Status:** IN PROGRESS (current)
+
+> [description]
+
+**Acceptance Criteria:**
+- ✅ [completed criterion]
+- ⬜ [pending criterion]
+
+---
+
+### ⬜ US-003: [title] (Priority 3)
+**Status:** PENDING
+
+> [description]
+
+**Acceptance Criteria:**
+- ⬜ [criterion 1]
+- ⬜ [criterion 2]
+```
+
+### Status Summary Format
+
+```markdown
+# [project] - Status Summary
+
+**Branch:** `[branchName]`
+**Progress:** [■■■■■□□□□□] 5/10 (50%)
+
+| ID | Title | Priority | Status |
+|----|-------|----------|--------|
+| US-001 | [title] | 1 | ✅ Complete |
+| US-002 | [title] | 2 | 🔄 In Progress |
+| US-003 | [title] | 3 | ⬜ Pending |
+
+**Next Up:** US-003 - [title]
+**Estimated Remaining:** 5 stories
+```
+
+### Story Detail Format
+
+```markdown
+# US-003: [title]
+
+**Priority:** 3 of 10
+**Status:** ⬜ Pending
+**Dependencies:** US-001, US-002
+
+## Description
+
+> As a [role], I want [goal] so that [benefit].
+
+## Acceptance Criteria
+
+| # | Criterion | Status |
+|---|-----------|--------|
+| 1 | [criterion text] | ⬜ |
+| 2 | [criterion text] | ⬜ |
+| 3 | Typecheck passes | ⬜ |
+
+## Size Analysis
+
+- **Files affected:** ~2-3 (estimated)
+- **Complexity:** Medium
+- **Est. iterations:** 1-2
+
+## Notes
+
+[Any notes from previous iterations]
+```
+
+## Status Indicators
+
+Use these consistently:
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Complete (`passes: true`) |
+| 🔄 | In Progress (first `passes: false` by priority) |
+| ⬜ | Pending (not yet started) |
+| ❌ | Blocked (has failing dependency) |
+
+## Progress Bar
+
+Generate progress bar based on completion:
+
+```
+0%:   [□□□□□□□□□□]
+10%:  [■□□□□□□□□□]
+50%:  [■■■■■□□□□□]
+100%: [■■■■■■■■■■]
+```
+
+## Dependency Analysis
+
+When reviewing, check for issues:
+
+### Dependency Violations
+Flag if a story depends on incomplete higher-priority stories:
+
+```markdown
+⚠️ **Dependency Warning**
+US-005 (Priority 5) may depend on:
+- US-003 (Priority 3) - ⬜ Not complete
+- US-004 (Priority 4) - ⬜ Not complete
+
+Consider completing dependencies first.
+```
+
+### Orphan Detection
+Flag stories that nothing depends on (potential scope creep):
+
+```markdown
+ℹ️ **Note:** US-008 appears to be standalone (no other stories depend on it).
+This is fine if intentional, but verify it's in scope.
+```
+
+## Quality Checks
+
+When reviewing, flag potential issues:
+
+### Size Warnings
+```markdown
+⚠️ **Size Warning:** US-004 has 7 acceptance criteria.
+Consider splitting into smaller stories.
+```
+
+### Vague Criteria
+```markdown
+⚠️ **Vague Criterion:** "Code is well-organized" in US-003
+This is not machine-verifiable. Suggest specific check.
+```
+
+### Missing Verification
+```markdown
+⚠️ **Missing Verification:** US-005 has no typecheck/test criterion.
+Add "Typecheck passes" or equivalent.
+```
+
+## Example Usage
+
+### Input PRD
+```json
+{
+  "project": "TaskApp",
+  "branchName": "ralph/priorities",
+  "description": "Add priority system",
+  "userStories": [
+    {"id": "US-001", "title": "Add priority column", "passes": true, ...},
+    {"id": "US-002", "title": "Add API endpoint", "passes": false, ...},
+    {"id": "US-003", "title": "Add UI component", "passes": false, ...}
+  ]
+}
+```
+
+### Output Review
+```markdown
+# PRD: TaskApp
+
+**Branch:** `ralph/priorities`
+**Description:** Add priority system
+
+## Progress
+
+[■■■□□□□□□□] 1/3 stories complete (33%)
+
+## Stories
+
+### ✅ US-001: Add priority column (Priority 1)
+**Status:** COMPLETE
+...
+
+### 🔄 US-002: Add API endpoint (Priority 2)
+**Status:** IN PROGRESS
+...
+
+### ⬜ US-003: Add UI component (Priority 3)
+**Status:** PENDING
+...
+```
+
+## Integration with Ralph
+
+### Pre-Run Review
+```
+Review prd.json and flag any issues before I run Ralph
+```
+
+### Progress Check (During Run)
+```
+Show current Ralph progress for prd.json
+```
+
+### Post-Run Summary
+```
+Summarize what Ralph completed in prd.json
+```
+
+## Related Skills
+
+- `ralph-specs` - Write Ralph-compatible specifications
+- `verification-before-completion` - Run verification commands

--- a/modules/home-manager/skills/internal/ralph-specs/SKILL.md
+++ b/modules/home-manager/skills/internal/ralph-specs/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: ralph-specs
+description: Write specifications optimized for Ralph Loop autonomous agent execution
+---
+
+# Ralph-Compatible Spec Writing
+
+## Overview
+
+Write Product Requirement Documents (PRDs) optimized for Ralph Loop execution. Ralph runs AI coding agents in autonomous loops until all user stories pass - specs must be unambiguous, atomic, and machine-verifiable.
+
+## When to Use
+
+- Planning features for autonomous AI implementation
+- Converting ideas into Ralph-executable PRDs
+- Breaking down large tasks into atomic user stories
+- Preparing work for unattended agent execution
+
+## Key Principles
+
+### 1. Fresh Context Each Iteration
+Each Ralph loop iteration spawns a NEW agent with clean context. The agent only knows:
+- The current `prd.json` (which stories pass/fail)
+- Git history from previous iterations  
+- `progress.txt` learnings
+- `AGENTS.md` patterns and conventions
+
+**Implication**: Every story must be self-contained with all needed context.
+
+### 2. One Context Window Per Story
+Stories must complete in a single agent context window (~32K-128K tokens depending on model).
+
+**Right-sized stories:**
+- Add a database column and migration
+- Create a single UI component
+- Add one API endpoint
+- Update a config file with new options
+
+**Too large (split these):**
+- "Build the entire dashboard"
+- "Add authentication"  
+- "Refactor the API layer"
+- "Migrate from X to Y"
+
+### 3. Machine-Verifiable Acceptance Criteria
+Every criterion must be testable without human judgment:
+
+**Good criteria:**
+- "Typecheck passes"
+- "All tests pass"
+- "File `src/config.ts` exports `DatabaseConfig` type"
+- "Running `curl localhost:3000/api/health` returns 200"
+
+**Bad criteria:**
+- "Code is clean"
+- "UI looks good"
+- "Performance is acceptable"
+
+### 4. Explicit Dependencies via Priority
+Stories execute in priority order. Lower numbers run first.
+
+```json
+{ "priority": 1, "title": "Add database schema" }
+{ "priority": 2, "title": "Add API endpoint (depends on schema)" }
+{ "priority": 3, "title": "Add UI component (depends on API)" }
+```
+
+## PRD Structure
+
+### Required Format: `prd.json`
+
+```json
+{
+  "project": "ProjectName",
+  "branchName": "ralph/feature-name",
+  "description": "One-line feature description",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Short descriptive title (max 60 chars)",
+      "description": "As a [role], I want [goal] so that [benefit]",
+      "acceptanceCriteria": [
+        "Specific, testable criterion",
+        "Another testable criterion",
+        "Typecheck passes"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}
+```
+
+### Field Requirements
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `project` | Yes | Project identifier |
+| `branchName` | Yes | Git branch for this work (prefix with `ralph/`) |
+| `description` | Yes | One-line feature summary |
+| `userStories` | Yes | Array of user stories |
+| `id` | Yes | Unique identifier (US-001, US-002, etc.) |
+| `title` | Yes | Short title (max 60 characters) |
+| `description` | Yes | User story format: As a [role], I want [goal]... |
+| `acceptanceCriteria` | Yes | Array of testable criteria |
+| `priority` | Yes | Execution order (1 = first) |
+| `passes` | Yes | Start as `false`, agent sets `true` when done |
+| `notes` | No | Agent adds learnings here |
+
+## Writing Process
+
+### Step 1: Define the Feature
+Start with a clear, bounded feature description:
+- What problem does this solve?
+- Who benefits?
+- What's the minimal viable scope?
+
+### Step 2: Decompose into Stories
+Break into 3-10 atomic stories. Each story should:
+- Take 5-30 minutes for an agent to implement
+- Have clear start and end states
+- Be independently verifiable
+
+### Step 3: Order by Dependencies
+Assign priorities based on dependencies:
+1. Data/schema changes first
+2. Backend logic second
+3. API endpoints third
+4. UI components last
+
+### Step 4: Write Acceptance Criteria
+For each story, write 2-5 criteria that are:
+- Binary (pass/fail, no partial credit)
+- Automatable (typecheck, tests, file existence)
+- Specific (exact file paths, function names)
+
+### Step 5: Add Verification Commands
+Always include at least one of:
+- `Typecheck passes`
+- `All tests pass`
+- `Verify in browser using dev-browser skill` (for UI)
+
+## Acceptance Criteria Patterns
+
+### For Data/Schema Changes
+```json
+"acceptanceCriteria": [
+  "Migration file exists at db/migrations/NNNN_add_priority.sql",
+  "Migration runs without errors",
+  "Schema includes priority column with type VARCHAR(10)",
+  "Typecheck passes"
+]
+```
+
+### For API Endpoints
+```json
+"acceptanceCriteria": [
+  "GET /api/tasks returns JSON array",
+  "Response includes 'priority' field on each task",
+  "Invalid requests return 400 with error message",
+  "Typecheck passes",
+  "API tests pass"
+]
+```
+
+### For UI Components
+```json
+"acceptanceCriteria": [
+  "PriorityBadge component exists at src/components/PriorityBadge.tsx",
+  "Component accepts 'priority' prop of type 'high' | 'medium' | 'low'",
+  "Renders colored badge (red=high, yellow=medium, gray=low)",
+  "Typecheck passes",
+  "Verify in browser using dev-browser skill"
+]
+```
+
+### For Configuration Changes
+```json
+"acceptanceCriteria": [
+  "Config file updated at path/to/config.nix",
+  "New option 'services.myapp.priority' added",
+  "Option has type 'enum [\"high\" \"medium\" \"low\"]'",
+  "Default value is 'medium'",
+  "nix flake check passes"
+]
+```
+
+## Common Mistakes
+
+### Stories Too Large
+**Bad:** "Implement user authentication"
+**Good:** Split into:
+1. Add user table schema
+2. Add password hashing utility
+3. Add login API endpoint
+4. Add session management
+5. Add login UI form
+
+### Vague Acceptance Criteria
+**Bad:** "Feature works correctly"
+**Good:** "POST /api/login with valid credentials returns 200 and session token"
+
+### Missing Dependencies
+**Bad:** UI story at priority 1, API at priority 3
+**Good:** Schema (1) -> API (2) -> UI (3)
+
+### No Verification Step
+**Bad:** Only functional criteria
+**Good:** Always include "Typecheck passes" or equivalent
+
+## Templates
+
+See bundled templates:
+- `templates/prd.json` - Empty PRD template
+- `templates/story-template.md` - Story writing guide
+
+## Examples
+
+See bundled examples:
+- `examples/feature-prd.json` - New feature implementation
+- `examples/refactor-prd.json` - Code refactoring
+- `examples/nix-config-prd.json` - Nix configuration change
+
+## Checklist Before Running Ralph
+
+Use `checklists/story-review.md` to verify:
+- [ ] Each story fits in one context window
+- [ ] All acceptance criteria are testable
+- [ ] Dependencies reflected in priorities
+- [ ] Verification commands included
+- [ ] No ambiguous language
+
+## Related Skills
+
+- `prd-review` - Display PRD in human-readable format
+- `verification-before-completion` - Run verification commands

--- a/modules/home-manager/skills/internal/ralph-specs/checklists/story-review.md
+++ b/modules/home-manager/skills/internal/ralph-specs/checklists/story-review.md
@@ -1,0 +1,124 @@
+# Story Review Checklist
+
+Use this checklist before running Ralph to ensure your PRD is ready for autonomous execution.
+
+## PRD-Level Checks
+
+### Metadata
+- [ ] `project` name is set
+- [ ] `branchName` starts with `ralph/`
+- [ ] `description` is a clear one-liner
+
+### Story Count
+- [ ] PRD has 3-10 user stories (optimal range)
+- [ ] If >10 stories, consider splitting into multiple PRDs
+
+## Per-Story Checks
+
+Run through each story:
+
+### US-XXX: ________________________________
+
+#### Size Check
+- [ ] Story can complete in one context window (~30 min agent work)
+- [ ] Story touches 1-3 files maximum
+- [ ] Story has single clear outcome
+
+#### Title Check
+- [ ] Title under 60 characters
+- [ ] Title starts with action verb (Add, Create, Update, Remove, Fix)
+- [ ] Title is specific, not vague
+
+#### Description Check
+- [ ] Follows "As a [role], I want [goal] so that [benefit]" format
+- [ ] Role is specific (developer, user, admin, operator)
+- [ ] Goal is concrete and bounded
+- [ ] Benefit explains the "why"
+
+#### Acceptance Criteria Check
+- [ ] Has 2-5 criteria (not too few, not too many)
+- [ ] Each criterion is binary (pass/fail)
+- [ ] No subjective language ("clean", "good", "proper")
+- [ ] Specific paths/names where applicable
+- [ ] Includes verification step:
+  - [ ] "Typecheck passes" OR
+  - [ ] "Tests pass" OR
+  - [ ] "nix flake check passes" OR
+  - [ ] "Verify in browser using dev-browser skill"
+
+#### Dependencies Check
+- [ ] Priority number reflects dependencies
+- [ ] No story depends on a higher-priority story
+- [ ] Foundation work (schema, types) comes first
+
+#### Initial State Check
+- [ ] `passes` is set to `false`
+- [ ] `notes` is empty string `""`
+
+## Common Issues to Fix
+
+### Story Too Large
+Signs:
+- More than 5 acceptance criteria
+- Touches more than 3 files
+- Contains words like "and", "also", "additionally"
+
+Fix: Split into multiple stories
+
+### Vague Criteria
+Signs:
+- Uses subjective words
+- No specific paths or values
+- Can't be automated
+
+Fix: Add specifics (file paths, exact values, commands)
+
+### Missing Dependencies
+Signs:
+- UI story before API story
+- API story before schema story
+- Integration before unit components
+
+Fix: Reorder priorities
+
+### No Verification
+Signs:
+- No typecheck/test criterion
+- No way to confirm completion
+
+Fix: Add "Typecheck passes" or equivalent
+
+## Final Verification
+
+Before starting Ralph:
+
+```bash
+# Validate JSON syntax
+cat prd.json | jq .
+
+# Check story count
+cat prd.json | jq '.userStories | length'
+
+# List all stories with status
+cat prd.json | jq '.userStories[] | {id, title, priority, passes}'
+
+# Check for stories without verification criteria
+cat prd.json | jq '.userStories[] | select(.acceptanceCriteria | map(test("passes|Verify")) | any | not) | .id'
+```
+
+## Ready to Run?
+
+All boxes checked? Start Ralph:
+
+```bash
+./ralph.sh
+```
+
+Monitor progress:
+```bash
+# Watch story completion
+watch -n 5 'cat prd.json | jq ".userStories[] | {id, passes}"'
+
+# Check learnings
+tail -f progress.txt
+```

--- a/modules/home-manager/skills/internal/ralph-specs/examples/feature-prd.json
+++ b/modules/home-manager/skills/internal/ralph-specs/examples/feature-prd.json
@@ -1,0 +1,131 @@
+{
+  "project": "TaskApp",
+  "branchName": "ralph/task-priority-system",
+  "description": "Add priority levels to tasks with filtering and visual indicators",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Add priority column to tasks database",
+      "description": "As a developer, I need to store task priority so it persists across sessions.",
+      "acceptanceCriteria": [
+        "Migration file exists at db/migrations/NNNN_add_priority.sql",
+        "Priority column added with type VARCHAR(10)",
+        "Column has CHECK constraint for values: 'high', 'medium', 'low'",
+        "Default value is 'medium'",
+        "Migration runs without errors",
+        "Typecheck passes"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Add TaskPriority type definition",
+      "description": "As a developer, I want a shared type for priority so the codebase has consistent typing.",
+      "acceptanceCriteria": [
+        "TaskPriority type exported from src/types/task.ts",
+        "Type is union: 'high' | 'medium' | 'low'",
+        "Task interface updated to include optional priority field",
+        "Typecheck passes"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-003",
+      "title": "Update createTask API for priority",
+      "description": "As a developer, I want the API to accept priority so tasks can be created with different levels.",
+      "acceptanceCriteria": [
+        "POST /api/tasks accepts optional 'priority' field",
+        "Priority validated against allowed values",
+        "Default 'medium' used when not specified",
+        "Invalid priority returns 400 with descriptive error",
+        "Typecheck passes",
+        "API tests pass"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-004",
+      "title": "Update getTask API to return priority",
+      "description": "As a developer, I want task responses to include priority for display.",
+      "acceptanceCriteria": [
+        "GET /api/tasks returns priority field on each task",
+        "GET /api/tasks/:id returns priority field",
+        "Typecheck passes",
+        "API tests pass"
+      ],
+      "priority": 4,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-005",
+      "title": "Create PriorityBadge component",
+      "description": "As a user, I want to see task priority at a glance via colored badges.",
+      "acceptanceCriteria": [
+        "PriorityBadge component exists at src/components/PriorityBadge.tsx",
+        "Accepts 'priority' prop of type TaskPriority",
+        "Renders: red badge for high, yellow for medium, gray for low",
+        "Includes accessible aria-label",
+        "Typecheck passes",
+        "Component tests pass"
+      ],
+      "priority": 5,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-006",
+      "title": "Add priority badge to task cards",
+      "description": "As a user, I want to see priority on task cards without clicking.",
+      "acceptanceCriteria": [
+        "TaskCard component displays PriorityBadge",
+        "Badge visible in top-right corner of card",
+        "Badge shown for all priority levels",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 6,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-007",
+      "title": "Add priority selector to task edit form",
+      "description": "As a user, I want to change priority when editing a task.",
+      "acceptanceCriteria": [
+        "Priority dropdown in TaskEditModal component",
+        "Shows current priority as selected value",
+        "Options: High, Medium, Low",
+        "Selection updates task via API",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 7,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-008",
+      "title": "Add priority filter to task list",
+      "description": "As a user, I want to filter tasks by priority to focus on important items.",
+      "acceptanceCriteria": [
+        "Filter dropdown with options: All, High, Medium, Low",
+        "Filter added to TaskListHeader component",
+        "Selecting filter updates displayed tasks",
+        "Filter state persisted in URL query param",
+        "Empty state shown when no tasks match",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 8,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/modules/home-manager/skills/internal/ralph-specs/examples/nix-config-prd.json
+++ b/modules/home-manager/skills/internal/ralph-specs/examples/nix-config-prd.json
@@ -1,0 +1,117 @@
+{
+  "project": "NixConfig",
+  "branchName": "ralph/add-ollama-service",
+  "description": "Add Ollama LLM service to system configuration with GPU support",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Create ollama module file",
+      "description": "As an operator, I want an Ollama module so I can declaratively configure local LLM hosting.",
+      "acceptanceCriteria": [
+        "File created at modules/home-manager/ollama.nix",
+        "Module has enable option with default false",
+        "Module imports without errors",
+        "nix flake check passes"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Add ollama package to module",
+      "description": "As an operator, I want Ollama installed when enabled.",
+      "acceptanceCriteria": [
+        "ollama package added to home.packages when enabled",
+        "Package only installed when enable = true",
+        "nix flake check passes"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-003",
+      "title": "Add port configuration option",
+      "description": "As an operator, I want to configure which port Ollama listens on.",
+      "acceptanceCriteria": [
+        "port option added with type lib.types.port",
+        "Default value is 11434",
+        "Option documented with description",
+        "nix flake check passes"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-004",
+      "title": "Add GPU acceleration option",
+      "description": "As an operator, I want to enable GPU acceleration for better performance.",
+      "acceptanceCriteria": [
+        "acceleration option added with type enum",
+        "Values: 'none', 'cuda', 'rocm', 'metal'",
+        "Default is 'none'",
+        "nix flake check passes"
+      ],
+      "priority": 4,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-005",
+      "title": "Add environment configuration",
+      "description": "As an operator, I want Ollama environment variables set correctly.",
+      "acceptanceCriteria": [
+        "OLLAMA_HOST set based on port option",
+        "OLLAMA_MODELS set to ~/.ollama/models",
+        "GPU-specific env vars set when acceleration enabled",
+        "nix flake check passes"
+      ],
+      "priority": 5,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-006",
+      "title": "Add models option for auto-pull",
+      "description": "As an operator, I want to specify which models to pull on activation.",
+      "acceptanceCriteria": [
+        "models option added with type list of strings",
+        "Default is empty list",
+        "Example in description: ['llama3.2', 'qwen2.5-coder']",
+        "nix flake check passes"
+      ],
+      "priority": 6,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-007",
+      "title": "Add ollama to llm-host role bundle",
+      "description": "As an operator, I want Ollama included when llm-host role is enabled.",
+      "acceptanceCriteria": [
+        "bundles.nix llm-host role references ollama module",
+        "Module enabled when role is active",
+        "nix flake check passes"
+      ],
+      "priority": 7,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-008",
+      "title": "Document ollama module in README",
+      "description": "As an operator, I want documentation for the new Ollama options.",
+      "acceptanceCriteria": [
+        "README.md llm-host section updated",
+        "All options listed with descriptions",
+        "Example configuration provided",
+        "nix flake check passes"
+      ],
+      "priority": 8,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/modules/home-manager/skills/internal/ralph-specs/examples/refactor-prd.json
+++ b/modules/home-manager/skills/internal/ralph-specs/examples/refactor-prd.json
@@ -1,0 +1,110 @@
+{
+  "project": "APIServer",
+  "branchName": "ralph/extract-validation-utils",
+  "description": "Extract inline validation logic into reusable validation utilities",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Create validation utilities module",
+      "description": "As a developer, I want a dedicated validation module so validation logic is centralized.",
+      "acceptanceCriteria": [
+        "File created at src/utils/validation.ts",
+        "Module exports empty object (placeholder)",
+        "Typecheck passes"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Add email validation utility",
+      "description": "As a developer, I want a reusable email validator to replace inline regex.",
+      "acceptanceCriteria": [
+        "isValidEmail function exported from src/utils/validation.ts",
+        "Function accepts string, returns boolean",
+        "Validates standard email format",
+        "Unit tests cover valid/invalid cases",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-003",
+      "title": "Add string length validation utility",
+      "description": "As a developer, I want length validators to replace inline checks.",
+      "acceptanceCriteria": [
+        "isValidLength function exported from src/utils/validation.ts",
+        "Accepts: value (string), min (number), max (number)",
+        "Returns boolean",
+        "Unit tests cover edge cases (empty, exact bounds)",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-004",
+      "title": "Add required field validation utility",
+      "description": "As a developer, I want a required field checker for form validation.",
+      "acceptanceCriteria": [
+        "isRequired function exported from src/utils/validation.ts",
+        "Returns false for null, undefined, empty string",
+        "Returns true for all other values including 0 and false",
+        "Unit tests pass",
+        "Typecheck passes"
+      ],
+      "priority": 4,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-005",
+      "title": "Refactor user registration to use validators",
+      "description": "As a developer, I want registration to use shared validators for consistency.",
+      "acceptanceCriteria": [
+        "src/handlers/registration.ts imports from validation utils",
+        "Inline email regex replaced with isValidEmail",
+        "Inline length checks replaced with isValidLength",
+        "No inline validation regex remaining in file",
+        "Existing tests still pass",
+        "Typecheck passes"
+      ],
+      "priority": 5,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-006",
+      "title": "Refactor profile update to use validators",
+      "description": "As a developer, I want profile updates to use shared validators.",
+      "acceptanceCriteria": [
+        "src/handlers/profile.ts imports from validation utils",
+        "All inline validation replaced with utility functions",
+        "Existing tests still pass",
+        "Typecheck passes"
+      ],
+      "priority": 6,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-007",
+      "title": "Add validation utilities to barrel export",
+      "description": "As a developer, I want validators accessible from main utils export.",
+      "acceptanceCriteria": [
+        "src/utils/index.ts re-exports all from validation.ts",
+        "Import { isValidEmail } from '@/utils' works",
+        "Typecheck passes"
+      ],
+      "priority": 7,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/modules/home-manager/skills/internal/ralph-specs/templates/prd.json
+++ b/modules/home-manager/skills/internal/ralph-specs/templates/prd.json
@@ -1,0 +1,19 @@
+{
+  "project": "",
+  "branchName": "ralph/",
+  "description": "",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "",
+      "description": "As a [role], I want [goal] so that [benefit]",
+      "acceptanceCriteria": [
+        "",
+        "Typecheck passes"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/modules/home-manager/skills/internal/ralph-specs/templates/story-template.md
+++ b/modules/home-manager/skills/internal/ralph-specs/templates/story-template.md
@@ -1,0 +1,166 @@
+# User Story Template for Ralph Loops
+
+## Story Structure
+
+```
+ID: US-XXX
+Title: [Action verb] [thing] [context] (max 60 chars)
+```
+
+## Description Format
+
+Use the standard user story format:
+
+```
+As a [role],
+I want [goal/desire],
+so that [benefit/value].
+```
+
+### Role Examples
+- `developer` - Someone writing code
+- `user` - End user of the application  
+- `admin` - Administrator with elevated privileges
+- `system` - Automated process or service
+- `operator` - Person managing infrastructure
+
+### Goal Examples
+- "to add a priority field to tasks"
+- "to filter tasks by status"
+- "to receive notifications when builds fail"
+- "to configure the service via environment variables"
+
+### Benefit Examples
+- "I can track what's most important"
+- "I can focus on relevant items"
+- "I can respond to issues quickly"
+- "deployment is more flexible"
+
+## Acceptance Criteria Guidelines
+
+### Structure
+Write 2-5 criteria per story. Each criterion should be:
+- **Binary**: Pass or fail, no partial credit
+- **Specific**: Exact paths, names, values
+- **Testable**: Can be verified by automation
+
+### Formula
+```
+[Subject] [verb] [expected state/behavior]
+```
+
+### Good Examples
+
+**File existence:**
+```
+File exists at src/components/PriorityBadge.tsx
+```
+
+**Type/interface:**
+```
+TaskPriority type exported from src/types/task.ts
+```
+
+**Behavior:**
+```
+POST /api/tasks with priority field saves to database
+```
+
+**Validation:**
+```
+Invalid priority value returns 400 error with message
+```
+
+**Build/check:**
+```
+Typecheck passes
+All tests pass
+nix flake check passes
+```
+
+**UI verification:**
+```
+Verify in browser using dev-browser skill
+```
+
+### Bad Examples (Avoid These)
+
+```
+Code is well-organized          # Subjective
+Performance is acceptable       # Unmeasurable  
+Feature works as expected       # Vague
+UI looks correct                # Subjective
+```
+
+## Size Guidelines
+
+### Right-Sized Story (5-30 min agent work)
+- Single file creation/modification
+- One database migration
+- One API endpoint
+- One UI component
+- One configuration change
+
+### Too Large (Split These)
+- Multiple unrelated files
+- Feature spanning data + API + UI
+- Refactoring multiple modules
+- Any story with >5 acceptance criteria
+
+## Priority Assignment
+
+### Rule: Dependencies determine priority
+
+```
+Priority 1: Foundation (schema, types, config)
+Priority 2: Core logic (services, utilities)
+Priority 3: Integration (API, handlers)
+Priority 4: Presentation (UI, formatting)
+Priority 5: Polish (docs, cleanup)
+```
+
+### Example Dependency Chain
+
+```
+US-001 (P1): Add priority column to tasks table
+    |
+US-002 (P2): Add TaskPriority type to shared types
+    |
+US-003 (P3): Update createTask API to accept priority
+    |
+US-004 (P4): Add priority selector to task form UI
+    |
+US-005 (P5): Add priority to task list documentation
+```
+
+## Complete Example
+
+```json
+{
+  "id": "US-003",
+  "title": "Add priority parameter to createTask API",
+  "description": "As a developer, I want the createTask API to accept a priority parameter so that tasks can be created with different priority levels.",
+  "acceptanceCriteria": [
+    "POST /api/tasks accepts optional 'priority' field in request body",
+    "Priority must be one of: 'high', 'medium', 'low'",
+    "Default priority is 'medium' when not specified",
+    "Invalid priority value returns 400 with error message",
+    "Typecheck passes",
+    "API tests pass"
+  ],
+  "priority": 3,
+  "passes": false,
+  "notes": ""
+}
+```
+
+## Checklist Before Adding Story
+
+- [ ] Title under 60 characters
+- [ ] Description follows As/I want/So that format
+- [ ] 2-5 acceptance criteria
+- [ ] All criteria are binary (pass/fail)
+- [ ] No subjective language
+- [ ] Includes verification step (typecheck/tests)
+- [ ] Priority reflects dependencies
+- [ ] Story fits in one context window

--- a/modules/home-manager/skills/manifest.nix
+++ b/modules/home-manager/skills/manifest.nix
@@ -125,4 +125,25 @@
     };
     deps = [];
   };
+
+  # Ralph Loop specification skills
+  "ralph-specs" = {
+    description = "Write specifications optimized for Ralph Loop autonomous agent execution. Covers PRD structure, atomic user stories, and machine-verifiable acceptance criteria";
+    roles = ["developer" "llm-client" "llm-claude"];
+    source = {
+      type = "internal";
+      path = ./internal/ralph-specs;
+    };
+    deps = [];
+  };
+
+  "prd-review" = {
+    description = "Display PRD files in human-readable format for review and status tracking. Shows progress, story details, and flags potential issues";
+    roles = ["developer" "llm-client" "llm-claude"];
+    source = {
+      type = "internal";
+      path = ./internal/prd-review;
+    };
+    deps = [];
+  };
 }


### PR DESCRIPTION
## Summary

Adds two complementary skills for writing and reviewing specifications optimized for Ralph Loop autonomous agent execution:

- **ralph-specs**: Guide for writing PRDs with atomic user stories, machine-verifiable acceptance criteria, and proper dependency ordering
- **prd-review**: Human-readable display of PRD status with progress tracking, quality checks, and issue flagging

## Background

Ralph Loop is a technique for autonomous AI coding that runs agents in a continuous loop until all user stories pass. Specs for Ralph must be:
- Atomic (one context window per story)
- Unambiguous (no human judgment needed)
- Machine-verifiable (pass/fail criteria)
- Properly ordered (dependencies via priority)

## Changes

### New Skills

**ralph-specs/** (`modules/home-manager/skills/internal/ralph-specs/`)
- `SKILL.md` - Main instructions for writing Ralph-compatible specs
- `templates/prd.json` - Empty PRD template
- `templates/story-template.md` - User story writing guide
- `examples/feature-prd.json` - New feature example (8 stories)
- `examples/refactor-prd.json` - Refactoring example (7 stories)  
- `examples/nix-config-prd.json` - Nix config example (8 stories)
- `checklists/story-review.md` - Pre-flight checklist

**prd-review/** (`modules/home-manager/skills/internal/prd-review/`)
- `SKILL.md` - Instructions for displaying PRDs in human-readable format
- Progress bars, status indicators, quality checks
- Flags oversized stories, vague criteria, missing verification

### Updated

- `modules/home-manager/skills/manifest.nix` - Registered both skills for `developer`, `llm-client`, `llm-claude` roles

## Usage

After rebuilding:

```bash
# Writing a spec
"Load the ralph-specs skill and help me create a PRD for [feature]"

# Reviewing a spec  
"Load the prd-review skill and review prd.json"
```