### PR TITLE
chore: wrap boot.loader settings in os/nixos.nix with lib.mkDefault

### DIFF
--- a/os/nixos.nix
+++ b/os/nixos.nix
@@ -1,8 +1,12 @@
-{pkgs, ...}: {
+{
+  lib,
+  pkgs,
+  ...
+}: {
   boot = {
     loader = {
-      systemd-boot.enable = true;
-      efi.canTouchEfiVariables = true;
+      systemd-boot.enable = lib.mkDefault true;
+      efi.canTouchEfiVariables = lib.mkDefault true;
     };
     kernelPackages = pkgs.linuxPackages_latest;
   };


### PR DESCRIPTION
## Summary
- Add `lib.mkDefault` to `boot.loader.systemd-boot.enable` and `boot.loader.efi.canTouchEfiVariables`
- Allows machine-specific configs to override these without Nix option conflicts
- No behavioral change for existing configs (`mkDefault = true` is still `true`)

## Testing
- check:lint passes
- test:darwin-eval passes
- test:nixos-eval passes