### PR TITLE
fix: use wweaver username for wweaver Darwin configuration

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -377,7 +377,13 @@
           echo "1Password CLI: found"
 
           # Get sudo password from 1Password
-          PASSWORD_PATH="op://Private/''${HOSTNAME} Sudo Password/password"
+          # Check if config defines a custom sudoPasswordRef, otherwise use default pattern
+          CUSTOM_REF=$(nix eval --impure --raw ".#darwinConfigurations.$CONFIG_NAME.config.myConfig.onepassword.sudoPasswordRef" 2>/dev/null || echo "")
+          if [[ -n "$CUSTOM_REF" ]]; then
+            PASSWORD_PATH="$CUSTOM_REF"
+          else
+            PASSWORD_PATH="op://Private/''${HOSTNAME} Sudo Password/password"
+          fi
           echo "Fetching sudo password from 1Password..."
           echo "  Path: $PASSWORD_PATH"
 
@@ -386,8 +392,9 @@
             echo "ERROR: Failed to read sudo password from 1Password"
             echo "  Attempted path: $PASSWORD_PATH"
             echo ""
-            echo "Ensure you have a '$HOSTNAME Sudo Password' item in your Private vault"
-            echo "with a 'password' field containing your sudo password."
+            echo "Ensure the item exists in 1Password."
+            echo "You can set myConfig.onepassword.sudoPasswordRef in the machine config"
+            echo "to override the default path (op://Private/<hostname> Sudo Password/password)."
             exit 1
           }
           echo "Sudo password: retrieved"

--- a/flake.nix
+++ b/flake.nix
@@ -241,12 +241,13 @@
           {
             nixpkgs.hostPlatform = "aarch64-darwin";
             system.stateVersion = 4;
-            system.primaryUser = "monkey";
+            system.primaryUser = "wweaver";
 
             myConfig =
-              mkUser "monkey" "me@willweaver.dev"
+              mkUser "wweaver" "me@willweaver.dev"
               // {
                 skills.superpowersPath = inputs.superpowers;
+                onepassword.sudoPasswordRef = "op://Employee/wweaver Sudo Password/password";
                 roles = {
                   developer.enable = true;
                   desktop.enable = true;

--- a/modules/common/options.nix
+++ b/modules/common/options.nix
@@ -537,6 +537,17 @@ with lib; {
         description = "Enable 1Password for sudo authentication (NixOS only)";
       };
 
+      sudoPasswordRef = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          1Password reference for the sudo password used by the system:switch task.
+          If empty (default), falls back to op://Private/<hostname> Sudo Password/password.
+          Override this for machines with different vault or item names,
+          e.g. "op://Employee/wweaver Sudo Password/password".
+        '';
+      };
+
       tokenFile = mkOption {
         type = types.path;
         default = "/etc/opnix-token";


### PR DESCRIPTION
## Summary

- Fix `system.primaryUser` and `mkUser` username from `monkey` to `wweaver` in the `wweaver` Darwin configuration — the OS user on this machine is `wweaver`, not `monkey`
- Add `myConfig.onepassword.sudoPasswordRef` option to allow per-machine override of the 1Password path used by `system:switch` to fetch the sudo password (defaults to `op://Private/<hostname> Sudo Password/password`)
- Set `sudoPasswordRef = "op://Employee/wweaver Sudo Password/password"` in the `wweaver` config to point to the correct vault/item

All other machines (`MegamanX`, `darwin-server`, `core`) remain unchanged with `monkey` as their username.