### PR TITLE
feat: add opencode config with providers, MCP servers, and vane updates for wweaver workstation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -244,9 +244,14 @@
             system.primaryUser = "wweaver";
 
             myConfig =
-              mkUser "wweaver" "me@willweaver.dev"
+              mkUser "wweaver" "wweaver@justworks.com"
               // {
-                skills.superpowersPath = inputs.superpowers;
+                skills = {
+                  superpowersPath = inputs.superpowers;
+                  externalInputs = {
+                    inherit (inputs) vercel-skills;
+                  };
+                };
                 onepassword.sudoPasswordRef = "op://Employee/wweaver Sudo Password/password";
                 roles = {
                   developer.enable = true;
@@ -264,14 +269,128 @@
                 };
                 vane = {
                   enable = true;
-                  # Uses default Ollama URL (host.docker.internal:11434)
-                  # Enable embedded SearxNG for web search
+                  autoStart = true;
+                  # Local Ollama for fast local models
+                  ollamaUrl = "http://host.docker.internal:11434";
+                  # LiteLLM for external/cloud models - configure via web UI
+                  openaiBaseUrl = "https://litellm.justworksai.net";
+                  # Embedded SearxNG for web search
                   embeddedSearxng = true;
-                  # Chat model - deepseek for reasoning tasks
-                  defaultModel = "deepseek-r1:14b";
+                  # Chat model (balanced speed/quality)
+                  defaultModel = "qwen3.5";
                   # Embedding model for vector search
                   embeddingModel = "nomic-embed-text";
+                  # Good resources for M4 Pro (14 cores, 48GB RAM)
+                  colima = {
+                    cpu = 6;
+                    memory = 12;
+                    disk = 60;
+                  };
                 };
+                opencode = {
+                  enable = true;
+                  model = "just-llms/claude-sonnet-4-6";
+                  disabledProviders = ["opencode"];
+                  extraMcpServers = {
+                    github = {
+                      type = "remote";
+                      url = "https://api.githubcopilot.com/mcp/";
+                      enabled = false;
+                    };
+                    jira = {
+                      type = "remote";
+                      url = "https://mcp.atlassian.com/v1/mcp";
+                      enabled = false;
+                    };
+                    confluence = {
+                      type = "remote";
+                      url = "https://mcp.atlassian.com/v1/mcp";
+                      enabled = false;
+                    };
+                  };
+                  commands = {
+                    diataxis = {
+                      description = "Audit and rewrite documentation using the Diataxis framework";
+                      template = ''
+                        Load the diataxis-docs skill and use it to audit and restructure the documentation in this project.
+
+                        Follow the Diataxis framework to organize content into:
+                        - Tutorials (learning-oriented)
+                        - How-to guides (goal-oriented)
+                        - Reference (information-oriented)
+                        - Explanation (understanding-oriented)
+
+                        $ARGUMENTS
+                      '';
+                    };
+                    workspace = {
+                      description = "Create a jj workspace for isolated work with fast sync enabled";
+                      template = ''
+                        Create a jj workspace session for isolated development work.
+
+                        Run this command:
+                        ```bash
+                        jj-workspace-session start $ARGUMENTS
+                        ```
+
+                        Then report the workspace name and path to the user, and cd into the workspace directory.
+
+                        If no arguments provided, this starts session tracking in the current workspace.
+                        If a name is provided (e.g., "feat/auth" or "fix/bug"), it creates a new workspace.
+                        A second argument can specify the base branch (defaults to main).
+
+                        Examples:
+                        - /workspace feat/user-auth      -> Creates feat/user-auth-<date>-<id> from main
+                        - /workspace fix/bug develop     -> Creates fix/bug-<date>-<id> from develop
+                        - /workspace                     -> Starts session in current workspace
+                      '';
+                    };
+                  };
+                  providers = {
+                    just-llms = {
+                      npm = "@ai-sdk/openai-compatible";
+                      name = "Just LLMs";
+                      baseURL = "https://litellm.justworksai.net";
+                      onePasswordItem = "op://Justworks/Justworks LiteLLM/wweaver-poweruser-key";
+                      dynamicModels = true;
+                      models = {
+                        "us.anthropic.claude-opus-4-5-20251101-v1:0" = {
+                          name = "Claude Opus 4.5 (Bedrock)";
+                        };
+                      };
+                    };
+                    ollama = {
+                      npm = "@ai-sdk/openai-compatible";
+                      name = "Ollama (local)";
+                      baseURL = "http://localhost:11434/v1";
+                      models = {
+                        "qwen3.5:latest" = {name = "Qwen 3.5 (7B)";};
+                        "qwen3.5:2b" = {name = "Qwen 3.5 (2B)";};
+                      };
+                    };
+                  };
+                };
+                claude-code = {
+                  enable = false;
+                  mcpServers = {
+                    github = {
+                      type = "remote";
+                      url = "https://api.githubcopilot.com/mcp/";
+                      enabled = true;
+                    };
+                    jira = {
+                      type = "remote";
+                      url = "https://mcp.atlassian.com/v1/mcp";
+                      enabled = false;
+                    };
+                    confluence = {
+                      type = "remote";
+                      url = "https://mcp.atlassian.com/v1/mcp";
+                      enabled = false;
+                    };
+                  };
+                };
+                llmClient.rtk.enable = true;
               };
           }
         ];


### PR DESCRIPTION
## Summary

- Add OpenCode configuration with just-llms and Ollama providers, MCP servers (GitHub, Jira, Confluence), and custom slash commands (diataxis, workspace)
- Update vane config with explicit Ollama URL, LiteLLM base URL, autoStart, and colima resource settings
- Update wweaver workstation email to wweaver@justworks.com and add vercel-skills external input
- Add claude-code configuration (disabled by default)