### PR TITLE
fix: use dynamic hostname in system:switch instead of hardcoded MegamanX

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -145,16 +145,117 @@
     "system:switch" = {
       description = "Apply configuration to current system (platform-aware)";
       exec = ''
+        set -euo pipefail
+
+        echo "=== System Switch ==="
+        echo ""
+
+        # Detect platform
         if [[ "$(uname)" == "Darwin" ]]; then
-          HOSTNAME=$(hostname -s)
-          PASSWORD_PATH="op://Private/''${HOSTNAME} Sudo Password/password"
-          NIXPKGS_ALLOW_UNFREE=1 op run \
-            --env-file=<(echo "SUDO_PASSWORD=$(op read "$PASSWORD_PATH")") \
-            -- bash -c 'echo "$SUDO_PASSWORD" | \
-            sudo -S NIXPKGS_ALLOW_UNFREE=1 darwin-rebuild switch --flake ./#MegamanX --impure'
+          PLATFORM="Darwin"
         else
-          sudo nixos-rebuild switch --flake ./
+          PLATFORM="Linux"
         fi
+        echo "Platform: $PLATFORM"
+
+        # Get hostname and map to configuration name
+        HOSTNAME=$(hostname -s)
+        echo "Hostname: $HOSTNAME"
+
+        if [[ "$PLATFORM" == "Darwin" ]]; then
+          # Map hostname to configuration name for Darwin
+          case "$HOSTNAME" in
+            "wweaver"|"Will-Stride-MBP")
+              CONFIG_NAME="wweaver"
+              ;;
+            "MegamanX")
+              CONFIG_NAME="MegamanX"
+              ;;
+            *)
+              echo ""
+              echo "ERROR: Unknown Darwin host: $HOSTNAME"
+              echo "Add a mapping for this host in devenv.nix system:switch task"
+              exit 1
+              ;;
+          esac
+          echo "Configuration: $CONFIG_NAME"
+          echo ""
+
+          # Check for 1Password CLI
+          if ! command -v op &> /dev/null; then
+            echo "ERROR: 1Password CLI (op) not found"
+            echo "Install 1Password CLI to use this task"
+            exit 1
+          fi
+          echo "1Password CLI: found"
+
+          # Get sudo password from 1Password
+          PASSWORD_PATH="op://Private/''${HOSTNAME} Sudo Password/password"
+          echo "Fetching sudo password from 1Password..."
+          echo "  Path: $PASSWORD_PATH"
+
+          SUDO_PASSWORD=$(op read "$PASSWORD_PATH" 2>&1) || {
+            echo ""
+            echo "ERROR: Failed to read sudo password from 1Password"
+            echo "  Attempted path: $PASSWORD_PATH"
+            echo ""
+            echo "Ensure you have a '$HOSTNAME Sudo Password' item in your Private vault"
+            echo "with a 'password' field containing your sudo password."
+            exit 1
+          }
+          echo "Sudo password: retrieved"
+          echo ""
+
+          # Build and switch
+          echo "--- Building Configuration ---"
+          echo "Running: darwin-rebuild switch --flake ./#$CONFIG_NAME --impure"
+          echo ""
+
+          echo "$SUDO_PASSWORD" | sudo -S NIXPKGS_ALLOW_UNFREE=1 darwin-rebuild switch \
+            --flake "./#$CONFIG_NAME" \
+            --impure \
+            --show-trace 2>&1 || {
+            EXIT_CODE=$?
+            echo ""
+            echo "ERROR: darwin-rebuild failed with exit code $EXIT_CODE"
+            echo ""
+            echo "Common issues to check:"
+            echo "  - Nix evaluation errors (check --show-trace output above)"
+            echo "  - Package build failures"
+            echo "  - Permission issues"
+            echo "  - Network connectivity for fetching packages"
+            exit $EXIT_CODE
+          }
+
+        else
+          # Linux/NixOS
+          CONFIG_NAME="$HOSTNAME"
+          echo "Configuration: $CONFIG_NAME"
+          echo ""
+
+          echo "--- Building Configuration ---"
+          echo "Running: nixos-rebuild switch --flake ./#$CONFIG_NAME"
+          echo ""
+
+          sudo nixos-rebuild switch \
+            --flake "./#$CONFIG_NAME" \
+            --show-trace 2>&1 || {
+            EXIT_CODE=$?
+            echo ""
+            echo "ERROR: nixos-rebuild failed with exit code $EXIT_CODE"
+            echo ""
+            echo "Common issues to check:"
+            echo "  - Nix evaluation errors (check --show-trace output above)"
+            echo "  - Package build failures"
+            echo "  - Permission issues"
+            echo "  - Network connectivity for fetching packages"
+            exit $EXIT_CODE
+          }
+        fi
+
+        echo ""
+        echo "=== System Switch Complete ==="
+        echo "Configuration '$CONFIG_NAME' applied successfully"
       '';
     };
 


### PR DESCRIPTION
## Summary

- Fix hardcoded `./#MegamanX` to use detected hostname via `CONFIG_NAME` mapping
- Add hostname-to-config mapping for Darwin hosts
- Add detailed progress reporting and error handling

## Problem

The `system:switch` task had `MegamanX` hardcoded in the `--flake` argument, meaning it would always apply the MegamanX configuration regardless of which machine was running the command. This bug existed in the original Taskfile.yml and was carried over during the migration to devenv tasks in PR #120.

## Changes

1. **Dynamic hostname mapping**: Maps detected hostname to correct configuration name
   - `wweaver` or `Will-Stride-MBP` → `wweaver` config  
   - `MegamanX` → `MegamanX` config

2. **Progress reporting**: Shows platform, hostname, configuration, and 1Password status

3. **Error handling**:
   - `set -euo pipefail` for strict error checking
   - Check for `op` CLI before attempting to use it
   - Clear error messages with troubleshooting hints
   - `--show-trace` added for debugging Nix evaluation errors

## Testing

Tested on `wweaver` host - task now correctly detects hostname and applies the `wweaver` configuration instead of `MegamanX`.