### PR TITLE
fix: set default opencode model to big-pickle for monkey user

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,10 @@
       development.enable = true;
       agent-skills.enable = true;
       onepassword.enable = true;
-      opencode.enable = true;
+      opencode = {
+        enable = true;
+        model = "opencode/big-pickle";
+      };
       claude-code = {
         enable = true;
         rtk.enable = true;


### PR DESCRIPTION
## Summary
- Set default opencode model to `opencode/big-pickle` for the monkey user (MegamanX)
- This prevents OpenCode from suggesting restricted models like gemini3 pro

## Changes
- Modified `mkUser` function in flake.nix to include default model for opencode
- Removed model overrides from agent configuration files in ~/.config/opencode