### PR TITLE
fix: wire myConfig.sharedModels into llm-host Ollama config

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -1164,6 +1164,10 @@
         echo "Testing role cascades ($CURRENT_SYSTEM)..."
         nix build ".#checks.''${CURRENT_SYSTEM}.role-cascades" --no-link
         echo "Role cascade test passed"
+        echo ""
+        echo "Testing llm-host sharedModels wiring ($CURRENT_SYSTEM)..."
+        nix build ".#checks.''${CURRENT_SYSTEM}.llm-host-shared-models" --no-link
+        echo "llm-host sharedModels test passed"
       '';
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -728,6 +728,7 @@
             role-composition
             role-packages
             role-cascades
+            llm-host-shared-models
             module-coverage
             skills-manifest
             skills-autoload-filtering

--- a/modules/roles/llm-host.nix
+++ b/modules/roles/llm-host.nix
@@ -15,7 +15,7 @@ in {
       enable = true;
       host = "0.0.0.0";
       port = 11434;
-      models = ["qwen3.5:2b" "qwen3.5" "qwen3.5:122b"];
+      models = config.myConfig.sharedModels;
     };
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -38,6 +38,7 @@ in
     role-composition = testRoles.allRolesCompositionTest;
     role-packages = testRoles.rolePackageInclusionTest;
     role-cascades = testRoles.roleCascadeTest;
+    llm-host-shared-models = testRoles.llmHostSharedModelsTest;
 
     # Skills tests
     skills-manifest = testSkills.manifestValidationTest;

--- a/tests/test-roles.nix
+++ b/tests/test-roles.nix
@@ -59,6 +59,55 @@
     }
   ];
 
+  # Evaluate llm-host role with default sharedModels
+  llmHostDefaultEval =
+    (lib.evalModules {
+      modules =
+        stubModules
+        ++ [
+          {
+            config.myConfig = {
+              users = [
+                {
+                  name = "testuser";
+                  email = "test@example.com";
+                  fullName = "Test User";
+                  isAdmin = true;
+                  sshIncludes = [];
+                }
+              ];
+              roles.llm-host.enable = true;
+            };
+          }
+        ];
+    })
+    .config;
+
+  # Evaluate llm-host role with custom sharedModels
+  llmHostCustomEval =
+    (lib.evalModules {
+      modules =
+        stubModules
+        ++ [
+          {
+            config.myConfig = {
+              users = [
+                {
+                  name = "testuser";
+                  email = "test@example.com";
+                  fullName = "Test User";
+                  isAdmin = true;
+                  sshIncludes = [];
+                }
+              ];
+              roles.llm-host.enable = true;
+              sharedModels = ["llama3.2" "mistral:7b"];
+            };
+          }
+        ];
+    })
+    .config;
+
   # Helper: evaluate modules with a specific role enabled
   evalWithRole = roleName:
     (lib.evalModules {
@@ -301,6 +350,43 @@ in {
       ${cascadeChecks}
 
       echo "All role cascades work correctly"
+      touch $out
+    '';
+
+  # Test that llm-host role wires myConfig.sharedModels into ollama.models
+  llmHostSharedModelsTest = let
+    defaultModels = llmHostDefaultEval.myConfig.sharedModels;
+    defaultOllamaModels = llmHostDefaultEval.myConfig.ollama.models;
+    customOllamaModels = llmHostCustomEval.myConfig.ollama.models;
+  in
+    pkgs.runCommand "test-llm-host-shared-models"
+    {}
+    ''
+      echo "=== Testing llm-host sharedModels wiring ==="
+
+      ${
+        if defaultModels == defaultOllamaModels
+        then ''echo "  default sharedModels propagated to ollama.models: OK"''
+        else ''
+          echo "  sharedModels default should propagate to ollama.models!"
+          echo "  sharedModels = ${builtins.toJSON defaultModels}"
+          echo "  ollama.models = ${builtins.toJSON defaultOllamaModels}"
+          exit 1
+        ''
+      }
+
+      ${
+        if customOllamaModels == ["llama3.2" "mistral:7b"]
+        then ''echo "  custom sharedModels reflected in ollama.models: OK"''
+        else ''
+          echo "  custom sharedModels should be reflected in ollama.models!"
+          echo "  expected = [\"llama3.2\" \"mistral:7b\"]"
+          echo "  got = ${builtins.toJSON customOllamaModels}"
+          exit 1
+        ''
+      }
+
+      echo "All llm-host sharedModels tests passed"
       touch $out
     '';
 }


### PR DESCRIPTION
## Summary

- `modules/roles/llm-host.nix` was hardcoding `models = ["qwen3.5:2b" "qwen3.5" "qwen3.5:122b"]` instead of reading from `config.myConfig.sharedModels`
- The `sharedModels` option in `modules/common/options.nix` (with default `["qwen3:4b" "gemma3:4b" "qwen3.5"]`) was defined as the central model configuration but never consumed
- Fixes the bug by wiring `config.myConfig.sharedModels` directly into `myConfig.ollama.models` in the llm-host role
- Adds `llmHostSharedModelsTest` in `tests/test-roles.nix` (using `evalModules`) to verify default and custom `sharedModels` values propagate correctly to `ollama.models`
- Wires the new test into `tests/default.nix`, `flake.nix` checks, and `devenv.nix` `test:roles` task