### PR TITLE
feat: add jj-autosync for automatic repository synchronization

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,10 @@
       development.enable = true;
       agent-skills.enable = true;
       onepassword.enable = true;
+      jj-autosync = {
+        enable = true;
+        username = name;
+      };
       opencode = {
         enable = true;
         model = "opencode/big-pickle";
@@ -330,6 +334,28 @@
                   - Explanation (understanding-oriented)
 
                   $ARGUMENTS
+                '';
+              };
+              workspace = {
+                description = "Create a jj workspace for isolated work with fast sync enabled";
+                template = ''
+                  Create a jj workspace session for isolated development work.
+
+                  Run this command:
+                  ```bash
+                  jj-workspace-session start $ARGUMENTS
+                  ```
+
+                  Then report the workspace name and path to the user, and cd into the workspace directory.
+
+                  If no arguments provided, this starts session tracking in the current workspace.
+                  If a name is provided (e.g., "feat/auth" or "fix/bug"), it creates a new workspace.
+                  A second argument can specify the base branch (defaults to main).
+
+                  Examples:
+                  - /workspace feat/user-auth      -> Creates feat/user-auth-<date>-<id> from main
+                  - /workspace fix/bug develop     -> Creates fix/bug-<date>-<id> from develop
+                  - /workspace                     -> Starts session in current workspace
                 '';
               };
             };

--- a/modules/common/options.nix
+++ b/modules/common/options.nix
@@ -259,6 +259,50 @@ with lib; {
       };
     };
 
+    jj-autosync = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable automatic jj repository synchronization";
+      };
+
+      username = mkOption {
+        type = types.str;
+        default = "";
+        description = "Username for launchd environment (required on Darwin)";
+      };
+
+      reposDir = mkOption {
+        type = types.str;
+        default = "$HOME/repos";
+        description = "Directory containing jj repositories to sync";
+      };
+
+      mainBranch = mkOption {
+        type = types.str;
+        default = "main";
+        description = "Main branch name to sync";
+      };
+
+      hourlySync = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Enable hourly background sync for all repos";
+      };
+
+      fastSyncInterval = mkOption {
+        type = types.int;
+        default = 300;
+        description = "Sync interval in seconds for active sessions (default: 300 = 5 minutes)";
+      };
+
+      sessionTtlSeconds = mkOption {
+        type = types.int;
+        default = 1800;
+        description = "Session TTL in seconds before auto-expiry (default: 1800 = 30 minutes). TTL resets on each sync.";
+      };
+    };
+
     claude-code = {
       enable = mkOption {
         type = types.bool;

--- a/modules/common/users.nix
+++ b/modules/common/users.nix
@@ -103,7 +103,8 @@ in {
             ++ optional config.myConfig.opencode.enable ../../modules/home-manager/opencode.nix
             ++ optional config.myConfig.claude-code.enable ../../modules/home-manager/claude-code.nix
             ++ optional config.myConfig.zellij.enable ../../modules/home-manager/zellij.nix
-            ++ optional config.myConfig.agent-skills.enable ../../modules/home-manager/skills/install.nix;
+            ++ optional config.myConfig.agent-skills.enable ../../modules/home-manager/skills/install.nix
+            ++ optional config.myConfig.jj-autosync.enable ../../modules/home-manager/jj-autosync.nix;
 
           # Pass user info to home-manager modules
           _module.args.userConfig = user;

--- a/modules/home-manager/jj-autosync.nix
+++ b/modules/home-manager/jj-autosync.nix
@@ -1,0 +1,853 @@
+# jj-autosync module: Automatic git/jj repository synchronization
+#
+# Provides:
+# - Background service that fetches/prunes main branch hourly
+# - Auto-syncs local main when changes are detected
+# - Session mode with configurable fast sync frequency for active development
+# - Integration with jj-workspace for OpenCode workspace management
+# - Cross-platform notifications for sync failures
+{
+  config,
+  lib,
+  pkgs,
+  osConfig ? null,
+  ...
+}:
+with lib; let
+  cfg = osConfig.myConfig.jj-autosync or config.myConfig.jj-autosync or {};
+  enabled = cfg.enable or false;
+  isDarwin =
+    if osConfig != null
+    then osConfig.myConfig.isDarwin or false
+    else pkgs.stdenv.isDarwin;
+
+  # Configuration values with defaults
+  reposDir = cfg.reposDir or "$HOME/repos";
+  mainBranch = cfg.mainBranch or "main";
+  hourlySync = cfg.hourlySync or true;
+  fastSyncInterval = cfg.fastSyncInterval or 300;
+  sessionTtlSeconds = cfg.sessionTtlSeconds or 1800; # 30 minutes default
+  username = cfg.username or "";
+
+  # Shared library content (embedded for Nix derivations)
+  sharedLibContent = ''
+    # Shared functions for jj-autosync scripts
+
+    # Generate short unique id (4 hex chars) - portable, no xxd dependency
+    generate_id() {
+        od -An -tx1 -N4 /dev/urandom 2>/dev/null | tr -d ' \n' | head -c 4
+    }
+
+    # Parse a simple key=value config file
+    parse_config() {
+        local config_file="$1"
+        local key="$2"
+        local default="$3"
+
+        if [[ -f "$config_file" ]]; then
+            local value
+            value=$(grep "^''${key}=" "$config_file" 2>/dev/null | cut -d'=' -f2- | tr -d ' ')
+            echo "''${value:-$default}"
+        else
+            echo "$default"
+        fi
+    }
+
+    # Cross-platform notification
+    notify() {
+        local title="''${1:-Notification}"
+        local message="''${2:-}"
+        local urgency="''${3:-normal}"
+
+        # Try noti first (cross-platform)
+        if command -v noti &>/dev/null; then
+            noti -t "$title" -m "$message" 2>/dev/null
+            return
+        fi
+
+        # macOS fallbacks
+        if [[ "$OSTYPE" == darwin* ]]; then
+            if command -v terminal-notifier &>/dev/null; then
+                terminal-notifier -title "$title" -message "$message" 2>/dev/null
+            else
+                osascript -e "display notification \"$message\" with title \"$title\"" 2>/dev/null || true
+            fi
+            return
+        fi
+
+        # Linux fallback
+        if command -v notify-send &>/dev/null; then
+            notify-send -u "$urgency" "$title" "$message" 2>/dev/null
+            return
+        fi
+    }
+  '';
+
+  # Script content as strings
+  jjAutosyncContent = ''
+    #!/usr/bin/env bash
+    # jj-autosync: Sync main branch with upstream
+    # Runs as background service or on-demand
+    # Only syncs repos that have a .jj-autosync file (opt-in per repo)
+    set -euo pipefail
+
+    # Embedded shared functions
+    ${sharedLibContent}
+
+    # Configuration from Nix options
+    REPOS_DIR="''${JJ_AUTOSYNC_REPOS_DIR:-${reposDir}}"
+    DEFAULT_MAIN_BRANCH="''${JJ_AUTOSYNC_MAIN_BRANCH:-${mainBranch}}"
+    LOG_FILE="''${JJ_AUTOSYNC_LOG:-/tmp/jj-autosync.log}"
+    CONFIG_FILE=".jj-autosync"
+
+    log() {
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >> "$LOG_FILE"
+    }
+
+    sync_repo() {
+        local repo="$1"
+        local repo_name
+        repo_name=$(basename "$repo")
+
+        # Check if it's a jj repo
+        if [[ ! -d "$repo/.jj" ]]; then
+            return 0
+        fi
+
+        cd "$repo"
+
+        # Check for opt-in config file
+        if [[ ! -f "$CONFIG_FILE" ]]; then
+            return 0
+        fi
+
+        # Parse config
+        local repo_enabled
+        repo_enabled=$(parse_config "$CONFIG_FILE" "enabled" "true")
+        local repo_main_branch
+        repo_main_branch=$(parse_config "$CONFIG_FILE" "main" "$DEFAULT_MAIN_BRANCH")
+
+        if [[ "$repo_enabled" != "true" ]]; then
+            log "[$repo_name] Sync disabled in config, skipping"
+            return 0
+        fi
+
+        log "[$repo_name] Starting sync (main=$repo_main_branch)..."
+
+        # Fetch with prune
+        if jj git fetch --prune 2>> "$LOG_FILE"; then
+            log "[$repo_name] Fetch completed"
+        else
+            log "[$repo_name] Fetch failed"
+            notify "jj-autosync" "Fetch failed for $repo_name" "critical"
+            return 1
+        fi
+
+        # Update local main to match remote
+        # First check if remote main exists
+        local remote_main_exists
+        if jj log -r "''${repo_main_branch}@origin" --no-graph -T 'commit_id' &>/dev/null; then
+            remote_main_exists=true
+        else
+            remote_main_exists=false
+        fi
+
+        if [[ "$remote_main_exists" == "true" ]]; then
+            # Ensure we're tracking the remote branch
+            jj bookmark track "''${repo_main_branch}@origin" 2>> "$LOG_FILE" || true
+
+            # Fast-forward local main to remote main
+            # This moves the local bookmark to match the remote
+            if jj bookmark set "$repo_main_branch" -r "''${repo_main_branch}@origin" 2>> "$LOG_FILE"; then
+                log "[$repo_name] Updated $repo_main_branch to match origin"
+            else
+                log "[$repo_name] Could not update $repo_main_branch (may have local changes)"
+            fi
+        fi
+
+        log "[$repo_name] Sync complete"
+    }
+
+    # Main execution
+    log "=== jj-autosync starting ==="
+
+    # Expand ~ and $HOME in repos dir
+    REPOS_DIR="''${REPOS_DIR/#\~/$HOME}"
+    REPOS_DIR="''${REPOS_DIR/\$HOME/$HOME}"
+
+    # Find all jj repos in the repos directory that have opted in
+    if [[ -d "$REPOS_DIR" ]]; then
+        for repo in "$REPOS_DIR"/*/; do
+            if [[ -d "$repo/.jj" && -f "$repo/$CONFIG_FILE" ]]; then
+                sync_repo "$repo" || true
+            fi
+        done
+    else
+        log "Repos directory not found: $REPOS_DIR"
+    fi
+
+    log "=== jj-autosync complete ==="
+  '';
+
+  jjWorkspaceSessionContent = ''
+    #!/usr/bin/env bash
+    # jj-workspace-session: Manage workspace sessions with increased sync frequency
+    # Delegates workspace creation to jj-workspace script
+    set -euo pipefail
+
+    # Embedded shared functions
+    ${sharedLibContent}
+
+    # Colors
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'
+    NC='\033[0m'
+
+    SESSION_DIR="''${HOME}/.local/state/jj-autosync"
+    SESSION_FILE="$SESSION_DIR/active-sessions"
+    LOCK_FILE="$SESSION_DIR/sessions.lock"
+    SESSION_TTL_SECONDS="${toString sessionTtlSeconds}"
+
+    mkdir -p "$SESSION_DIR"
+
+    usage() {
+        cat <<EOF
+    Usage: jj-workspace-session <command> [args]
+
+    Manage jj workspace sessions with fast sync (every ${toString (fastSyncInterval / 60)} minutes).
+    Sessions auto-expire after ${toString (sessionTtlSeconds / 60)} minutes of inactivity.
+
+    Commands:
+      start [name] [base]    Start a session (creates workspace if name given)
+      stop                   Stop session in current directory
+      touch                  Reset session TTL (call periodically to keep alive)
+      status                 Show active sessions
+      list                   List active sessions
+      sync                   Manually trigger sync for current repo
+      prune                  Remove expired sessions
+
+    Examples:
+      jj-workspace-session start                    # Start session in current workspace
+      jj-workspace-session start feat/auth          # Create workspace and start session
+      jj-workspace-session start fix/bug develop    # Create workspace from develop
+      jj-workspace-session touch                    # Keep session alive
+      jj-workspace-session stop                     # Stop session
+    EOF
+        exit 1
+    }
+
+    # File locking for concurrent access safety
+    acquire_lock() {
+        local timeout=5
+        local count=0
+        while ! mkdir "$LOCK_FILE" 2>/dev/null; do
+            sleep 0.1
+            count=$((count + 1))
+            if [[ $count -gt $((timeout * 10)) ]]; then
+                echo -e "''${RED}Error: Could not acquire lock''${NC}" >&2
+                return 1
+            fi
+        done
+    }
+
+    release_lock() {
+        rmdir "$LOCK_FILE" 2>/dev/null || true
+    }
+
+    # Get current timestamp
+    now() {
+        date +%s
+    }
+
+    # Add or update a session
+    # Format: repo_path|workspace_name|last_touch_timestamp
+    add_session() {
+        local repo_path="$1"
+        local workspace_name="$2"
+
+        acquire_lock
+        trap release_lock EXIT
+
+        # Remove existing entry for this path
+        if [[ -f "$SESSION_FILE" ]]; then
+            grep -v "^''${repo_path}|" "$SESSION_FILE" > "$SESSION_FILE.tmp" 2>/dev/null || true
+            mv "$SESSION_FILE.tmp" "$SESSION_FILE"
+        fi
+
+        # Add new entry
+        echo "''${repo_path}|''${workspace_name}|$(now)" >> "$SESSION_FILE"
+    }
+
+    # Touch (refresh TTL) for a session
+    touch_session() {
+        local repo_path="$1"
+
+        acquire_lock
+        trap release_lock EXIT
+
+        if [[ ! -f "$SESSION_FILE" ]]; then
+            return 1
+        fi
+
+        # Find and update the session
+        local found=false
+        local temp_file="$SESSION_FILE.tmp"
+        > "$temp_file"
+
+        while IFS='|' read -r path name timestamp; do
+            if [[ "$path" == "$repo_path" ]]; then
+                echo "''${path}|''${name}|$(now)" >> "$temp_file"
+                found=true
+            else
+                echo "''${path}|''${name}|''${timestamp}" >> "$temp_file"
+            fi
+        done < "$SESSION_FILE"
+
+        mv "$temp_file" "$SESSION_FILE"
+
+        if [[ "$found" == "false" ]]; then
+            return 1
+        fi
+    }
+
+    remove_session() {
+        local repo_path="$1"
+
+        acquire_lock
+        trap release_lock EXIT
+
+        if [[ -f "$SESSION_FILE" ]]; then
+            grep -v "^''${repo_path}|" "$SESSION_FILE" > "$SESSION_FILE.tmp" 2>/dev/null || true
+            mv "$SESSION_FILE.tmp" "$SESSION_FILE"
+        fi
+    }
+
+    is_session_active() {
+        local repo_path="$1"
+        if [[ -f "$SESSION_FILE" ]]; then
+            grep -q "^''${repo_path}|" "$SESSION_FILE"
+            return $?
+        fi
+        return 1
+    }
+
+    # Prune expired sessions (TTL exceeded)
+    prune_expired() {
+        acquire_lock
+        trap release_lock EXIT
+
+        if [[ ! -f "$SESSION_FILE" ]]; then
+            return 0
+        fi
+
+        local current_time
+        current_time=$(now)
+        local temp_file="$SESSION_FILE.tmp"
+        local pruned=0
+        > "$temp_file"
+
+        while IFS='|' read -r path name timestamp; do
+            local age=$((current_time - timestamp))
+            if [[ $age -lt $SESSION_TTL_SECONDS ]]; then
+                echo "''${path}|''${name}|''${timestamp}" >> "$temp_file"
+            else
+                echo "Pruned expired session: $path ($name) - inactive for $((age / 60)) minutes" >&2
+                pruned=$((pruned + 1))
+            fi
+        done < "$SESSION_FILE"
+
+        mv "$temp_file" "$SESSION_FILE"
+        echo "$pruned"
+    }
+
+    cmd_start() {
+        local name="''${1:-}"
+        local base="''${2:-main}"
+
+        # Ensure we're in a jj repo
+        if [[ ! -d ".jj" ]]; then
+            echo -e "''${RED}Error: Not in a jj repository''${NC}"
+            exit 1
+        fi
+
+        local repo_path
+        repo_path=$(pwd)
+        local workspace_name="default"
+
+        # If name provided, create a workspace using jj-workspace
+        if [[ -n "$name" ]]; then
+            echo -e "''${GREEN}Creating workspace via jj-workspace...''${NC}"
+
+            # Call jj-workspace create and capture output
+            local output
+            if ! output=$(jj-workspace create "$name" "$base" 2>&1); then
+                echo -e "''${RED}Failed to create workspace:''${NC}"
+                echo "$output"
+                exit 1
+            fi
+
+            echo "$output"
+
+            # Parse the workspace path from output (last line: WORKSPACE_PATH=...)
+            local ws_path
+            ws_path=$(echo "$output" | grep "^WORKSPACE_PATH=" | cut -d'=' -f2)
+
+            if [[ -n "$ws_path" && -d "$ws_path" ]]; then
+                repo_path=$(cd "$ws_path" && pwd)
+                # Extract workspace name from path
+                workspace_name=$(basename "$ws_path")
+            fi
+        fi
+
+        # Register the session
+        add_session "$repo_path" "$workspace_name"
+
+        echo -e "''${GREEN}Session started with ${toString (fastSyncInterval / 60)}-minute sync interval''${NC}"
+        echo -e "Session TTL: ${toString (sessionTtlSeconds / 60)} minutes (auto-refreshed on sync)"
+        echo -e "Run 'jj-workspace-session stop' when done"
+    }
+
+    cmd_stop() {
+        local repo_path
+        repo_path=$(pwd)
+
+        if ! is_session_active "$repo_path"; then
+            echo -e "''${YELLOW}No active session in current directory''${NC}"
+            return 0
+        fi
+
+        remove_session "$repo_path"
+        echo -e "''${GREEN}Session stopped''${NC}"
+    }
+
+    cmd_touch() {
+        local repo_path
+        repo_path=$(pwd)
+
+        if touch_session "$repo_path"; then
+            echo -e "''${GREEN}Session TTL refreshed''${NC}"
+        else
+            echo -e "''${YELLOW}No active session in current directory''${NC}"
+            return 1
+        fi
+    }
+
+    cmd_status() {
+        # Prune expired first
+        local pruned
+        pruned=$(prune_expired 2>&1 | tail -1)
+        if [[ "$pruned" -gt 0 ]]; then
+            echo -e "''${YELLOW}Pruned $pruned expired session(s)''${NC}"
+            echo ""
+        fi
+
+        echo -e "''${GREEN}Active Sessions:''${NC}"
+        if [[ -f "$SESSION_FILE" && -s "$SESSION_FILE" ]]; then
+            local current_time
+            current_time=$(now)
+            while IFS='|' read -r path name timestamp; do
+                local age=$((current_time - timestamp))
+                local remaining=$((SESSION_TTL_SECONDS - age))
+                echo -e "  ''${BLUE}$path''${NC}"
+                echo -e "    Workspace: $name"
+                echo -e "    Last activity: $((age / 60)) min ago"
+                echo -e "    Expires in: $((remaining / 60)) min"
+            done < "$SESSION_FILE"
+        else
+            echo "  (no active sessions)"
+        fi
+    }
+
+    cmd_list() {
+        cmd_status
+    }
+
+    cmd_sync() {
+        if [[ ! -d ".jj" ]]; then
+            echo -e "''${RED}Error: Not in a jj repository''${NC}"
+            exit 1
+        fi
+
+        # Touch the session to refresh TTL
+        local repo_path
+        repo_path=$(pwd)
+        touch_session "$repo_path" 2>/dev/null || true
+
+        echo -e "''${YELLOW}Syncing...''${NC}"
+        if jj git fetch --prune; then
+            echo -e "''${GREEN}Sync complete''${NC}"
+        else
+            echo -e "''${RED}Sync failed''${NC}"
+            exit 1
+        fi
+    }
+
+    cmd_prune() {
+        local pruned
+        pruned=$(prune_expired 2>&1 | tail -1)
+        echo -e "''${GREEN}Pruned $pruned expired session(s)''${NC}"
+    }
+
+    # Main
+    COMMAND="''${1:-}"
+
+    case "$COMMAND" in
+        start)
+            shift
+            cmd_start "$@"
+            ;;
+        stop)
+            cmd_stop
+            ;;
+        touch)
+            cmd_touch
+            ;;
+        status|list)
+            cmd_status
+            ;;
+        sync)
+            cmd_sync
+            ;;
+        prune)
+            cmd_prune
+            ;;
+        -h|--help|"")
+            usage
+            ;;
+        *)
+            echo -e "''${RED}Unknown command: $COMMAND''${NC}"
+            usage
+            ;;
+    esac
+  '';
+
+  jjFastSyncContent = ''
+    #!/usr/bin/env bash
+    # jj-fast-sync: Sync repos with active sessions
+    # Only syncs repos that have a .jj-autosync file with fast_sync=true
+    # Prunes expired sessions and refreshes TTL on successful sync
+    set -euo pipefail
+
+    # Embedded shared functions
+    ${sharedLibContent}
+
+    SESSION_DIR="$HOME/.local/state/jj-autosync"
+    SESSION_FILE="$SESSION_DIR/active-sessions"
+    LOCK_FILE="$SESSION_DIR/sessions.lock"
+    LOG_FILE="/tmp/jj-fast-sync.log"
+    CONFIG_FILE=".jj-autosync"
+    SESSION_TTL_SECONDS="${toString sessionTtlSeconds}"
+
+    log() {
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >> "$LOG_FILE"
+    }
+
+    now() {
+        date +%s
+    }
+
+    # File locking
+    acquire_lock() {
+        local timeout=5
+        local count=0
+        while ! mkdir "$LOCK_FILE" 2>/dev/null; do
+            sleep 0.1
+            count=$((count + 1))
+            if [[ $count -gt $((timeout * 10)) ]]; then
+                log "Could not acquire lock"
+                exit 1
+            fi
+        done
+    }
+
+    release_lock() {
+        rmdir "$LOCK_FILE" 2>/dev/null || true
+    }
+
+    # Prune expired sessions and return active ones
+    prune_and_get_sessions() {
+        acquire_lock
+        trap release_lock EXIT
+
+        if [[ ! -f "$SESSION_FILE" ]]; then
+            return
+        fi
+
+        local current_time
+        current_time=$(now)
+        local temp_file="$SESSION_FILE.tmp"
+        > "$temp_file"
+
+        while IFS='|' read -r path name timestamp; do
+            local age=$((current_time - timestamp))
+            if [[ $age -lt $SESSION_TTL_SECONDS ]]; then
+                echo "''${path}|''${name}|''${timestamp}" >> "$temp_file"
+                echo "''${path}|''${name}|''${timestamp}"
+            else
+                log "Pruned expired session: $path ($name)"
+            fi
+        done < "$SESSION_FILE"
+
+        mv "$temp_file" "$SESSION_FILE"
+    }
+
+    # Update session timestamp after successful sync
+    touch_session() {
+        local target_path="$1"
+
+        acquire_lock
+        trap release_lock EXIT
+
+        if [[ ! -f "$SESSION_FILE" ]]; then
+            return
+        fi
+
+        local temp_file="$SESSION_FILE.tmp"
+        > "$temp_file"
+
+        while IFS='|' read -r path name timestamp; do
+            if [[ "$path" == "$target_path" ]]; then
+                echo "''${path}|''${name}|$(now)" >> "$temp_file"
+            else
+                echo "''${path}|''${name}|''${timestamp}" >> "$temp_file"
+            fi
+        done < "$SESSION_FILE"
+
+        mv "$temp_file" "$SESSION_FILE"
+    }
+
+    # No active sessions? Exit early
+    if [[ ! -f "$SESSION_FILE" || ! -s "$SESSION_FILE" ]]; then
+        exit 0
+    fi
+
+    log "=== Fast sync starting ==="
+
+    # Get active sessions (also prunes expired ones)
+    sessions=$(prune_and_get_sessions)
+
+    if [[ -z "$sessions" ]]; then
+        log "No active sessions after pruning"
+        exit 0
+    fi
+
+    # Process each active session
+    echo "$sessions" | while IFS='|' read -r repo_path workspace_name timestamp; do
+        if [[ -z "$repo_path" ]]; then
+            continue
+        fi
+
+        # Find the repo root (workspace might be in a subdirectory)
+        repo_root="$repo_path"
+        while [[ "$repo_root" != "/" && ! -d "$repo_root/.jj" ]]; do
+            repo_root=$(dirname "$repo_root")
+        done
+
+        # Verify it's a jj repo
+        if [[ ! -d "$repo_root/.jj" ]]; then
+            log "Not a jj repo: $repo_path, skipping"
+            continue
+        fi
+
+        # Check config at repo root level
+        local config_path="$repo_root/$CONFIG_FILE"
+        if [[ ! -f "$config_path" ]]; then
+            # Also check workspace path
+            config_path="$repo_path/$CONFIG_FILE"
+        fi
+
+        if [[ -f "$config_path" ]]; then
+            local fast_sync
+            fast_sync=$(parse_config "$config_path" "fast_sync" "false")
+            if [[ "$fast_sync" == "true" ]]; then
+                log "Syncing: $repo_path ($workspace_name)"
+                if (cd "$repo_path" && jj git fetch --prune 2>> "$LOG_FILE"); then
+                    log "Sync successful for $repo_path"
+                    # Refresh TTL on successful sync
+                    touch_session "$repo_path"
+                else
+                    log "Fetch failed for $repo_path"
+                    notify "jj-fast-sync" "Sync failed for $(basename "$repo_path")" "critical"
+                fi
+            else
+                log "Fast sync disabled for $repo_path, skipping"
+            fi
+        else
+            log "No config file for $repo_path, skipping"
+        fi
+    done
+
+    log "=== Fast sync complete ==="
+  '';
+
+  jjAutosyncStatusContent = ''
+    #!/usr/bin/env bash
+    # jj-autosync-status: Show status and logs for jj-autosync services
+    set -euo pipefail
+
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'
+    NC='\033[0m'
+
+    echo -e "''${GREEN}=== jj-autosync Status ===''${NC}"
+    echo ""
+
+    # Show session status
+    echo -e "''${BLUE}Active Sessions:''${NC}"
+    jj-workspace-session status 2>/dev/null || echo "  (session manager not available)"
+    echo ""
+
+    # Show recent logs
+    echo -e "''${BLUE}Recent Hourly Sync Log:''${NC}"
+    if [[ -f /tmp/jj-autosync.log ]]; then
+        tail -20 /tmp/jj-autosync.log
+    else
+        echo "  (no log file)"
+    fi
+    echo ""
+
+    echo -e "''${BLUE}Recent Fast Sync Log:''${NC}"
+    if [[ -f /tmp/jj-fast-sync.log ]]; then
+        tail -20 /tmp/jj-fast-sync.log
+    else
+        echo "  (no log file)"
+    fi
+  '';
+
+  # Build PATH that includes user profile
+  servicePath =
+    if isDarwin
+    then "/Users/${username}/.nix-profile/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
+    else "$HOME/.nix-profile/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin";
+in {
+  config = mkIf enabled {
+    # Assertions
+    assertions = [
+      {
+        assertion = !isDarwin || username != "";
+        message = "jj-autosync.username is required on Darwin for launchd services";
+      }
+    ];
+
+    # Install the scripts as executables
+    home.packages =
+      [
+        (pkgs.writeShellScriptBin "jj-autosync" jjAutosyncContent)
+        (pkgs.writeShellScriptBin "jj-workspace-session" jjWorkspaceSessionContent)
+        (pkgs.writeShellScriptBin "jj-fast-sync" jjFastSyncContent)
+        (pkgs.writeShellScriptBin "jj-autosync-status" jjAutosyncStatusContent)
+        # Cross-platform notification tool
+        pkgs.noti
+      ]
+      ++ (
+        if isDarwin
+        then [pkgs.terminal-notifier]
+        else [pkgs.libnotify]
+      );
+
+    # launchd agents for macOS
+    launchd.agents = mkIf isDarwin {
+      # Hourly sync for all repos
+      jj-autosync = mkIf hourlySync {
+        enable = true;
+        config = {
+          ProgramArguments = ["${pkgs.writeShellScript "jj-autosync" jjAutosyncContent}"];
+          StartInterval = 3600; # 1 hour
+          RunAtLoad = true;
+          StandardOutPath = "/tmp/jj-autosync-launchd.log";
+          StandardErrorPath = "/tmp/jj-autosync-launchd.err";
+          EnvironmentVariables = {
+            HOME = "/Users/${username}";
+            PATH = servicePath;
+            JJ_AUTOSYNC_REPOS_DIR = reposDir;
+            JJ_AUTOSYNC_MAIN_BRANCH = mainBranch;
+          };
+        };
+      };
+
+      # Fast sync for active sessions
+      jj-fast-sync = {
+        enable = true;
+        config = {
+          ProgramArguments = ["${pkgs.writeShellScript "jj-fast-sync" jjFastSyncContent}"];
+          StartInterval = fastSyncInterval;
+          RunAtLoad = true; # Runs but exits immediately if no sessions
+          StandardOutPath = "/tmp/jj-fast-sync-launchd.log";
+          StandardErrorPath = "/tmp/jj-fast-sync-launchd.err";
+          EnvironmentVariables = {
+            HOME = "/Users/${username}";
+            PATH = servicePath;
+          };
+        };
+      };
+    };
+
+    # systemd user services for Linux
+    systemd.user.services = mkIf (!isDarwin) {
+      jj-autosync = mkIf hourlySync {
+        Unit = {
+          Description = "jj repository auto-sync (hourly)";
+          After = ["network-online.target"];
+        };
+        Service = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.writeShellScript "jj-autosync" jjAutosyncContent}";
+          Environment = [
+            "HOME=%h"
+            "PATH=%h/.nix-profile/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
+            "JJ_AUTOSYNC_REPOS_DIR=${reposDir}"
+            "JJ_AUTOSYNC_MAIN_BRANCH=${mainBranch}"
+          ];
+        };
+      };
+
+      jj-fast-sync = {
+        Unit = {
+          Description = "jj repository fast sync for active sessions";
+          After = ["network-online.target"];
+        };
+        Service = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.writeShellScript "jj-fast-sync" jjFastSyncContent}";
+          Environment = [
+            "HOME=%h"
+            "PATH=%h/.nix-profile/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
+          ];
+        };
+      };
+    };
+
+    systemd.user.timers = mkIf (!isDarwin) {
+      jj-autosync = mkIf hourlySync {
+        Unit = {
+          Description = "Hourly jj auto-sync timer";
+        };
+        Timer = {
+          OnCalendar = "hourly";
+          Persistent = true;
+        };
+        Install = {
+          WantedBy = ["timers.target"];
+        };
+      };
+
+      jj-fast-sync = {
+        Unit = {
+          Description = "Fast jj sync timer for active sessions";
+        };
+        Timer = {
+          OnUnitActiveSec = "${toString fastSyncInterval}s";
+          OnBootSec = "5min";
+          Persistent = true;
+        };
+        Install = {
+          WantedBy = ["timers.target"];
+        };
+      };
+    };
+  };
+}

--- a/modules/home-manager/skills/external/jj/SKILL.md
+++ b/modules/home-manager/skills/external/jj/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jj
-description: Use Jujutsu (jj) for version control. Covers workflow, commits, bookmarks with Conventional Branch naming, pushing to GitHub, absorb, squash, stacked PRs, and workspaces for multi-project isolation. Use when working with jj, creating commits, pushing changes, or managing version control.
+description: Use Jujutsu (jj) for version control. Covers workflow, commits, bookmarks with Conventional Branch naming, pushing to GitHub, absorb, squash, stacked PRs, workspaces with auto-sync for OpenCode sessions. Use when working with jj, creating commits, pushing changes, or managing version control.
 ---
 
 # Jujutsu (jj) Version Control
@@ -26,6 +26,50 @@ description: Use Jujutsu (jj) for version control. Covers workflow, commits, boo
 | `jj absorb` | Auto-distribute to ancestors |
 | `jj git push` | Push to remote |
 | `jj git fetch` | Fetch from remote |
+
+## OpenCode Workspace Workflow
+
+When working with OpenCode, use **workspace sessions** to isolate your work and enable fast sync:
+
+### Starting a Session
+
+Use the `/workspace` command in OpenCode:
+```
+/workspace feat/user-auth        # Create workspace from main
+/workspace fix/login develop     # Create workspace from develop branch
+/workspace                       # Just enable fast sync in current workspace
+```
+
+Or use the CLI directly:
+```bash
+jj-workspace-session start feat/auth      # Create workspace + start session
+jj-workspace-session start                # Start session in current workspace
+```
+
+### What Happens
+
+1. **Workspace Created**: `feat/auth-20260223-a1b2` (type/topic-date-id format)
+2. **Fast Sync Enabled**: Repository syncs every 5 minutes (vs hourly)
+3. **Main Stays Clean**: Your work is isolated, main auto-syncs with upstream
+4. **Session TTL**: Sessions auto-expire after 30 minutes of inactivity (TTL resets on each sync)
+
+### Session Commands
+
+```bash
+jj-workspace-session start [type/topic] [base]   # Start session
+jj-workspace-session stop                         # End session
+jj-workspace-session touch                        # Reset TTL manually
+jj-workspace-session status                       # Show active sessions
+jj-workspace-session sync                         # Manual sync (also resets TTL)
+jj-workspace-session prune                        # Remove expired sessions
+```
+
+### Ending a Session
+
+```bash
+jj-workspace-session stop    # Stops fast sync, keeps workspace
+jj-workspace remove <name>   # Remove workspace when done
+```
 
 ## Workflow Scripts
 
@@ -70,13 +114,17 @@ Creates PR with correct base branch for stacking.
 ### `jj-workspace` - Manage Workspaces
 
 ```bash
-jj-workspace create feature-auth      # New workspace from main
-jj-workspace create bugfix main       # New workspace from specific base
-jj-workspace list                     # Show all workspaces
-jj-workspace remove feature-auth      # Remove workspace
-jj-workspace clean                    # Remove all workspaces
-jj-workspace status                   # Status of all workspaces
+jj-workspace create feat/user-auth      # Creates feat/user-auth-<date>-<id>
+jj-workspace create fix/bug develop     # New workspace from develop
+jj-workspace list                       # Show all workspaces
+jj-workspace remove <name>              # Remove workspace
+jj-workspace clean                      # Remove all workspaces
+jj-workspace status                     # Status of all workspaces
 ```
+
+**Naming Convention**: `<type>/<topic>-<date>-<id>`
+- Types: `feat`, `fix`, `hotfix`, `chore`, `release`
+- Auto-generated date (YYYYMMDD) and 4-char id
 
 ## Conventional Branch Naming
 
@@ -94,6 +142,36 @@ Rules:
 - Lowercase alphanumerics and hyphens only
 - No consecutive/leading/trailing hyphens
 - Include ticket numbers: `feat/gh-123-add-feature`
+
+## Background Auto-Sync
+
+Repositories opt-in to auto-sync by adding a `.jj-autosync` config file:
+
+```bash
+# .jj-autosync - add to repo root (commit it to share with team)
+enabled=true      # Enable hourly sync
+main=main         # Main branch name
+fast_sync=true    # Enable 5-min sync during sessions
+```
+
+| Mode | Frequency | Requires |
+|------|-----------|----------|
+| **Hourly** | Every hour | `enabled=true` in `.jj-autosync` |
+| **Session** | Every 5 min | `fast_sync=true` + active session |
+
+### Status and Logs
+
+```bash
+jj-autosync-status          # Show sessions and recent logs
+```
+
+Logs are at:
+- `/tmp/jj-autosync.log` - Hourly sync log
+- `/tmp/jj-fast-sync.log` - Session sync log
+
+### Notifications
+
+Sync failures trigger cross-platform desktop notifications (using `noti`, `terminal-notifier`, or `notify-send`).
 
 ## Manual Workflow (if not using scripts)
 

--- a/modules/home-manager/skills/external/jj/scripts/jj-workspace
+++ b/modules/home-manager/skills/external/jj/scripts/jj-workspace
@@ -1,56 +1,48 @@
 #!/usr/bin/env bash
 # jj-workspace: Manage jj workspaces for isolated work
 # Usage: jj-workspace <command> [args]
-# Example: jj-workspace create feature-auth
+# Example: jj-workspace create feat/auth
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+# Source shared library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=jj-workspace-lib
+source "${SCRIPT_DIR}/jj-workspace-lib"
 
-WORKSPACES_DIR="./workspaces"
+# Use library colors
+RED="$JJ_RED"
+GREEN="$JJ_GREEN"
+YELLOW="$JJ_YELLOW"
+BLUE="$JJ_BLUE"
+NC="$JJ_NC"
+
+WORKSPACES_DIR="$JJ_WORKSPACES_DIR"
 
 usage() {
     cat <<EOF
 Usage: jj-workspace <command> [args]
 
 Manage jj workspaces for isolated multi-task work.
+Workspace names use convention: <type>/<topic>-<date>-<id>
 
 Commands:
-  create <name> [base]   Create a new workspace (default base: main)
-  list                   List all workspaces
-  remove <name>          Remove a workspace
-  clean                  Remove all workspaces
-  status                 Show status of all workspaces
+  create <type/topic> [base]   Create a new workspace (default base: main)
+  list                         List all workspaces
+  remove <name>                Remove a workspace
+  clean                        Remove all workspaces
+  status                       Show status of all workspaces
+
+Types: feat, fix, hotfix, chore, release
 
 Examples:
-  jj-workspace create feature-auth          # New workspace from main
-  jj-workspace create bugfix-login develop  # New workspace from develop
+  jj-workspace create feat/user-auth        # Creates feat/user-auth-20260223-a1b2
+  jj-workspace create fix/login develop     # Creates fix/login-20260223-c3d4 from develop
   jj-workspace list                         # Show all workspaces
-  jj-workspace remove feature-auth          # Remove workspace
+  jj-workspace remove feat-user-auth-*      # Remove workspace
   jj-workspace clean                        # Remove all workspaces
 EOF
     exit 1
-}
-
-# Ensure workspaces directory exists
-ensure_workspaces_dir() {
-    if [[ ! -d "$WORKSPACES_DIR" ]]; then
-        mkdir -p "$WORKSPACES_DIR"
-        echo -e "${YELLOW}Created workspaces directory: ${WORKSPACES_DIR}${NC}"
-        
-        # Check if .gitignore exists and add workspaces/ if needed
-        if [[ -f .gitignore ]]; then
-            if ! grep -q "^workspaces/" .gitignore; then
-                echo "workspaces/" >> .gitignore
-                echo -e "${YELLOW}Added workspaces/ to .gitignore${NC}"
-            fi
-        fi
-    fi
 }
 
 cmd_create() {
@@ -59,25 +51,45 @@ cmd_create() {
     
     if [[ -z "$name" ]]; then
         echo -e "${RED}Error: Workspace name required${NC}"
-        echo "Usage: jj-workspace create <name> [base]"
+        echo "Usage: jj-workspace create <type>/<topic> [base]"
+        echo ""
+        echo "Naming convention: <type>/<topic>-<date>-<id>"
+        echo "Types: feat, fix, hotfix, chore, release"
+        echo ""
+        echo "Examples:"
+        echo "  jj-workspace create feat/user-auth"
+        echo "  jj-workspace create fix/login-bug develop"
         exit 1
     fi
     
-    ensure_workspaces_dir
+    jj_ensure_workspaces_dir "$WORKSPACES_DIR"
     
-    local workspace_path="${WORKSPACES_DIR}/${name}"
+    # Generate full workspace name with date and id
+    local full_name
+    full_name=$(jj_generate_workspace_name "$name")
+    
+    # Create directory-safe version (replace / with -)
+    local dir_name
+    dir_name=$(jj_workspace_to_dirname "$full_name")
+    local workspace_path="${WORKSPACES_DIR}/${dir_name}"
     
     if [[ -d "$workspace_path" ]]; then
         echo -e "${RED}Error: Workspace already exists: ${workspace_path}${NC}"
         exit 1
     fi
     
-    echo -e "${GREEN}Creating workspace: ${name} (base: ${base})${NC}"
+    echo -e "${GREEN}Creating workspace: ${full_name} (base: ${base})${NC}"
     jj workspace add "$workspace_path" -r "$base"
     
     echo -e "\n${GREEN}Workspace created!${NC}"
+    echo -e "Name:   ${BLUE}${full_name}${NC}"
+    echo -e "Path:   ${BLUE}${workspace_path}${NC}"
+    echo -e ""
     echo -e "To use: ${BLUE}cd ${workspace_path}${NC}"
     echo -e "Then:   ${BLUE}jj new${NC} to start working"
+    
+    # Output the path for scripting (last line, parseable)
+    echo "WORKSPACE_PATH=${workspace_path}"
 }
 
 cmd_list() {
@@ -88,7 +100,8 @@ cmd_list() {
         echo -e "\n${GREEN}Workspace directories:${NC}"
         for dir in "$WORKSPACES_DIR"/*/; do
             if [[ -d "$dir" ]]; then
-                local name=$(basename "$dir")
+                local name
+                name=$(basename "$dir")
                 echo -e "  ${BLUE}${name}${NC} -> ${dir}"
             fi
         done
@@ -134,7 +147,8 @@ cmd_clean() {
     fi
     
     # Get list of workspaces
-    local workspaces=$(jj workspace list | grep -v "^default" | awk '{print $1}' || true)
+    local workspaces
+    workspaces=$(jj workspace list | grep -v "^default" | awk '{print $1}' || true)
     
     for ws in $workspaces; do
         if [[ -n "$ws" && "$ws" != "default" ]]; then
@@ -164,7 +178,8 @@ cmd_status() {
     if [[ -d "$WORKSPACES_DIR" ]]; then
         for dir in "$WORKSPACES_DIR"/*/; do
             if [[ -d "$dir" ]]; then
-                local name=$(basename "$dir")
+                local name
+                name=$(basename "$dir")
                 echo -e "${BLUE}${name}:${NC}"
                 (cd "$dir" && jj log -r '@' --no-graph -T 'concat(change_id.short(), " ", description.first_line())' 2>/dev/null || echo "  (error reading)")
                 echo ""

--- a/modules/home-manager/skills/external/jj/scripts/jj-workspace-lib
+++ b/modules/home-manager/skills/external/jj/scripts/jj-workspace-lib
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# jj-workspace-lib: Shared functions for jj workspace management
+# Source this file from other scripts: source "$(dirname "$0")/jj-workspace-lib"
+
+# Colors for output
+export JJ_RED='\033[0;31m'
+export JJ_GREEN='\033[0;32m'
+export JJ_YELLOW='\033[1;33m'
+export JJ_BLUE='\033[0;34m'
+export JJ_NC='\033[0m' # No Color
+
+# Default workspace directory
+export JJ_WORKSPACES_DIR="${JJ_WORKSPACES_DIR:-./workspaces}"
+
+# Generate short unique id (4 hex chars) - portable, no xxd dependency
+jj_generate_id() {
+    od -An -tx1 -N4 /dev/urandom 2>/dev/null | tr -d ' \n' | head -c 4
+}
+
+# Generate full workspace name with type/topic-date-id format
+# Usage: jj_generate_workspace_name "feat/auth" -> "feat/auth-20260302-a1b2"
+jj_generate_workspace_name() {
+    local name="$1"
+    local date_str
+    date_str=$(date +%Y%m%d)
+    local session_id
+    session_id=$(jj_generate_id)
+    
+    # Handle type/topic format - default to feat/ if no type specified
+    if [[ "$name" == */* ]]; then
+        echo "${name}-${date_str}-${session_id}"
+    else
+        echo "feat/${name}-${date_str}-${session_id}"
+    fi
+}
+
+# Convert workspace name to directory-safe version (replace / with -)
+jj_workspace_to_dirname() {
+    local name="$1"
+    echo "$name" | tr '/' '-'
+}
+
+# Ensure workspaces directory exists and is in .gitignore
+jj_ensure_workspaces_dir() {
+    local workspaces_dir="${1:-$JJ_WORKSPACES_DIR}"
+    
+    if [[ ! -d "$workspaces_dir" ]]; then
+        mkdir -p "$workspaces_dir"
+        echo -e "${JJ_YELLOW}Created workspaces directory: ${workspaces_dir}${JJ_NC}"
+    fi
+    
+    # Check if .gitignore exists and add workspaces/ if needed
+    if [[ -f .gitignore ]]; then
+        local gitignore_entry
+        gitignore_entry=$(basename "$workspaces_dir")/
+        if ! grep -q "^${gitignore_entry}$" .gitignore 2>/dev/null; then
+            echo "$gitignore_entry" >> .gitignore
+            echo -e "${JJ_YELLOW}Added ${gitignore_entry} to .gitignore${JJ_NC}"
+        fi
+    fi
+}
+
+# Check if we're in a jj repository
+jj_in_repo() {
+    [[ -d ".jj" ]]
+}
+
+# Find the jj repo root from current directory
+jj_find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.jj" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir=$(dirname "$dir")
+    done
+    return 1
+}
+
+# Parse a simple key=value config file
+# Usage: jj_parse_config "/path/to/.jj-autosync" "enabled" "true"
+jj_parse_config() {
+    local config_file="$1"
+    local key="$2"
+    local default="$3"
+    
+    if [[ -f "$config_file" ]]; then
+        local value
+        value=$(grep "^${key}=" "$config_file" 2>/dev/null | cut -d'=' -f2- | tr -d ' ')
+        echo "${value:-$default}"
+    else
+        echo "$default"
+    fi
+}
+
+# Cross-platform notification
+# Usage: jj_notify "Title" "Message" ["urgency"]
+# Urgency: normal (default), low, critical
+jj_notify() {
+    local title="${1:-Notification}"
+    local message="${2:-}"
+    local urgency="${3:-normal}"
+    
+    # Try noti first (cross-platform)
+    if command -v noti &>/dev/null; then
+        noti -t "$title" -m "$message" 2>/dev/null
+        return
+    fi
+    
+    # macOS fallbacks
+    if [[ "$OSTYPE" == darwin* ]]; then
+        if command -v terminal-notifier &>/dev/null; then
+            terminal-notifier -title "$title" -message "$message" 2>/dev/null
+        else
+            osascript -e "display notification \"$message\" with title \"$title\"" 2>/dev/null
+        fi
+        return
+    fi
+    
+    # Linux fallback
+    if command -v notify-send &>/dev/null; then
+        notify-send -u "$urgency" "$title" "$message" 2>/dev/null
+        return
+    fi
+    
+    # No notification system available - silent
+    :
+}


### PR DESCRIPTION
## Summary

Adds automatic jj repository synchronization with:
- Hourly background sync for opted-in repositories
- Fast 5-minute sync during active OpenCode workspace sessions
- Session TTL with 30-minute auto-expiry (resets on each sync)
- Cross-platform notifications for sync failures
- `/workspace` command for OpenCode to create isolated workspaces

## Features

- `jj-autosync` home-manager module with launchd (macOS) and systemd (Linux) services
- `jj-workspace-session` CLI for managing workspace sessions with TTL
- `jj-workspace` script refactored to use shared library (`jj-workspace-lib`)
- `jj-autosync-status` command to view sessions and logs
- File locking for concurrent session access safety

## Configuration

Repositories opt-in by adding `.jj-autosync`:

```
enabled=true      # Enable hourly sync
main=main         # Main branch name  
fast_sync=true    # Enable 5-min sync during sessions
```

### Nix Options

| Option | Default | Description |
|--------|---------|-------------|
| `reposDir` | `$HOME/repos` | Directory containing repos to sync |
| `mainBranch` | `main` | Default main branch name |
| `hourlySync` | `true` | Enable/disable hourly sync |
| `fastSyncInterval` | `300` | Sync interval (seconds) for active sessions |
| `sessionTtlSeconds` | `1800` | Session TTL before auto-expiry (30 min) |

## Cross-Platform Notifications

Uses `noti` as primary notification tool with fallbacks:
- **macOS**: `terminal-notifier`, `osascript`
- **Linux**: `notify-send` (libnotify)

## Session Management

Sessions auto-expire after 30 minutes of inactivity. TTL resets on each successful sync, keeping active sessions alive while cleaning up stale ones.

```bash
jj-workspace-session start feat/auth    # Create workspace + start session
jj-workspace-session touch              # Reset TTL manually
jj-workspace-session status             # Show active sessions with TTL
jj-workspace-session prune              # Remove expired sessions
```

## Changes from Review

- Fixed bookmark sync to actually update local branch (`jj bookmark set` instead of just `track`)
- Replaced `xxd` with portable `od` for ID generation
- Fixed repo root discovery to check for `.jj` directory
- Added session TTL with auto-expiry and file locking
- Wired up all Nix options to script behavior
- Added cross-platform notifications via `noti`
- Refactored scripts to use shared library
- Added assertion requiring username on Darwin
- Added `~/.nix-profile/bin` to service PATH