### PR TITLE
fix: replace deprecated --allow-new with auto-track-bookmarks config

### DIFF
--- a/docs/how-to/create-pr-with-jj.md
+++ b/docs/how-to/create-pr-with-jj.md
@@ -62,7 +62,7 @@ If you prefer manual control:
 jj bookmark set feat/user-auth -r @
 
 # Push to remote
-jj git push --bookmark feat/user-auth --allow-new
+jj git push --bookmark feat/user-auth
 
 # Create PR
 g h pr create --head feat/user-auth --fill
@@ -108,10 +108,10 @@ jj bookmark delete feat/user-auth
 
 ### "Failed to push"
 
-You might need `--allow-new` for the first push:
+Ensure the remote is configured and you have push access:
 
 ```bash
-jj git push --bookmark feat/user-auth --allow-new
+jj git remote list
 ```
 
 ## Next Steps

--- a/docs/how-to/create-stacked-prs.md
+++ b/docs/how-to/create-stacked-prs.md
@@ -51,7 +51,7 @@ jj describe -m "feat: Add API endpoints"
 jj bookmark set feat/api-endpoints -r @
 
 # 5. Push with correct base
-jj git push --bookmark feat/api-endpoints --allow-new
+jj git push --bookmark feat/api-endpoints
 
 # 6. Create PR targeting the first branch
 g h pr create --base "$CURRENT_BOOKMARK" --head feat/api-endpoints --fill

--- a/docs/reference/jj-commands.md
+++ b/docs/reference/jj-commands.md
@@ -84,7 +84,6 @@ Complete reference for Jujutsu (jj) commands. For workflow context see the [tuto
 | `jj git fetch --remote origin` | Fetch from a specific remote |
 | `jj git push` | Push tracked bookmarks |
 | `jj git push --bookmark <name>` | Push a specific bookmark |
-| `jj git push --bookmark <name> --allow-new` | Push a bookmark for the first time |
 | `jj git export` | Flush jj state to git refs |
 | `jj git import` | Import git ref changes into jj |
 | `jj git remote list` | List configured remotes |

--- a/docs/tutorials/jj-workflow.md
+++ b/docs/tutorials/jj-workflow.md
@@ -90,11 +90,11 @@ Set a bookmark (jj's name for a branch) and push:
 
 ```bash
 jj bookmark set feat/my-change -r @
-jj git push --bookmark feat/my-change --allow-new
+jj git push --bookmark feat/my-change
 gh pr create --head feat/my-change --fill
 ```
 
-`--allow-new` is required the first time you push a bookmark. After that, plain `jj git push` is enough.
+New bookmarks are automatically tracked by the remote thanks to the `remotes.origin.auto-track-bookmarks` config.
 
 **Bookmark naming convention:**
 

--- a/docs/tutorials/multi-agent-workspaces.md
+++ b/docs/tutorials/multi-agent-workspaces.md
@@ -243,7 +243,7 @@ Or manually:
 
 ```bash
 jj bookmark set feat/user-auth -r @
-jj git push --bookmark feat/user-auth --allow-new
+jj git push --bookmark feat/user-auth
 gh pr create --head feat/user-auth --fill
 ```
 

--- a/modules/home-manager/foundation.nix
+++ b/modules/home-manager/foundation.nix
@@ -28,6 +28,9 @@
         push-bookmark-prefix = "push-";
         default-branch = "main";
       };
+      remotes.origin = {
+        auto-track-bookmarks = "glob:*";
+      };
       colors = earthsong.jjColors;
       ui = {
         editor = "hx";

--- a/modules/home-manager/skills/external/jj/SKILL.md
+++ b/modules/home-manager/skills/external/jj/SKILL.md
@@ -211,7 +211,7 @@ jj new main                              # Start from main
 # ... make changes ...
 jj describe -m "Add feature"             # Describe
 jj bookmark set feat/my-feature -r @     # Create bookmark
-jj git push --bookmark feat/my-feature --allow-new
+jj git push --bookmark feat/my-feature
 gh pr create --head feat/my-feature
 ```
 
@@ -236,7 +236,6 @@ jj git push
 
 1. **Working in described commit**: Always `jj new` before making changes
 2. **Using `-c @` for updates**: This creates NEW bookmark/PR. Use `jj squash` + `jj git push`
-3. **Forgetting `--allow-new`**: Required first time pushing a bookmark
 
 ## Undo
 

--- a/modules/home-manager/skills/external/jj/commands/push.md
+++ b/modules/home-manager/skills/external/jj/commands/push.md
@@ -12,12 +12,11 @@ Standalone push command. Can be used independently or as part of the finish work
 ## Usage
 
 ```bash
-jj-push [--allow-new] [--dry-run] [bookmark]
+jj-push [--dry-run] [bookmark]
 ```
 
 ## Options
 
-- `--allow-new` - Allow pushing a new bookmark for the first time
 - `--dry-run` - Show what would be done without executing
 - `[bookmark]` - Bookmark to push (defaults to current bookmark)
 
@@ -25,8 +24,7 @@ jj-push [--allow-new] [--dry-run] [bookmark]
 
 ```bash
 jj-push                    # Push current bookmark
-jj-push feat/my-feature    # Push specific bookmark  
-jj-push --allow-new        # Push new bookmark for first time
+jj-push feat/my-feature    # Push specific bookmark
 jj-push --dry-run          # Preview push
 ```
 

--- a/modules/home-manager/skills/external/jj/scripts/jj-pr
+++ b/modules/home-manager/skills/external/jj/scripts/jj-pr
@@ -125,7 +125,7 @@ jj bookmark set "$BRANCH" -r @
 
 # Push to remote
 echo -e "\n${JJ_GREEN}5. Pushing to remote...${JJ_NC}"
-jj_push_bookmark "$BRANCH" true
+jj_push_bookmark "$BRANCH"
 
 # Create PR
 echo -e "\n${JJ_GREEN}6. Creating PR...${JJ_NC}"

--- a/modules/home-manager/skills/external/jj/scripts/jj-push
+++ b/modules/home-manager/skills/external/jj/scripts/jj-push
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # jj-push: Push bookmark to origin
-# Usage: jj-push [--allow-new] [--dry-run] [bookmark]
-# Example: jj-push --allow-new feat/my-feature
+# Usage: jj-push [--dry-run] [bookmark]
+# Example: jj-push feat/my-feature
 
 set -euo pipefail
 
@@ -10,35 +10,28 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/jj-workspace-lib"
 
 # Parse arguments
-ALLOW_NEW=false
 DRY_RUN=false
 BOOKMARK=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --allow-new)
-            ALLOW_NEW=true
-            shift
-            ;;
         --dry-run)
             DRY_RUN=true
             shift
             ;;
         -h|--help)
             cat <<'EOF'
-Usage: jj-push [--allow-new] [--dry-run] [bookmark]
+Usage: jj-push [--dry-run] [bookmark]
 
 Push bookmark to origin. If no bookmark specified, uses current bookmark.
 
 Options:
-  --allow-new       Allow pushing a new bookmark for the first time
   --dry-run         Show what would be done without doing it
   -h, --help        Show this help
 
 Examples:
   jj-push                    # Push current bookmark
   jj-push feat/my-feature    # Push specific bookmark
-  jj-push --allow-new        # Push new bookmark for first time
   jj-push --dry-run          # Preview push without executing
 EOF
             exit 0
@@ -77,23 +70,12 @@ echo -e "Bookmark: ${JJ_YELLOW}${BOOKMARK}${JJ_NC}"
 
 if [[ "$DRY_RUN" == true ]]; then
     echo -e "${JJ_YELLOW}[DRY RUN] Would push bookmark: ${BOOKMARK}${JJ_NC}"
-    if [[ "$ALLOW_NEW" == true ]]; then
-        echo -e "${JJ_YELLOW}[DRY RUN] With --allow-new flag${JJ_NC}"
-    fi
     echo -e "${JJ_GREEN}Dry run complete - no changes made${JJ_NC}"
     exit 0
 fi
 
 # Push to origin
-if [[ "$ALLOW_NEW" == true ]]; then
-    echo -e "${JJ_GREEN}Pushing bookmark (with --allow-new)...${JJ_NC}"
-    jj_push_bookmark "$BOOKMARK" true
-else
-    echo -e "${JJ_GREEN}Pushing bookmark...${JJ_NC}"
-    if ! jj_push_bookmark "$BOOKMARK" false 2>&1; then
-        echo -e "${JJ_YELLOW}Push failed, trying with --allow-new...${JJ_NC}"
-        jj_push_bookmark "$BOOKMARK" true
-    fi
-fi
+echo -e "${JJ_GREEN}Pushing bookmark...${JJ_NC}"
+jj_push_bookmark "$BOOKMARK"
 
 echo -e "${JJ_GREEN}Push complete: ${BOOKMARK}${JJ_NC}"

--- a/modules/home-manager/skills/external/jj/scripts/jj-stack
+++ b/modules/home-manager/skills/external/jj/scripts/jj-stack
@@ -146,7 +146,7 @@ jj bookmark set "$BRANCH" -r @
 
 # Push to remote
 echo -e "\n${JJ_GREEN}5. Pushing to remote...${JJ_NC}"
-jj_push_bookmark "$BRANCH" true
+jj_push_bookmark "$BRANCH"
 
 # Create PR with correct base
 echo -e "\n${JJ_GREEN}6. Creating PR (base: ${PARENT_BOOKMARK})...${JJ_NC}"

--- a/modules/home-manager/skills/external/jj/scripts/jj-workspace-lib
+++ b/modules/home-manager/skills/external/jj/scripts/jj-workspace-lib
@@ -238,14 +238,8 @@ jj_merge_pr() {
 }
 
 # Push bookmark to origin
-# Usage: jj_push_bookmark <bookmark> [allow_new]
+# Usage: jj_push_bookmark <bookmark>
 jj_push_bookmark() {
     local bookmark="$1"
-    local allow_new="${2:-false}"
-    
-    if [[ "$allow_new" == "true" ]]; then
-        jj git push --bookmark "$bookmark" --allow-new
-    else
-        jj git push --bookmark "$bookmark"
-    fi
+    jj git push --bookmark "$bookmark"
 }

--- a/modules/home-manager/skills/internal/yak-shaving/SKILL.md
+++ b/modules/home-manager/skills/internal/yak-shaving/SKILL.md
@@ -130,7 +130,7 @@ echo "Implemented X, Y, Z. Tests pass." | yx field "yak name" progress
 
 ```bash
 jj bookmark set chore/yak-slug -r @
-jj git push --bookmark chore/yak-slug --allow-new
+jj git push --bookmark chore/yak-slug
 gh pr create --title "chore: description" --body "..."
 ```
 


### PR DESCRIPTION
## Summary

- Adds `remotes.origin.auto-track-bookmarks = "glob:*"` to the declarative jj config in `foundation.nix`, so new bookmarks are automatically tracked by the remote
- Removes all `--allow-new` flags from jj scripts (`jj-push`, `jj-pr`, `jj-stack`, `jj-workspace-lib`)
- Updates all documentation and skill files to remove `--allow-new` references

## Why

`jj git push --allow-new` is deprecated in jj 0.40+. The recommended replacement is configuring `remotes.<name>.auto-track-bookmarks` to automatically track new bookmarks, eliminating the need for the flag entirely.

## Files Changed

**Config:**
- `modules/home-manager/foundation.nix` — added `remotes.origin.auto-track-bookmarks`

**Scripts:**
- `skills/external/jj/scripts/jj-push` — removed `--allow-new` flag and fallback logic
- `skills/external/jj/scripts/jj-workspace-lib` — simplified `jj_push_bookmark()` function
- `skills/external/jj/scripts/jj-pr` — removed `true` arg to `jj_push_bookmark`
- `skills/external/jj/scripts/jj-stack` — removed `true` arg to `jj_push_bookmark`

**Docs/Skills:**
- 7 docs and skill files updated to remove `--allow-new` from examples