### PR TITLE
chore: add workflow_dispatch trigger to pr-validation.yml

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,6 +4,7 @@ name: PR Validation
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Add workflow_dispatch trigger to pr-validation.yml
- Allows manually triggering validation from GitHub UI
- Preserves existing pull_request trigger

## Testing
- check:lint (yamllint) passes