### PR TITLE
chore: remove empty llm-server bundle from bundles.nix

### DIFF
--- a/bundles.nix
+++ b/bundles.nix
@@ -295,12 +295,6 @@ with pkgs.lib; {
         };
       };
     };
-
-    llm-server = {
-      packages = [];
-
-      config = {};
-    };
   };
 
   platforms = {


### PR DESCRIPTION
## Summary

- Remove empty `llm-server` bundle (`packages = []`, `config = {}`) from `bundles.nix`
- Dead code — no packages, no config, not referenced elsewhere in Nix files
- The actual LLM hosting role is `llm-host` in `modules/roles/llm-host.nix`

## Testing

- `check:lint` passes
- `test:darwin-eval` passes