### PR TITLE
chore: remove unused ollama.useHomebrew option

### DIFF
--- a/modules/common/options.nix
+++ b/modules/common/options.nix
@@ -763,12 +763,6 @@ with lib; {
         default = null;
         description = "Path to environment file with additional Ollama configuration";
       };
-
-      useHomebrew = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Use Homebrew-installed Ollama instead of Nix package (Darwin only). Useful for getting the latest version with Metal acceleration";
-      };
     };
 
     vane = {


### PR DESCRIPTION
## Summary
- Remove unused `myConfig.ollama.useHomebrew` option from `modules/common/options.nix`
- Option was defined but never referenced anywhere in the codebase
- Reduces dead code and options.nix complexity

## Testing
- `check:lint` passes
- `test:darwin-eval` passes