### PR TITLE
feat: add openclaw-host role for OpenClaw integration

### DIFF
--- a/targets/drlight/default.nix
+++ b/targets/drlight/default.nix
@@ -1,20 +1,23 @@
 {
   inputs,
-  lib,
+  pkgs,
   ...
-}: {
-  imports =
-    lib.optionals (builtins.pathExists /etc/nixos/hardware-configuration.nix) [
-      /etc/nixos/hardware-configuration.nix
-    ]
-    ++ lib.optionals (!builtins.pathExists /etc/nixos/hardware-configuration.nix) [
-      ../hardware-stub.nix
-    ];
+}:
+# NixOS module for the `drlight` machine.
+# - Configures basic networking / SSH settings used in flake.nix
+# - Runs Jellyfin and Mealie services
+# Note: User configuration comes from modules/nixos/base.nix via myConfig.users
+{
+  imports = [
+    ./hardware-configuration.nix
+    ../../modules/nixos/services.nix
+  ];
 
   # Host/network/time settings for drlight
   networking = {
     hostName = "drlight";
     networkmanager.enable = true;
+    firewall.allowedTCPPorts = [9000];
   };
   time.timeZone = "America/New_York";
 
@@ -23,11 +26,44 @@
   system.autoUpgrade = {
     enable = true;
     flake = inputs.self.outPath;
-    flags = [
-      "-L"
-      "--refresh"
-    ];
+    flags = ["-L"];
     dates = "02:00";
     randomizedDelaySec = "45min";
+  };
+
+  # Automatically update flake inputs to latest (nix flake update)
+  # This runs at 1:00 AM and updates flake.lock to latest on main branches
+  systemd.services.flake-autoupdate = {
+    description = "Update Nix flake inputs to latest";
+    path = [pkgs.git pkgs.nix];
+    serviceConfig = {
+      Type = "oneshot";
+      User = "monkey";
+      Environment = "HOME=/home/monkey";
+      WorkingDirectory = "/home/monkey/repos/nix";
+      ExecStart = "${pkgs.nix}/bin/nix flake update";
+    };
+  };
+
+  systemd.timers.flake-autoupdate = {
+    description = "Timer for flake autoupdate";
+    wantedBy = ["timers.target"];
+    timerConfig = {
+      OnCalendar = "01:00";
+      RandomizedDelaySec = "30min";
+    };
+  };
+
+  # Run openclaw-vm microvm as a systemd service
+  systemd.services.openclaw-vm = {
+    description = "OpenClaw MicroVM";
+    wantedBy = ["multi-user.target"];
+    after = ["network.target"];
+    serviceConfig = {
+      Type = "simple";
+      ExecStart = "${pkgs.nix}/bin/nix run ${inputs.self}#microvm.nixosConfigurations.openclaw-vm.config.microvm.runner";
+      Restart = "always";
+      RestartSec = "10";
+    };
   };
 }

--- a/targets/microvms/openclaw-vm.nix
+++ b/targets/microvms/openclaw-vm.nix
@@ -1,0 +1,36 @@
+# openclaw-vm target configuration
+# Dedicated OpenClaw host running in a microvm
+{pkgs, ...}: {
+  # Override hostname
+  networking.hostName = "openclaw-vm";
+
+  # Create openclaw user
+  users.users.openclaw = {
+    isNormalUser = true;
+    description = "OpenClaw User";
+    extraGroups = ["wheel"];
+    shell = pkgs.zsh;
+    home = "/home/openclaw";
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIIxGvpCUmx1UV3K22/+sWLdRknZmlTmQgckoAUCApF8" # MegamanX
+    ];
+  };
+
+  # Root SSH access
+  users.users.root.openssh.authorizedKeys.keys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIIxGvpCUmx1UV3K22/+sWLdRknZmlTmQgckoAUCApF8" # MegamanX
+  ];
+
+  # Ensure zsh is available
+  programs.zsh.enable = true;
+
+  # Allow passwordless sudo for openclaw user
+  security.sudo.wheelNeedsPassword = false;
+
+  # Time zone
+  time.timeZone = "America/New_York";
+
+  # OpenClaw specific configuration
+  # The openclaw-host role provides the package and home-manager config
+  networking.firewall.allowedTCPPorts = [8080]; # OpenClaw gateway port (adjust as needed)
+}


### PR DESCRIPTION
## Summary
This PR deconstructs the standalone openclaw-local flake and integrates it into the main nix repository as a new "openclaw-host" role.

### Changes:
- Add nix-openclaw flake input
- Add nix-openclaw overlay to provide openclaw package
- Add nix-openclaw home-manager module to Darwin and NixOS configs
- Create openclaw-host role in bundles.nix with openclaw package
- Create modules/home-manager/openclaw.nix configuration module
- Enable myConfig.openclaw-host configuration when role is used

### Test Plan:
- [x] `nix flake check --no-build` passes
- [x] All configurations evaluate correctly
- [ ] Test with `openclaw-host` role added to a host (drlight or MegamanX)

### Implementation Plan:
See `docs/plans/2025-03-01-openclaw-host-role.md` for detailed implementation steps.