### PR TITLE
feat: add Conventional Branch naming to jj skill

### DIFF
--- a/modules/home-manager/skills/external/jj/SKILL.md
+++ b/modules/home-manager/skills/external/jj/SKILL.md
@@ -1,449 +1,140 @@
 ---
 name: jj
-description: Use Jujutsu (jj) for version control. Covers workflow, commits, bookmarks, pushing to GitHub, absorb, squash, stacked PRs, and workspaces for multi-project isolation. Use when working with jj, creating commits, pushing changes, or managing version control.
+description: Use Jujutsu (jj) for version control. Covers workflow, commits, bookmarks with Conventional Branch naming, pushing to GitHub, absorb, squash, stacked PRs, and workspaces for multi-project isolation. Use when working with jj, creating commits, pushing changes, or managing version control.
 ---
 
 # Jujutsu (jj) Version Control
 
-## The Key Mental Model
+## Key Mental Model
 
-**In jj, the working copy IS a commit.** This is fundamentally different from Git where you stage changes then commit. In jj, you're always working inside a commit.
+**The working copy IS a commit.** Changes you make are immediately part of the current commit. There's no staging area.
 
-This means:
+- Always `jj new` before starting new work
+- Use `jj squash` to fold changes into parent
+- Use `jj absorb` to auto-distribute fixes to ancestors
 
-- Changes you make are immediately part of the current commit
-- You should start new work in a fresh commit (so you can squash it later)
-- There's no staging area - your working directory is the commit
+## Quick Reference
 
-## Core Workflow
+| Command | Purpose |
+|---------|---------|
+| `jj status` | Check current state (ALWAYS run first) |
+| `jj log` | View commit history |
+| `jj diff` | See changes in current commit |
+| `jj new` | Create new empty commit |
+| `jj describe -m "msg"` | Set commit message |
+| `jj squash` | Move changes to parent |
+| `jj absorb` | Auto-distribute to ancestors |
+| `jj git push` | Push to remote |
+| `jj git fetch` | Fetch from remote |
 
-### Always Start with `jj status`
+## Workflow Scripts
 
-Before any operation, check your state:
+Use the bundled scripts for common workflows (run from skill's scripts/ directory or add to PATH):
 
-```bash
-jj status
-```
-
-- "Working copy is clean" = you're in an empty commit, ready to work
-- Shows file changes = current commit has work in it
-- Shows description = current commit is already described
-
-### The Basic Pattern
-
-```bash
-# 1. Create a new commit BEFORE starting work
-jj new
-
-# 2. Make your changes (edit files)
-
-# 3. Describe what you did
-jj describe -m "Add user authentication"
-
-# 4. Create a new commit for the next task
-jj new
-
-# Repeat
-```
-
-**Why `jj new` before work?** If you work directly in a described commit, those changes get mixed in. Then you have to split them later. Starting fresh means you can always squash back if needed.
-
-### Common Commands
+### `jj-pr` - Create New PR
 
 ```bash
-jj status          # Check current state - ALWAYS run first
-jj log             # View commit history
-jj diff            # See changes in current commit
-jj describe -m ""  # Set/update commit message
-jj new             # Create new empty commit
-jj squash          # Move current changes into parent commit
-jj absorb          # Auto-distribute changes to ancestor commits
+# Usage: jj-pr <type> <description> [commit-message]
+jj-pr feat user-auth "Add user authentication"
+jj-pr fix null-pointer
+jj-pr chore deps-update
 ```
 
-## Bookmarks (Not Branches)
+Types: `feat`, `fix`, `hotfix`, `release`, `chore`
 
-jj uses "bookmarks" instead of Git branches. Key differences:
-
-- Bookmarks are just labels pointing to commits
-- They don't automatically advance when you commit
-- You can have commits without any bookmark
+### `jj-update` - Update Existing PR
 
 ```bash
-jj bookmark list              # List all bookmarks
-jj bookmark set foo -r @      # Create/move bookmark to current commit
-jj bookmark delete foo        # Delete a bookmark
+# Usage: jj-update [new-commit-message]
+jj-update                        # Squash and push, keep message
+jj-update "Fix review comments"  # Squash with new message
 ```
 
-## Pushing to GitHub
-
-### First Push (New PR)
-
-Use `--change` (`-c`) to auto-create a bookmark and push:
+### `jj-sync` - Sync with Main
 
 ```bash
-# Push current commit, auto-generates bookmark name
-jj git push -c @
-
-# Push parent of working copy (common when @ is empty)
-jj git push -c @-
+# Usage: jj-sync [base-branch]
+jj-sync         # Fetch and rebase onto main
+jj-sync develop # Rebase onto develop
 ```
 
-This creates a bookmark with an auto-generated name like `push-abcdefgh` and pushes it.
-
-### Subsequent Pushes (Same PR)
-
-Once a bookmark exists and tracks the remote, just push:
+### `jj-stack` - Stacked PRs
 
 ```bash
-jj git push
+# Usage: jj-stack <type> <description> [commit-message]
+jj-stack feat login-ui "Add login components"
 ```
 
-jj knows which bookmarks have changed and pushes them. Force push is automatic when history rewrites.
+Creates PR with correct base branch for stacking.
 
-### Creating the PR
+### `jj-workspace` - Manage Workspaces
 
 ```bash
-# Get the bookmark name from jj log or the push output
-jj log -r @ --no-graph
-
-# Create PR with gh CLI (must specify --head since gh uses git)
-gh pr create --head push-abcdefgh
+jj-workspace create feature-auth      # New workspace from main
+jj-workspace create bugfix main       # New workspace from specific base
+jj-workspace list                     # Show all workspaces
+jj-workspace remove feature-auth      # Remove workspace
+jj-workspace clean                    # Remove all workspaces
+jj-workspace status                   # Status of all workspaces
 ```
 
-## Making More Changes to a PR
+## Conventional Branch Naming
 
-When you need to update an existing PR:
+Branch format: `<type>/<description>`
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| `feat/` | New features | `feat/user-auth` |
+| `fix/` | Bug fixes | `fix/null-pointer` |
+| `hotfix/` | Urgent fixes | `hotfix/security-patch` |
+| `release/` | Releases | `release/v1.2.0` |
+| `chore/` | Non-code tasks | `chore/deps-update` |
+
+Rules:
+- Lowercase alphanumerics and hyphens only
+- No consecutive/leading/trailing hyphens
+- Include ticket numbers: `feat/gh-123-add-feature`
+
+## Manual Workflow (if not using scripts)
+
+### Create PR
 
 ```bash
-# 1. Create new commit on top of the PR commit
-jj new
-
-# 2. Make your changes
-
-# 3. Fold changes back into the PR commit
-jj squash          # Moves all changes to parent
-
-# 4. Push the update
-jj git push
-```
-
-**Never work directly in the PR commit.** Always `jj new` first, then squash back.
-
-## Squash vs Absorb
-
-### `jj squash` - When You Know Where It Goes
-
-Moves changes from current commit into parent:
-
-```bash
-jj squash                    # All changes to parent
-jj squash file.rs            # Only specific files
-jj squash --into <commit>    # Into a specific commit (not just parent)
-```
-
-### `jj absorb` - Auto-Distribute to Ancestors
-
-Analyzes each changed line and moves it to the ancestor commit that last modified that line:
-
-```bash
-jj absorb
-```
-
-**Best for stacked PRs**: When you have commits A → B → C and fix things that belong in different commits, `jj absorb` figures out where each change should go.
-
-Try `jj absorb` first. If it can't figure out where something goes (new lines, ambiguous context), use `jj squash` manually.
-
-## Stacked PRs Workflow
-
-When working on multiple dependent PRs:
-
-```bash
-# Create stack: each commit = one PR
-jj new main
-# work on feature A
-jj describe -m "Feature A"
-jj git push -c @
-
-jj new
-# work on feature B (depends on A)
-jj describe -m "Feature B"
-jj git push -c @
-
-# Continue stacking...
-```
-
-### After a PR Merges
-
-When a PR in the middle of the stack merges:
-
-```bash
-# 1. Update the next PR's base branch on GitHub
-gh pr edit <PR_NUMBER> --base main
-
-# 2. Fetch the new main
-jj git fetch
-
-# 3. Rebase the remaining stack onto main
-jj rebase -r <first-remaining-commit> -d main
-
-# 4. Push all updated branches
-jj git push --all
-```
-
-The `*` mark in `jj log` indicates bookmarks that need pushing.
-
-## Editing Earlier Commits
-
-Need to modify a commit that has descendants?
-
-```bash
-# Switch working copy to that commit
-jj edit <commit-id>
-
-# Make changes (they go directly into that commit)
-
-# Return to where you were
-jj edit @
-
-# Descendants are automatically rebased
-jj git push --all
-```
-
-## Splitting Commits
-
-When a commit has changes that should be separate:
-
-```bash
-# Interactive split
-jj split
-
-# Non-interactive: specify files for first commit
-JJ_EDITOR=true jj split -m "First commit message" file1.rs file2.rs
-# Remaining files stay in second commit
-jj describe -m "Second commit message"
-```
-
-## Workspaces (Multi-Project Isolation)
-
-Workspaces let you work on multiple independent features in the same repo without context pollution. Each workspace has its own working copy and working-copy commit, but shares the repo's history, bookmarks, and remote connections.
-
-**Why use workspaces for agents?**
-
-- **Context isolation**: Each workspace sees only its own files, limiting token usage
-- **No permission issues**: Workspaces are local - no git auth or GitHub tokens needed
-- **Shared history**: All workspaces see the same commits, bookmarks, and PRs
-- **Independent builds**: Run tests in one workspace while coding in another
-
-### Creating a Workspace
-
-```bash
-# From your main repo directory, create workspace for a specific feature
-jj workspace add ./workspaces/feature-auth
-
-# Start work from a specific commit (e.g., main)
-jj workspace add ./workspaces/api-refactor -r main
-
-# Create workspace with empty sparse patterns (minimal checkout)
-jj workspace add ./workspaces/docs --sparse-patterns=empty
-```
-
-The workspace name defaults to the directory basename (e.g., `feature-auth`).
-
-**Important**: Add `workspaces/` to your `.gitignore` to prevent tracking workspace directories.
-
-### Listing Workspaces
-
-```bash
-jj workspace list
-```
-
-In `jj log`, workspace indicators show which workspace owns each working-copy commit:
-
-```
-@      abc123   feature-auth@    (empty) Working copy
-|  @   def456   api-refactor@    (empty) Working copy
-| /
-o      789xyz   main             "Latest release"
-```
-
-### Workflow: Agent Per Workspace
-
-For AI agents working on multiple tasks:
-
-```bash
-# 1. Create isolated workspace for each task
-jj workspace add ./workspaces/task-1 -r main
-jj workspace add ./workspaces/task-2 -r main
-
-# 2. Agent works in task-1 directory
-cd ./workspaces/task-1
-jj new
+jj new main                              # Start from main
 # ... make changes ...
-jj describe -m "Implement feature X"
-jj git push -c @-
-
-# 3. Switch to task-2 (different directory, different context)
-cd ../task-2
-jj new
-# ... different changes ...
-jj describe -m "Fix bug Y"
-jj git push -c @-
-
-# 4. Both PRs visible from either workspace
-gh pr list  # Works from any workspace
+jj describe -m "Add feature"             # Describe
+jj bookmark set feat/my-feature -r @     # Create bookmark
+jj git push --bookmark feat/my-feature --allow-new
+gh pr create --head feat/my-feature
 ```
 
-### Rebasing Across Workspaces
-
-Since all workspaces share the repo, rebase operations affect all:
+### Update PR
 
 ```bash
-# From any workspace, fetch updates
+jj new                    # New commit on top
+# ... make changes ...
+jj squash                 # Fold into PR commit
+jj git push               # Push update
+```
+
+### Sync with Main
+
+```bash
 jj git fetch
-
-# Rebase a commit (affects all workspaces that descend from it)
-jj rebase -r <commit> -d main
-
-# Push all changed bookmarks (from any workspace)
-jj git push --all
-```
-
-If a workspace's working-copy commit gets rebased from another workspace, it becomes "stale":
-
-```bash
-# In the affected workspace, update to latest
-jj workspace update-stale
-```
-
-### PR Management from Any Workspace
-
-GitHub CLI works identically from any workspace since they share the `.git` directory:
-
-```bash
-# Create PR (works from any workspace)
-jj git push -c @-
-gh pr create --head push-abcdefgh
-
-# List all PRs
-gh pr list
-
-# Check PR status
-gh pr view <number>
-
-# Merge a PR (triggers CI, merges on GitHub)
-gh pr merge <number>
-```
-
-### Sparse Patterns for Focused Work
-
-Limit which files appear in a workspace to reduce agent context:
-
-```bash
-# Create workspace with only specific directories
-jj workspace add ./workspaces/backend
-cd ./workspaces/backend
-jj sparse set --add 'src/backend/**' --add 'tests/backend/**'
-
-# Or start empty and add incrementally
-jj workspace add ./workspaces/minimal --sparse-patterns=empty
-cd ./workspaces/minimal
-jj sparse set --add 'src/api/endpoints.rs'
-```
-
-### Cleaning Up Workspaces
-
-```bash
-# Remove a workspace (keeps its commits, just detaches working copy)
-jj workspace forget <workspace-name>
-
-# Then delete the directory manually
-rm -rf ./workspaces/<workspace-name>
-```
-
-### Common Workspace Commands
-
-```bash
-jj workspace list              # Show all workspaces
-jj workspace add <path>        # Create new workspace
-jj workspace add <path> -r @   # New workspace starting at current commit
-jj workspace forget <name>     # Stop tracking workspace
-jj workspace update-stale      # Sync after external rebase
-jj workspace root              # Show workspace root directory
-jj sparse list                 # Show current sparse patterns
-jj sparse set --add 'path/**'  # Add paths to sparse checkout
-jj sparse reset                # Reset to full checkout
-```
-
-### Workspace Naming Conventions
-
-For multi-agent or multi-task setups, use `./workspaces/` subdirectory:
-
-```
-myrepo/
-├── workspaces/          # Add to .gitignore
-│   ├── feature-foo/     # Feature work
-│   ├── bugfix-bar/      # Bug fix
-│   ├── review-123/      # PR review workspace
-│   └── experiment/      # Throwaway experiments
-├── src/
-└── ...
-```
-
-## Undo
-
-Made a mistake? jj tracks all operations:
-
-```bash
-jj undo              # Undo last operation
-jj op log            # View operation history
-jj op restore <id>   # Restore to specific operation
+jj rebase -r @ -d main
+jj git push
 ```
 
 ## Common Mistakes
 
-### Working in a Described Commit
+1. **Working in described commit**: Always `jj new` before making changes
+2. **Using `-c @` for updates**: This creates NEW bookmark/PR. Use `jj squash` + `jj git push`
+3. **Forgetting `--allow-new`**: Required first time pushing a bookmark
 
-**Wrong:**
-
-```bash
-jj describe -m "Feature A"
-# ... keep making changes in same commit ...
-# Now Feature A commit has unrelated stuff mixed in
-```
-
-**Right:**
+## Undo
 
 ```bash
-jj describe -m "Feature A"
-jj new                      # Start fresh for next work
-# ... make changes ...
-jj squash                   # If changes belong in Feature A
-```
-
-### Forgetting `--allow-new` on First Push
-
-```bash
-# First time pushing a bookmark to a new remote
-jj git push --bookmark main --allow-new
-```
-
-After the bookmark exists on the remote, you don't need this flag.
-
-### Pushing a New Commit as a New PR
-
-**Wrong:**
-
-```bash
-jj new
-# ... changes for existing PR ...
-jj git push -c @            # Creates NEW bookmark/PR!
-```
-
-**Right:**
-
-```bash
-jj new
-# ... changes for existing PR ...
-jj squash                   # Fold into existing PR commit
-jj git push                 # Updates existing bookmark
+jj undo              # Undo last operation
+jj op log            # View operation history
+jj op restore <id>   # Restore to specific point
 ```

--- a/modules/home-manager/skills/external/jj/scripts/jj-pr
+++ b/modules/home-manager/skills/external/jj/scripts/jj-pr
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# jj-pr: Create a new PR with conventional branch naming
+# Usage: jj-pr <type> <description> [commit-message]
+# Example: jj-pr feat user-auth "Add user authentication flow"
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+usage() {
+    cat <<EOF
+Usage: jj-pr <type> <description> [commit-message]
+
+Create a new PR with conventional branch naming.
+
+Types:
+  feat, feature  - New features
+  fix, bugfix    - Bug fixes
+  hotfix         - Urgent fixes
+  release        - Release preparation
+  chore          - Non-code tasks (deps, docs)
+
+Arguments:
+  type           - Branch type prefix
+  description    - Branch description (kebab-case)
+  commit-message - Optional commit message (uses description if not provided)
+
+Examples:
+  jj-pr feat user-auth "Add user authentication flow"
+  jj-pr fix null-pointer
+  jj-pr chore deps-update "Update dependencies to latest versions"
+EOF
+    exit 1
+}
+
+# Validate type
+validate_type() {
+    local type="$1"
+    case "$type" in
+        feat|feature|fix|bugfix|hotfix|release|chore)
+            return 0
+            ;;
+        *)
+            echo -e "${RED}Error: Invalid type '$type'${NC}"
+            echo "Valid types: feat, feature, fix, bugfix, hotfix, release, chore"
+            exit 1
+            ;;
+    esac
+}
+
+# Normalize type (feature -> feat, bugfix -> fix)
+normalize_type() {
+    local type="$1"
+    case "$type" in
+        feature) echo "feat" ;;
+        bugfix) echo "fix" ;;
+        *) echo "$type" ;;
+    esac
+}
+
+# Validate description (kebab-case, no special chars)
+validate_description() {
+    local desc="$1"
+    if [[ ! "$desc" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+        echo -e "${RED}Error: Description must be kebab-case (lowercase, hyphens only)${NC}"
+        echo "Got: $desc"
+        echo "Example: user-auth, fix-null-pointer, gh-123-add-feature"
+        exit 1
+    fi
+}
+
+# Main
+if [[ $# -lt 2 ]]; then
+    usage
+fi
+
+TYPE="$1"
+DESC="$2"
+MESSAGE="${3:-$DESC}"
+
+validate_type "$TYPE"
+validate_description "$DESC"
+
+TYPE=$(normalize_type "$TYPE")
+BRANCH="${TYPE}/${DESC}"
+
+echo -e "${YELLOW}Creating PR with branch: ${BRANCH}${NC}"
+
+# Check current state
+echo -e "\n${GREEN}1. Checking status...${NC}"
+jj status
+
+# Check if we have changes
+if jj diff --stat | grep -q .; then
+    echo -e "\n${GREEN}2. Changes detected in working copy${NC}"
+else
+    echo -e "\n${YELLOW}Warning: No changes in working copy${NC}"
+    read -p "Continue anyway? [y/N] " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+# Describe the commit
+echo -e "\n${GREEN}3. Setting commit message...${NC}"
+jj describe -m "$MESSAGE"
+
+# Create bookmark
+echo -e "\n${GREEN}4. Creating bookmark: ${BRANCH}${NC}"
+jj bookmark set "$BRANCH" -r @
+
+# Push to remote
+echo -e "\n${GREEN}5. Pushing to remote...${NC}"
+jj git push --bookmark "$BRANCH" --allow-new
+
+# Create PR
+echo -e "\n${GREEN}6. Creating PR...${NC}"
+gh pr create --head "$BRANCH" --fill
+
+echo -e "\n${GREEN}Done! PR created with branch: ${BRANCH}${NC}"

--- a/modules/home-manager/skills/external/jj/scripts/jj-stack
+++ b/modules/home-manager/skills/external/jj/scripts/jj-stack
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# jj-stack: Add another PR to the current stack
+# Usage: jj-stack <type> <description> [commit-message]
+# Example: jj-stack feat login-ui "Add login UI components"
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+usage() {
+    cat <<EOF
+Usage: jj-stack <type> <description> [commit-message]
+
+Add another PR to the current stack (stacked PRs workflow).
+
+This script:
+1. Creates a new commit on top of current
+2. Sets commit message
+3. Creates conventional branch bookmark
+4. Pushes to remote
+5. Creates PR with proper base branch
+
+Types:
+  feat, feature  - New features
+  fix, bugfix    - Bug fixes
+  hotfix         - Urgent fixes
+  release        - Release preparation
+  chore          - Non-code tasks (deps, docs)
+
+Arguments:
+  type           - Branch type prefix
+  description    - Branch description (kebab-case)
+  commit-message - Optional commit message (uses description if not provided)
+
+Examples:
+  jj-stack feat login-ui "Add login UI components"
+  jj-stack fix validation-error
+EOF
+    exit 1
+}
+
+# Validate type
+validate_type() {
+    local type="$1"
+    case "$type" in
+        feat|feature|fix|bugfix|hotfix|release|chore)
+            return 0
+            ;;
+        *)
+            echo -e "${RED}Error: Invalid type '$type'${NC}"
+            echo "Valid types: feat, feature, fix, bugfix, hotfix, release, chore"
+            exit 1
+            ;;
+    esac
+}
+
+# Normalize type (feature -> feat, bugfix -> fix)
+normalize_type() {
+    local type="$1"
+    case "$type" in
+        feature) echo "feat" ;;
+        bugfix) echo "fix" ;;
+        *) echo "$type" ;;
+    esac
+}
+
+# Validate description (kebab-case, no special chars)
+validate_description() {
+    local desc="$1"
+    if [[ ! "$desc" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+        echo -e "${RED}Error: Description must be kebab-case (lowercase, hyphens only)${NC}"
+        echo "Got: $desc"
+        echo "Example: user-auth, fix-null-pointer, gh-123-add-feature"
+        exit 1
+    fi
+}
+
+# Get bookmark name for a revision
+get_bookmark() {
+    local rev="$1"
+    jj log -r "$rev" --no-graph -T 'bookmarks' 2>/dev/null | head -1 | sed 's/\*.*//' | tr -d ' '
+}
+
+# Main
+if [[ $# -lt 2 ]]; then
+    usage
+fi
+
+TYPE="$1"
+DESC="$2"
+MESSAGE="${3:-$DESC}"
+
+validate_type "$TYPE"
+validate_description "$DESC"
+
+TYPE=$(normalize_type "$TYPE")
+BRANCH="${TYPE}/${DESC}"
+
+# Get parent bookmark for PR base
+PARENT_BOOKMARK=$(get_bookmark '@-')
+if [[ -z "$PARENT_BOOKMARK" ]]; then
+    echo -e "${RED}Error: Parent commit has no bookmark${NC}"
+    echo "The parent commit needs a bookmark for stacked PRs to work."
+    echo "Create one with: jj bookmark set <name> -r @-"
+    exit 1
+fi
+
+echo -e "${YELLOW}Adding to stack: ${BRANCH} (based on ${PARENT_BOOKMARK})${NC}"
+
+# Check current state
+echo -e "\n${GREEN}1. Current stack:${NC}"
+jj log -r 'ancestors(@, 5)' --no-graph
+
+# Check if we have changes
+if jj diff --stat | grep -q .; then
+    echo -e "\n${GREEN}2. Changes detected in working copy${NC}"
+else
+    echo -e "\n${YELLOW}Warning: No changes in working copy${NC}"
+    read -p "Continue anyway? [y/N] " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+# Describe the commit
+echo -e "\n${GREEN}3. Setting commit message...${NC}"
+jj describe -m "$MESSAGE"
+
+# Create bookmark
+echo -e "\n${GREEN}4. Creating bookmark: ${BRANCH}${NC}"
+jj bookmark set "$BRANCH" -r @
+
+# Push to remote
+echo -e "\n${GREEN}5. Pushing to remote...${NC}"
+jj git push --bookmark "$BRANCH" --allow-new
+
+# Create PR with correct base
+echo -e "\n${GREEN}6. Creating PR (base: ${PARENT_BOOKMARK})...${NC}"
+gh pr create --head "$BRANCH" --base "$PARENT_BOOKMARK" --fill
+
+# Create new empty commit for next work
+echo -e "\n${GREEN}7. Creating new commit for next work...${NC}"
+jj new
+
+echo -e "\n${GREEN}Done! Stacked PR created.${NC}"
+echo -e "Stack: ${PARENT_BOOKMARK} -> ${BRANCH}"

--- a/modules/home-manager/skills/external/jj/scripts/jj-sync
+++ b/modules/home-manager/skills/external/jj/scripts/jj-sync
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# jj-sync: Fetch latest and rebase current work onto main
+# Usage: jj-sync [base-branch]
+# Example: jj-sync main
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+usage() {
+    cat <<EOF
+Usage: jj-sync [base-branch]
+
+Fetch latest from remote and rebase current work onto base branch.
+
+This script:
+1. Fetches latest from remote
+2. Rebases current commit (or stack) onto base branch
+3. Shows the new state
+
+Arguments:
+  base-branch - Branch to rebase onto (default: main)
+
+Examples:
+  jj-sync              # Rebase onto main
+  jj-sync develop      # Rebase onto develop
+EOF
+    exit 1
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+fi
+
+BASE="${1:-main}"
+
+echo -e "${YELLOW}Syncing with ${BASE}...${NC}"
+
+# Show current state
+echo -e "\n${GREEN}1. Current state:${NC}"
+jj log -r '@-::@' --no-graph
+
+# Fetch latest
+echo -e "\n${GREEN}2. Fetching from remote...${NC}"
+jj git fetch
+
+# Check if we're already on base
+CURRENT_PARENT=$(jj log -r '@-' --no-graph -T 'change_id' 2>/dev/null || echo "")
+BASE_ID=$(jj log -r "$BASE" --no-graph -T 'change_id' 2>/dev/null || echo "")
+
+if [[ "$CURRENT_PARENT" == "$BASE_ID" ]]; then
+    echo -e "\n${GREEN}Already up to date with ${BASE}${NC}"
+else
+    # Rebase onto base
+    echo -e "\n${GREEN}3. Rebasing onto ${BASE}...${NC}"
+    jj rebase -r @ -d "$BASE"
+fi
+
+# Show new state
+echo -e "\n${GREEN}4. New state:${NC}"
+jj log -r "${BASE}::@" --no-graph
+
+# Check if push is needed
+if jj log -r '@' --no-graph | grep -q '\*'; then
+    echo -e "\n${YELLOW}Note: Bookmark needs pushing (marked with *)${NC}"
+    echo "Run 'jj git push' to update remote"
+fi
+
+echo -e "\n${GREEN}Done! Synced with ${BASE}${NC}"

--- a/modules/home-manager/skills/external/jj/scripts/jj-update
+++ b/modules/home-manager/skills/external/jj/scripts/jj-update
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# jj-update: Update an existing PR (squash changes into parent and push)
+# Usage: jj-update [commit-message]
+# Example: jj-update "Fix review comments"
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+usage() {
+    cat <<EOF
+Usage: jj-update [commit-message]
+
+Update an existing PR by squashing current changes into parent commit.
+
+This script:
+1. Checks that you have changes to squash
+2. Optionally updates the commit message
+3. Squashes changes into parent
+4. Pushes to remote
+
+Arguments:
+  commit-message - Optional new commit message (keeps existing if not provided)
+
+Examples:
+  jj-update                           # Squash and push, keep existing message
+  jj-update "Add error handling"      # Squash with new message
+EOF
+    exit 1
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+fi
+
+MESSAGE="${1:-}"
+
+echo -e "${YELLOW}Updating PR...${NC}"
+
+# Check current state
+echo -e "\n${GREEN}1. Checking status...${NC}"
+jj status
+
+# Check if we have changes
+if ! jj diff --stat | grep -q .; then
+    echo -e "${RED}Error: No changes in working copy to squash${NC}"
+    echo "Make some changes first, then run jj-update"
+    exit 1
+fi
+
+# Show what will be squashed
+echo -e "\n${GREEN}2. Changes to squash:${NC}"
+jj diff --stat
+
+# Squash into parent
+echo -e "\n${GREEN}3. Squashing into parent commit...${NC}"
+jj squash
+
+# Update message if provided
+if [[ -n "$MESSAGE" ]]; then
+    echo -e "\n${GREEN}4. Updating commit message...${NC}"
+    jj describe -m "$MESSAGE"
+fi
+
+# Push to remote
+echo -e "\n${GREEN}5. Pushing to remote...${NC}"
+jj git push
+
+echo -e "\n${GREEN}Done! PR updated.${NC}"
+
+# Show final state
+echo -e "\n${YELLOW}Current state:${NC}"
+jj log -r '@-::@' --no-graph

--- a/modules/home-manager/skills/external/jj/scripts/jj-workspace
+++ b/modules/home-manager/skills/external/jj/scripts/jj-workspace
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# jj-workspace: Manage jj workspaces for isolated work
+# Usage: jj-workspace <command> [args]
+# Example: jj-workspace create feature-auth
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+WORKSPACES_DIR="./workspaces"
+
+usage() {
+    cat <<EOF
+Usage: jj-workspace <command> [args]
+
+Manage jj workspaces for isolated multi-task work.
+
+Commands:
+  create <name> [base]   Create a new workspace (default base: main)
+  list                   List all workspaces
+  remove <name>          Remove a workspace
+  clean                  Remove all workspaces
+  status                 Show status of all workspaces
+
+Examples:
+  jj-workspace create feature-auth          # New workspace from main
+  jj-workspace create bugfix-login develop  # New workspace from develop
+  jj-workspace list                         # Show all workspaces
+  jj-workspace remove feature-auth          # Remove workspace
+  jj-workspace clean                        # Remove all workspaces
+EOF
+    exit 1
+}
+
+# Ensure workspaces directory exists
+ensure_workspaces_dir() {
+    if [[ ! -d "$WORKSPACES_DIR" ]]; then
+        mkdir -p "$WORKSPACES_DIR"
+        echo -e "${YELLOW}Created workspaces directory: ${WORKSPACES_DIR}${NC}"
+        
+        # Check if .gitignore exists and add workspaces/ if needed
+        if [[ -f .gitignore ]]; then
+            if ! grep -q "^workspaces/" .gitignore; then
+                echo "workspaces/" >> .gitignore
+                echo -e "${YELLOW}Added workspaces/ to .gitignore${NC}"
+            fi
+        fi
+    fi
+}
+
+cmd_create() {
+    local name="${1:-}"
+    local base="${2:-main}"
+    
+    if [[ -z "$name" ]]; then
+        echo -e "${RED}Error: Workspace name required${NC}"
+        echo "Usage: jj-workspace create <name> [base]"
+        exit 1
+    fi
+    
+    ensure_workspaces_dir
+    
+    local workspace_path="${WORKSPACES_DIR}/${name}"
+    
+    if [[ -d "$workspace_path" ]]; then
+        echo -e "${RED}Error: Workspace already exists: ${workspace_path}${NC}"
+        exit 1
+    fi
+    
+    echo -e "${GREEN}Creating workspace: ${name} (base: ${base})${NC}"
+    jj workspace add "$workspace_path" -r "$base"
+    
+    echo -e "\n${GREEN}Workspace created!${NC}"
+    echo -e "To use: ${BLUE}cd ${workspace_path}${NC}"
+    echo -e "Then:   ${BLUE}jj new${NC} to start working"
+}
+
+cmd_list() {
+    echo -e "${GREEN}Workspaces:${NC}\n"
+    jj workspace list
+    
+    if [[ -d "$WORKSPACES_DIR" ]]; then
+        echo -e "\n${GREEN}Workspace directories:${NC}"
+        for dir in "$WORKSPACES_DIR"/*/; do
+            if [[ -d "$dir" ]]; then
+                local name=$(basename "$dir")
+                echo -e "  ${BLUE}${name}${NC} -> ${dir}"
+            fi
+        done
+    fi
+}
+
+cmd_remove() {
+    local name="${1:-}"
+    
+    if [[ -z "$name" ]]; then
+        echo -e "${RED}Error: Workspace name required${NC}"
+        echo "Usage: jj-workspace remove <name>"
+        exit 1
+    fi
+    
+    local workspace_path="${WORKSPACES_DIR}/${name}"
+    
+    echo -e "${YELLOW}Removing workspace: ${name}${NC}"
+    
+    # Forget the workspace in jj
+    if jj workspace list | grep -q "$name"; then
+        jj workspace forget "$name"
+        echo -e "${GREEN}Workspace forgotten from jj${NC}"
+    fi
+    
+    # Remove the directory
+    if [[ -d "$workspace_path" ]]; then
+        rm -rf "$workspace_path"
+        echo -e "${GREEN}Directory removed: ${workspace_path}${NC}"
+    fi
+    
+    echo -e "\n${GREEN}Done!${NC}"
+}
+
+cmd_clean() {
+    echo -e "${YELLOW}This will remove ALL workspaces.${NC}"
+    read -p "Are you sure? [y/N] " -n 1 -r
+    echo
+    
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Cancelled."
+        exit 0
+    fi
+    
+    # Get list of workspaces
+    local workspaces=$(jj workspace list | grep -v "^default" | awk '{print $1}' || true)
+    
+    for ws in $workspaces; do
+        if [[ -n "$ws" && "$ws" != "default" ]]; then
+            echo -e "${YELLOW}Forgetting: ${ws}${NC}"
+            jj workspace forget "$ws" 2>/dev/null || true
+        fi
+    done
+    
+    # Remove directory
+    if [[ -d "$WORKSPACES_DIR" ]]; then
+        rm -rf "$WORKSPACES_DIR"
+        echo -e "${GREEN}Removed: ${WORKSPACES_DIR}${NC}"
+    fi
+    
+    echo -e "\n${GREEN}All workspaces cleaned!${NC}"
+}
+
+cmd_status() {
+    echo -e "${GREEN}Workspace Status:${NC}\n"
+    
+    # Show jj workspace list
+    jj workspace list
+    
+    echo ""
+    
+    # Show each workspace's current state
+    if [[ -d "$WORKSPACES_DIR" ]]; then
+        for dir in "$WORKSPACES_DIR"/*/; do
+            if [[ -d "$dir" ]]; then
+                local name=$(basename "$dir")
+                echo -e "${BLUE}${name}:${NC}"
+                (cd "$dir" && jj log -r '@' --no-graph -T 'concat(change_id.short(), " ", description.first_line())' 2>/dev/null || echo "  (error reading)")
+                echo ""
+            fi
+        done
+    fi
+}
+
+# Main
+COMMAND="${1:-}"
+
+case "$COMMAND" in
+    create)
+        shift
+        cmd_create "$@"
+        ;;
+    list|ls)
+        cmd_list
+        ;;
+    remove|rm)
+        shift
+        cmd_remove "$@"
+        ;;
+    clean)
+        cmd_clean
+        ;;
+    status)
+        cmd_status
+        ;;
+    -h|--help|"")
+        usage
+        ;;
+    *)
+        echo -e "${RED}Unknown command: ${COMMAND}${NC}"
+        usage
+        ;;
+esac


### PR DESCRIPTION
## Summary

- Adds full [Conventional Branch](https://conventional-branch.github.io) specification to the jj skill
- Updates push/PR workflow examples to use meaningful bookmark names instead of auto-generated ones
- Includes naming rules, supported types, and common patterns

## Changes

### New Section: Conventional Branch Naming
- Branch name format: `<type>/<description>`
- Supported types: `feature/`, `feat/`, `bugfix/`, `fix/`, `hotfix/`, `release/`, `chore/`
- Naming rules (lowercase, hyphens, ticket numbers)
- Quick workflow example with conventional names
- Common pattern examples

### Updated Sections
- **Pushing to GitHub**: Now recommends conventional branch names as primary approach
- **Stacked PRs**: Updated examples to use conventional naming like `feature/auth-service`
- **Description**: Added "Conventional Branch naming" to skill description

## Why

Conventional branch naming makes PRs more discoverable and integrates better with CI/CD automation. Auto-generated names like `push-abcdefgh` are hard to identify at a glance.