### PR TITLE
feat: make aerospace external monitor configurable

### DIFF
--- a/modules/common/options.nix
+++ b/modules/common/options.nix
@@ -1253,6 +1253,14 @@ with lib; {
       };
     };
 
+    aerospace = {
+      externalMonitor = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "External monitor identifier for aerospace workspace assignment (e.g., 'PHL'). Set to null to disable monitor-specific workspace assignment.";
+      };
+    };
+
     sketchybar = {
       enable = mkOption {
         type = types.bool;

--- a/modules/home-manager/aerospace.nix
+++ b/modules/home-manager/aerospace.nix
@@ -1,4 +1,11 @@
-{pkgs, ...}: {
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.myConfig;
+in {
   services.aerospace = {
     enable = true;
     package = pkgs.aerospace;
@@ -99,17 +106,18 @@
           run = ["move-node-to-workspace 3.Dash"];
         }
       ];
-      # Default: new workspaces go to external monitor (PHL 346B1C)
+      # Default: new workspaces go to external monitor (if configured)
       on-focused-monitor-changed = ["move-mouse monitor-lazy-center"];
 
-      workspace-to-monitor-force-assignment = {
-        # Comms stays on built-in display
-        "2.Comms" = ["built-in"];
-        # Everything else goes to external monitor
-        "1.Main" = ["PHL" "main"];
-        "3.Dash" = ["PHL" "main"];
-        "4.Distracted" = ["PHL" "main"];
-      };
+      workspace-to-monitor-force-assignment =
+        # Comms always stays on built-in display
+        {"2.Comms" = ["built-in"];}
+        // lib.optionalAttrs (cfg.aerospace.externalMonitor != null) {
+          # Everything else goes to external monitor when configured
+          "1.Main" = [cfg.aerospace.externalMonitor "main"];
+          "3.Dash" = [cfg.aerospace.externalMonitor "main"];
+          "4.Distracted" = [cfg.aerospace.externalMonitor "main"];
+        };
     };
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -87,5 +87,9 @@ in
     workspace-switch = testWorkspaceSwitch.workspaceSwitchTest;
     fjj-options = testHomeManager.fjjOptionsTest;
     fjj-custom-options = testHomeManager.fjjCustomOptionsTest;
+
+    # Aerospace option tests
+    aerospace-options = testHomeManager.aerospaceOptionsTest;
+    aerospace-custom-options = testHomeManager.aerospaceCustomOptionsTest;
   }
   // vmTests

--- a/tests/test-home-manager.nix
+++ b/tests/test-home-manager.nix
@@ -1,5 +1,5 @@
 # Home-manager module option tests using evalModules
-# Tests jj-autosync options, opencode options, fjj options, and shell alias structure
+# Tests jj-autosync options, opencode options, fjj options, aerospace options, and shell alias structure
 {pkgs, ...}: let
   inherit (pkgs) lib;
 
@@ -16,6 +16,28 @@
       config._module.args = {inherit pkgs;};
     }
   ];
+
+  # --- aerospace option tests ---
+
+  # Evaluate aerospace with defaults (externalMonitor = null)
+  aerospaceDefaults =
+    (lib.evalModules {
+      modules = stubModules;
+    }).config.myConfig.aerospace;
+
+  # Evaluate aerospace with externalMonitor set
+  aerospaceCustom =
+    (lib.evalModules {
+      modules =
+        stubModules
+        ++ [
+          {
+            config.myConfig.aerospace = {
+              externalMonitor = "TEST";
+            };
+          }
+        ];
+    }).config.myConfig.aerospace;
 
   # --- fjj option tests ---
 
@@ -430,6 +452,40 @@ in {
       }
 
       echo "All fjj custom options verified"
+      touch $out
+    '';
+
+  # Test aerospace option defaults
+  aerospaceOptionsTest =
+    pkgs.runCommand "test-aerospace-options"
+    {}
+    ''
+      echo "=== Testing aerospace Option Defaults ==="
+
+      ${
+        if aerospaceDefaults.externalMonitor == null
+        then ''echo "  externalMonitor default = null: OK"''
+        else ''echo "  externalMonitor should default to null!"; exit 1''
+      }
+
+      echo "All aerospace option defaults verified"
+      touch $out
+    '';
+
+  # Test aerospace custom option values
+  aerospaceCustomOptionsTest =
+    pkgs.runCommand "test-aerospace-custom-options"
+    {}
+    ''
+      echo "=== Testing aerospace Custom Options ==="
+
+      ${
+        if aerospaceCustom.externalMonitor == "TEST"
+        then ''echo "  externalMonitor = TEST: OK"''
+        else ''echo "  externalMonitor should be TEST!"; exit 1''
+      }
+
+      echo "All aerospace custom options verified"
       touch $out
     '';
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded 'PHL' monitor name in `modules/home-manager/aerospace.nix`
- Add `myConfig.aerospace.externalMonitor` option (`nullOr str`, default: `null`) to `modules/common/options.nix`
- When `null`: only the Comms workspace has a built-in assignment; no external monitor assignments
- When set (e.g., `"PHL"`): uses the provided monitor identifier for the external monitor assignments

## Testing

- Tests added for both `null` (default) and non-null `externalMonitor` in `tests/test-home-manager.nix`
- Tests registered in `tests/default.nix` as `aerospace-options` and `aerospace-custom-options`
- `check:lint` passes
- `test:darwin-eval` passes
- `test:all` passes
- `check:all` passes