### PR TITLE
feat: add shave-yaks skill for autonomous yak backlog processing

### DIFF
--- a/modules/home-manager/skills/internal/shave-yaks/SKILL.md
+++ b/modules/home-manager/skills/internal/shave-yaks/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: shave-yaks
+description: Use when you want to autonomously work through a yak backlog end-to-end — triaging, implementing, testing, and shipping PRs until all yaks are done or flagged for refinement
+---
+
+# Shave Yaks
+
+## Overview
+
+Autonomous yak shaving: triage the backlog, implement each yak in an isolated jj workspace with TDD/BDD tests, ship a PR, watch CI, merge, and loop until done. Yaks with insufficient context get flagged for human refinement instead of guessed at.
+
+**Key mental model:** One yak = one jj workspace = one subagent = one PR. Parallel where file conflicts are impossible.
+
+**Required skills:** `yak-shaving` (yx commands), `jj` (workspace/PR workflow), `watch-ci-jobs` (CI polling)
+
+## When to Use
+
+- `/shave` — work through the entire backlog autonomously
+- Batch of yaks exist and you want to ship them without manual orchestration
+- After a planning session that produced many new todo yaks
+
+## Scripts
+
+All scripts live in `scripts/` relative to this skill:
+
+| Script | Purpose |
+|--------|---------|
+| `yak-triage.sh` | Find actionable (todo, leaf, unblocked) yaks |
+| `yak-claim.sh "name"` | Safely claim a yak (sync → check → start → sync) |
+| `yak-needs-refinement.sh "name"` | Test if yak has enough context to implement |
+| `yak-worker-prompt.sh "name"` | Generate full subagent implementation prompt |
+| `yak-mark-refinement.sh "name" "reason"` | Tag yak @needs-human with reason |
+
+## The /shave Loop
+
+```
+WHILE actionable yaks exist:
+  1. yx sync                          — pull latest state
+  2. yak-triage.sh                    — find todo leaf yaks
+  3. FOR EACH batch of compatible yaks (no file conflicts):
+     a. yak-needs-refinement.sh       — test clarity
+        → unclear: yak-mark-refinement.sh, skip
+        → clear:   yak-claim.sh, dispatch subagent
+  4. WAIT for all subagents to complete
+  5. yx sync                          — pull done state
+  6. Check if any remain
+```
+
+**Compatibility check:** Two yaks are safe to run in parallel if they don't touch the same files. Check yak contexts for overlapping file paths. When in doubt, serialize.
+
+## BDD/TDD Requirements for Each Yak
+
+Every subagent MUST follow this order — no exceptions:
+
+```
+RED:   Write failing test first
+         → Nix: pkgs.runCommand that exits 1 without the fix
+         → Shell: bash test with mock structures
+         → CI: check verifying file structure
+GREEN: Write minimal implementation to pass the test
+REFACTOR: Clean up while keeping tests green
+```
+
+Acceptance criteria in yak context → test cases. Each `- [ ] criterion` becomes a test assertion.
+
+**BDD style:** Tests describe outcomes, not mechanisms.
+```nix
+# ❌ Mechanism: "module sets this attribute"
+if config.services.foo.package == pkgs.foo
+# ✅ Outcome: "foo service uses the configured package"
+if config.services.foo.package == configuredPkg
+```
+
+## Deciding: Implement vs Refine
+
+```
+Has context?           → No  → Mark @needs-human: "No context defined"
+Has acceptance criteria? → No  → Mark @needs-human: "No checkboxes/criteria"
+Has specific files?    → No  → Mark @needs-human: "No file paths mentioned"
+All yes?               → Implement
+```
+
+Use `yak-needs-refinement.sh` to automate this check. Don't guess at vague yaks — flag them and move on. A wrong implementation wastes more time than a refinement request.
+
+## Parallelism Rules
+
+**Safe to parallelize:** Yaks touching different files/modules (checked via context file paths)
+
+**Must serialize:**
+- Two yaks editing the same Nix file
+- A yak + its parent (parent blocked by child)
+- Yaks that both modify `flake.nix` or `tests/default.nix` (high conflict surface)
+
+**Practical limit:** 2-3 parallel subagents. More causes merge conflicts.
+
+## PR Workflow per Yak
+
+Each subagent runs the full cycle:
+
+```bash
+# 1. Workspace (isolated, off current main)
+jj git fetch
+jj workspace add --name <type>-<slug> .workspaces/<type>-<slug>
+
+# 2. Implement (TDD first)
+
+# 3. Validate
+devenv tasks run check:lint
+devenv tasks run test:darwin-eval
+git add -A && nix build --impure ".#checks.aarch64-darwin.<test>" --no-link
+
+# 4. Commit + push + PR
+jj describe -m "<type>: <what and why>"
+jj bookmark set <branch> -r @
+jj git push --bookmark <branch>
+gh pr create ...
+
+# 5. Watch CI (poll gh pr view --json statusCheckRollup)
+# 6. Merge when green
+gh pr merge <n> --repo <repo> --squash --delete-branch --admin
+
+# 7. Mark done
+yx done "<yak name>" && yx sync
+jj workspace forget <name> && rm -rf .workspaces/<name>
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Implementing a vague yak | Run `yak-needs-refinement.sh` first; flag if unclear |
+| Two subagents editing the same file | Check context file paths before parallelizing |
+| Forgetting `git add -A` before `nix build --impure` | Staged files must be visible for impure eval |
+| Claiming without syncing | Always `yx sync` before AND after `yx start` |
+| Merging with failing CI | Wait for all checks — `"conclusion":"SUCCESS"` |
+| Implementation before test | RED phase is mandatory; delete any code written before tests |
+
+## Finishing Up
+
+After all yaks are done or flagged:
+
+```bash
+yx sync
+yx ls  # Show final state: done ✓, @needs-human ○ flagged
+```
+
+Report to human:
+- How many yaks shaved
+- Which yaks were flagged for refinement and why
+- Any PRs that needed human intervention

--- a/modules/home-manager/skills/internal/shave-yaks/commands/shave.md
+++ b/modules/home-manager/skills/internal/shave-yaks/commands/shave.md
@@ -1,0 +1,72 @@
+---
+description: Autonomously triage and implement yaks until all are shaved or flagged for refinement
+agent: build
+---
+
+Work through the yak backlog autonomously using the `shave-yaks` skill.
+
+## Your Mission
+
+Loop through all actionable yaks until none remain. For each yak:
+- If it has clear acceptance criteria and file context → implement it (TDD/BDD, PR, CI, merge)
+- If it's unclear → flag it with @needs-human and move on
+
+**Do not stop until every leaf yak is either done ✓ or tagged @needs-human.**
+
+## Setup
+
+Locate the skill scripts:
+```bash
+SKILL_DIR="$HOME/.config/opencode/skills/shave-yaks/scripts"
+```
+
+## The Loop
+
+```bash
+yx sync
+while true; do
+  count=$("$SKILL_DIR/yak-triage.sh" --count 2>/dev/null || echo 0)
+  [[ "$count" -eq 0 ]] && break
+
+  # Get actionable yaks
+  yaks=$("$SKILL_DIR/yak-triage.sh" --names)
+
+  # For each yak, decide: implement or flag
+  # Dispatch compatible yaks as parallel subagents
+  # Wait for all to complete before next round
+done
+```
+
+## Implementation Rules
+
+Load the `shave-yaks` skill for the full workflow. Key requirements:
+
+1. **Sync first** — `yx sync` before every triage pass
+2. **Triage before acting** — use `yak-triage.sh` to find actionable yaks
+3. **Check refinement need** — run `yak-needs-refinement.sh` before claiming any yak
+4. **Claim with protocol** — use `yak-claim.sh` (sync → check → start → sync)
+5. **Dispatch subagents** — use `yak-worker-prompt.sh` to generate each subagent's prompt
+6. **Parallel where safe** — check contexts for file overlap; serialize when in doubt
+7. **TDD mandatory** — every subagent must write tests BEFORE implementation
+8. **BDD style** — acceptance criteria map to test assertions on desired outcomes
+9. **Full PR cycle** — each subagent does: implement → validate → commit → PR → CI → merge → done
+
+## Parallelism
+
+Check yak contexts for overlapping file paths. Run non-overlapping yaks in parallel subagents. Serialize yaks that touch the same files. Limit to 2-3 parallel subagents.
+
+## When a Yak Needs Refinement
+
+```bash
+reason=$("$SKILL_DIR/yak-needs-refinement.sh" "yak name" 2>&1) || {
+  "$SKILL_DIR/yak-mark-refinement.sh" "yak name" "$reason"
+  # skip to next yak
+}
+```
+
+## When Done
+
+Report:
+- Count of yaks shaved (merged PRs)
+- Count flagged for refinement (with reasons)
+- Any open issues requiring human attention

--- a/modules/home-manager/skills/internal/shave-yaks/scripts/yak-claim.sh
+++ b/modules/home-manager/skills/internal/shave-yaks/scripts/yak-claim.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# yak-claim.sh - Safely claim a yak following the claim protocol
+#
+# Performs: sync → check state → start → sync
+# Exits non-zero if yak is already wip or done.
+#
+# Usage:
+#   ./yak-claim.sh "yak name"
+#
+# Exit codes:
+#   0 - claimed successfully
+#   1 - yak already wip or done (skip it)
+#   2 - yak not found
+
+set -euo pipefail
+
+YAK_NAME="${1:-}"
+if [[ -z "$YAK_NAME" ]]; then
+    echo "Usage: $0 \"yak name\"" >&2
+    exit 2
+fi
+
+echo "Syncing yaks..." >&2
+yx sync
+
+# Check current state
+state=$(yx show "$YAK_NAME" --format json 2>/dev/null \
+    | python3 -c "import json,sys; print(json.load(sys.stdin).get('state','unknown'))" \
+    || echo "unknown")
+
+case "$state" in
+    todo)
+        echo "Claiming: $YAK_NAME" >&2
+        yx start "$YAK_NAME"
+        yx sync
+        echo "Claimed." >&2
+        exit 0
+        ;;
+    wip)
+        echo "Already in progress: $YAK_NAME — skipping" >&2
+        exit 1
+        ;;
+    done)
+        echo "Already done: $YAK_NAME — skipping" >&2
+        exit 1
+        ;;
+    *)
+        echo "Unknown state '$state' for: $YAK_NAME" >&2
+        exit 2
+        ;;
+esac

--- a/modules/home-manager/skills/internal/shave-yaks/scripts/yak-mark-refinement.sh
+++ b/modules/home-manager/skills/internal/shave-yaks/scripts/yak-mark-refinement.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# yak-mark-refinement.sh - Tag a yak as needing human refinement
+#
+# Tags the yak with @needs-human and appends a refinement request to context.
+#
+# Usage:
+#   ./yak-mark-refinement.sh "yak name" "reason why it needs refinement"
+
+set -euo pipefail
+
+YAK_NAME="${1:-}"
+REASON="${2:-Insufficient context for autonomous implementation.}"
+
+if [[ -z "$YAK_NAME" ]]; then
+    echo "Usage: $0 \"yak name\" \"reason\"" >&2
+    exit 1
+fi
+
+echo "Marking '$YAK_NAME' as needing refinement..." >&2
+
+# Tag it
+yx tag "$YAK_NAME" @needs-human
+
+# Get existing context and append refinement note
+existing=$(yx context --show "$YAK_NAME" 2>/dev/null || echo "")
+
+{
+    if [[ -n "$existing" ]]; then
+        echo "$existing"
+        echo ""
+    fi
+    echo "## Needs Refinement"
+    echo ""
+    echo "Flagged by autonomous agent on $(date '+%Y-%m-%d')."
+    echo ""
+    echo "**Reason:** $REASON"
+    echo ""
+    echo "To unblock: add Goal, Acceptance Criteria with checkboxes, and specific file paths."
+} | yx context "$YAK_NAME"
+
+yx sync
+echo "Tagged '$YAK_NAME' with @needs-human. Reason: $REASON" >&2

--- a/modules/home-manager/skills/internal/shave-yaks/scripts/yak-needs-refinement.sh
+++ b/modules/home-manager/skills/internal/shave-yaks/scripts/yak-needs-refinement.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# yak-needs-refinement.sh - Check if a yak has enough context to implement autonomously
+#
+# A yak needs refinement if it lacks:
+#   - Any context (no Goal, no Acceptance Criteria)
+#   - Specific file paths to work on
+#   - Clear acceptance criteria (no checkboxes or vague ones)
+#
+# Usage:
+#   ./yak-needs-refinement.sh "yak name"
+#
+# Exit codes:
+#   0 - yak is clear enough to implement
+#   1 - yak needs refinement
+#
+# Outputs:
+#   If needs refinement: prints reason to stdout
+#   If clear: prints nothing
+
+set -euo pipefail
+
+YAK_NAME="${1:-}"
+if [[ -z "$YAK_NAME" ]]; then
+    echo "Usage: $0 \"yak name\"" >&2
+    exit 2
+fi
+
+# Get yak details
+yak_json=$(yx show "$YAK_NAME" --format json 2>/dev/null) || {
+    echo "Yak not found: $YAK_NAME" >&2
+    exit 2
+}
+
+context=$(echo "$yak_json" | python3 -c "import json,sys; y=json.load(sys.stdin); v=y.get('context'); print('' if v is None else v)")
+name=$(echo "$yak_json" | python3 -c "import json,sys; y=json.load(sys.stdin); print(y.get('name',''))")
+
+# Check 1: Has any context at all?
+if [[ -z "$context" || "$context" == "null" ]]; then
+    echo "No context defined. Need: Goal, Acceptance Criteria, and key files."
+    exit 1
+fi
+
+# Check 2: Has acceptance criteria (looks for checkboxes or numbered criteria)
+if ! echo "$context" | grep -qiE '(- \[|acceptance criteria|criteria|definition of done)'; then
+    echo "No acceptance criteria found. Context exists but lacks testable criteria."
+    exit 1
+fi
+
+# Check 3: Mentions specific files (heuristic: contains .nix or .sh or path-like strings)
+if ! echo "$context" | grep -qE '(\.(nix|sh|yml|yaml|md|json|toml)|modules/|tests/|\.github/)'; then
+    echo "No specific files mentioned. Need concrete file paths for autonomous implementation."
+    exit 1
+fi
+
+# Yak is clear enough
+exit 0

--- a/modules/home-manager/skills/internal/shave-yaks/scripts/yak-triage.sh
+++ b/modules/home-manager/skills/internal/shave-yaks/scripts/yak-triage.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# yak-triage.sh - Find actionable yaks ready for implementation
+#
+# Outputs one yak per line (JSON objects) that:
+#   - Are in state "todo"
+#   - Have no children of their own (leaf nodes)
+#   - Are not tagged with any blocking tag (e.g. @needs-human, @needs-e2e-vm)
+#   - Are not already wip (claimed by another agent)
+#
+# Usage:
+#   ./yak-triage.sh                  # Print actionable yaks as JSON array
+#   ./yak-triage.sh --names          # Print just the names, one per line
+#   ./yak-triage.sh --count          # Print count only
+#   ./yak-triage.sh --max N          # Limit output to N yaks (default: unlimited)
+#
+# Exit codes:
+#   0 - found actionable yaks
+#   1 - no actionable yaks found
+
+set -euo pipefail
+
+# Parse args
+MODE="json"
+MAX=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --names) MODE="names" ;;
+        --count) MODE="count" ;;
+        --max)   MAX="$2"; shift ;;
+        *) echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+    shift
+done
+
+# Blocking tags - yaks with these should not be auto-implemented
+BLOCKING_TAGS=(
+    "@needs-human"
+    "@needs-e2e-vm"
+    "@needs-refactoring"
+    "@blocked"
+    "@wip"
+)
+
+# Get all yaks as flat JSON
+all_yaks=$(yx ls --format json 2>/dev/null)
+
+# Filter to actionable leaf yaks using Python (available everywhere)
+actionable=$(python3 - "$all_yaks" "${BLOCKING_TAGS[@]}" <<'PYEOF'
+import json, sys
+
+raw = sys.argv[1]
+blocking_tags = set(sys.argv[2:])
+
+yaks = json.loads(raw)
+
+def is_actionable(yak):
+    # Must be todo state
+    if yak.get("state") != "todo":
+        return False
+    # Must be a leaf (no children, or all children are done)
+    children = yak.get("children", [])
+    if children:
+        non_done = [c for c in children if c.get("state") != "done"]
+        if non_done:
+            return False
+    # Must not have blocking tags
+    tags = set(yak.get("tags", []))
+    if tags & blocking_tags:
+        return False
+    return True
+
+def flatten(yaks):
+    """Recursively flatten yak tree into list."""
+    result = []
+    for y in yaks:
+        result.append(y)
+        for child in y.get("children", []):
+            result.append(child)
+            for grandchild in child.get("children", []):
+                result.append(grandchild)
+    return result
+
+flat = flatten(yaks)
+actionable = [y for y in flat if is_actionable(y)]
+print(json.dumps(actionable, indent=2))
+PYEOF
+)
+
+count=$(echo "$actionable" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+
+if [[ "$count" -eq 0 ]]; then
+    if [[ "$MODE" == "count" ]]; then
+        echo "0"
+    fi
+    exit 1
+fi
+
+# Apply max limit if set
+if [[ "$MAX" -gt 0 ]]; then
+    actionable=$(echo "$actionable" | python3 -c "
+import json, sys
+yaks = json.load(sys.stdin)
+print(json.dumps(yaks[:$MAX], indent=2))
+")
+    count=$(echo "$actionable" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+fi
+
+case "$MODE" in
+    json)
+        echo "$actionable"
+        ;;
+    names)
+        echo "$actionable" | python3 -c "
+import json, sys
+for y in json.load(sys.stdin):
+    print(y['name'])
+"
+        ;;
+    count)
+        echo "$count"
+        ;;
+esac

--- a/modules/home-manager/skills/internal/shave-yaks/scripts/yak-worker-prompt.sh
+++ b/modules/home-manager/skills/internal/shave-yaks/scripts/yak-worker-prompt.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# yak-worker-prompt.sh - Generate a complete subagent implementation prompt for a yak
+#
+# Outputs a fully-formed prompt that can be sent to a subagent to implement
+# the yak end-to-end: workspace → implement (TDD/BDD) → PR → CI → merge → done.
+#
+# Usage:
+#   ./yak-worker-prompt.sh "yak name" [--repo-root /path/to/repo]
+#
+# Output: prompt text on stdout
+
+set -euo pipefail
+
+YAK_NAME="${1:-}"
+REPO_ROOT="${2:-$(git rev-parse --show-toplevel 2>/dev/null || jj root 2>/dev/null || pwd)}"
+GH_REPO=""
+
+if [[ -z "$YAK_NAME" ]]; then
+    echo "Usage: $0 \"yak name\" [repo-root]" >&2
+    exit 1
+fi
+
+# Get GitHub repo
+GH_REPO=$(jj git remote list 2>/dev/null | grep -E '^origin\s' | awk '{print $2}' \
+    | sed -E 's#^(git@github\.com:|https://github\.com/)##' \
+    | sed -E 's#\.git$##' \
+    | sed -E 's#^https://[^@]+@github\.com/##' \
+    || echo "")
+
+# Get yak details as JSON
+yak_json=$(yx show "$YAK_NAME" --format json 2>/dev/null)
+context=$(echo "$yak_json" | python3 -c "import json,sys; y=json.load(sys.stdin); print(y.get('context','(no context)'))")
+tags=$(echo "$yak_json" | python3 -c "import json,sys; y=json.load(sys.stdin); print(' '.join(y.get('tags',[])))")
+parent=$(echo "$yak_json" | python3 -c "
+import json,sys
+y=json.load(sys.stdin)
+bc = y.get('breadcrumb',[])
+print(' > '.join(bc) if bc else 'root')
+" 2>/dev/null || echo "")
+
+# Generate a slug from the yak name (lowercase, hyphens, max 40 chars)
+slug=$(echo "$YAK_NAME" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/-*$//' | cut -c1-40)
+# Determine branch type from name heuristics
+branch_type="fix"
+if echo "$YAK_NAME" | grep -qiE '^(add|create|implement|wire|enable|introduce)'; then
+    branch_type="feat"
+elif echo "$YAK_NAME" | grep -qiE '^(test|coverage|spec)'; then
+    branch_type="test"
+elif echo "$YAK_NAME" | grep -qiE '^(refactor|consolidate|extract|move|rename|remove|clean)'; then
+    branch_type="chore"
+fi
+branch_name="${branch_type}/${slug}"
+workspace_name="${branch_type}-${slug}"
+
+cat <<PROMPT
+You are working in the Nix system configuration repository at ${REPO_ROOT}.
+
+## Your Yak
+
+**Name:** ${YAK_NAME}
+**Parent:** ${parent}
+**Tags:** ${tags:-none}
+
+## Context & Acceptance Criteria
+
+${context}
+
+## Required Workflow
+
+### 1. Setup — fresh workspace off main
+
+\`\`\`bash
+cd ${REPO_ROOT}
+jj git fetch
+jj workspace add --name ${workspace_name} .workspaces/${workspace_name}
+\`\`\`
+
+Work in \`.workspaces/${workspace_name}\` but run devenv tasks from the repo root.
+
+### 2. Understand before implementing
+
+Read all relevant files mentioned in the context above. Run:
+\`\`\`bash
+devenv tasks run check:lint   # understand the baseline
+\`\`\`
+
+### 3. Implement using TDD/BDD
+
+**Write tests FIRST, then the implementation.**
+
+- Tests must be written before implementation code
+- Each acceptance criterion above maps to at least one test
+- Tests should be BDD-style: describe the DESIRED OUTCOME, not the mechanism
+- For Nix modules: use \`lib.evalModules\` with a stub to verify option behavior
+- For shell scripts: use a bash test with mock filesystem structures
+- For CI/workflow changes: write a check that verifies the file structure is correct
+
+The pattern used in this codebase:
+- Nix tests live in \`tests/\` as \`.nix\` files
+- Tests are \`pkgs.runCommand\` derivations that exit 0 on success
+- New tests wire into \`tests/default.nix\`, \`flake.nix\` checks, and a devenv task
+
+### 4. Validate locally before committing
+
+\`\`\`bash
+# From repo root:
+devenv tasks run check:lint
+devenv tasks run test:darwin-eval   # catches module errors
+# Build the new check:
+git add -A
+nix build --impure ".#checks.aarch64-darwin.<test-name>" --no-link
+\`\`\`
+
+### 5. Commit (jj, not git)
+
+\`\`\`bash
+jj describe -m "<type>: <what and why, referencing the yak>
+
+<body explaining what changed and why>"
+\`\`\`
+
+### 6. Push and create PR
+
+\`\`\`bash
+jj bookmark set ${branch_name} -r @
+jj git push --bookmark ${branch_name}
+gh pr create \\
+  --title "<type>: <concise description>" \\
+  --head "${branch_name}" \\
+  --body "\$(cat <<'EOF'
+## Summary
+- What changed and why (1-3 bullets)
+
+## Acceptance Criteria Met
+$(echo "$context" | grep -oE '- \[.\] .*' | head -10 || echo "- See yak context")
+
+## Testing
+- Tests added: <list>
+- Local validation: lint + darwin-eval + nix build check
+EOF
+)"
+\`\`\`
+
+### 7. Watch CI and merge
+
+Poll until all checks complete:
+\`\`\`bash
+# Poll every 30-60 seconds:
+gh pr view <number> --repo ${GH_REPO} --json statusCheckRollup
+\`\`\`
+
+Wait for ALL checks to show \`"conclusion":"SUCCESS"\` and \`"status":"COMPLETED"\`, then:
+\`\`\`bash
+gh pr merge <number> --repo ${GH_REPO} --squash --delete-branch --admin
+\`\`\`
+
+### 8. Mark yak done and clean up
+
+\`\`\`bash
+yx done "${YAK_NAME}"
+yx sync
+jj git fetch
+cd ${REPO_ROOT}
+jj workspace forget ${workspace_name}
+rm -rf .workspaces/${workspace_name}
+\`\`\`
+
+## Critical Rules
+
+- **Tests first** — write failing tests before any implementation code
+- **Use \`jj describe\`** not \`git commit\` — the working copy IS the commit
+- **\`git add -A\` before \`nix build --impure\`** — staged files must be visible
+- **Run devenv tasks from repo root**, not from workspace
+- **alejandra formats Nix** — \`check:lint\` will fail on unformatted code (run \`alejandra .\` to fix)
+- **Check both platforms**: Darwin eval is required; NixOS eval if you touched NixOS-only modules
+- **If CI fails**: investigate the failure, fix it, push an update (jj squash + jj git push), do NOT merge broken code
+
+## Return
+
+When done, report:
+1. PR URL and number
+2. Whether merged successfully
+3. Final commit hash on main
+4. Any issues encountered or open questions
+PROMPT

--- a/modules/home-manager/skills/manifest.nix
+++ b/modules/home-manager/skills/manifest.nix
@@ -182,4 +182,18 @@
     deps = [];
     autoLoad = true;
   };
+
+  "shave-yaks" = {
+    description = "Use when you want to autonomously work through a yak backlog end-to-end — triaging, implementing, testing, and shipping PRs until all yaks are done or flagged for refinement";
+    roles = ["developer" "opencode" "claude"];
+    source = {
+      type = "internal";
+      path = ./internal/shave-yaks;
+    };
+    deps = ["yak-shaving" "jj" "watch-ci-jobs"];
+    commands = {
+      path = ./internal/shave-yaks/commands;
+      list = ["shave"];
+    };
+  };
 }


### PR DESCRIPTION
## Summary

Adds the `shave-yaks` internal skill — an autonomous yak backlog processor that loops through todo yaks, implements them with TDD/BDD, ships PRs, watches CI, and merges until everything is done or flagged for human refinement.

## What's Included

**Scripts** (`modules/home-manager/skills/internal/shave-yaks/scripts/`):

| Script | Purpose |
|--------|---------|
| `yak-triage.sh` | Find actionable (todo, leaf, unblocked) yaks via `yx ls --format json` |
| `yak-claim.sh` | Safe claim protocol: sync → check state → start → sync |
| `yak-needs-refinement.sh` | Test if a yak has Goal + Acceptance Criteria + file paths |
| `yak-mark-refinement.sh` | Tag @needs-human with reason, append to context |
| `yak-worker-prompt.sh` | Generate complete subagent prompt including TDD requirements |

**Skill** (`SKILL.md`): Documents the /shave loop, BDD/TDD requirements per yak, parallelism rules, and the decide-implement-vs-refine heuristic.

**Command** (`commands/shave.md`): `/shave` slash command that agents invoke to start the loop.

**Manifest**: Registered for `developer`/`opencode`/`claude` roles with `yak-shaving`, `jj`, and `watch-ci-jobs` as deps.

## Design Decisions

- Scripts do the mechanical work; SKILL.md teaches the judgment (what to parallelize, when to flag for refinement)
- `yak-worker-prompt.sh` embeds the TDD mandate directly in each subagent prompt so they can't skip it
- Refinement detection is heuristic (looks for checkboxes, file paths) — low false-positive rate preferred over high recall
- Parallelism is opt-in via context inspection, not automatic