### PR TITLE
chore: document that nix.settings.experimental-features copies in machine-types are intentional

### DIFF
--- a/machine-types/desktop.nix
+++ b/machine-types/desktop.nix
@@ -15,7 +15,7 @@
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
-  # Enable flakes (for rebuilding)
+  # Enable flakes (intentional: type-desktop does not include os/nixos.nix)
   nix.settings.experimental-features = ["nix-command" "flakes"];
 
   # Networking

--- a/machine-types/server.nix
+++ b/machine-types/server.nix
@@ -14,7 +14,7 @@
     kernelModules = ["kvm-intel" "kvm-amd"];
   };
 
-  # Enable flakes
+  # Enable flakes (intentional: type-server does not include os/nixos.nix)
   nix.settings.experimental-features = ["nix-command" "flakes"];
 
   # Networking - DHCP for IP and hostname

--- a/os/nixos.nix
+++ b/os/nixos.nix
@@ -1,3 +1,6 @@
+# Canonical NixOS platform configuration (used by: zero)
+# Note: machine-types/* and os/microvm.nix define their own copies since they
+# are NOT included alongside this file in any nixosConfiguration.
 {
   lib,
   pkgs,


### PR DESCRIPTION
## Summary

- Investigated all instances of `nix.settings.experimental-features = ["nix-command" "flakes"]` across the codebase
- Confirmed no copies are redundant — added clarifying comments to prevent future confusion
- No functional changes; comment-only update

## Analysis

The yak asked to remove redundant copies from `machine-types/` if they were covered by `os/nixos.nix`. Investigation shows they are **not** covered:

| File | nixosConfigurations that use it | Includes os/nixos.nix? |
|------|--------------------------------|------------------------|
| `os/nixos.nix` | `zero` | — (is nixos.nix) |
| `os/microvm.nix` | `dev-vm`, `openclaw`, `matrix` (via `mkMicrovm`) | No — replaces nixos.nix for VMs |
| `machine-types/server.nix` | `type-server`, `type-server-arm` | **No** |
| `machine-types/desktop.nix` | `type-desktop` | **No** |
| `targets/bootstrap/default.nix` | `bootstrap` | No (standalone) |
| `targets/installer-iso/default.nix` | `installer-iso` | No (standalone) |
| `scripts/lib/bootstrap-config.nix` | Not a flake config | No (standalone script) |

`os/nixos.nix` is only included in the `zero` nixosConfiguration (flake.nix:537). The `type-*` configurations use `machine-types/` directly without `os/nixos.nix`, so all copies are independently required.

## What Was Changed

- `os/nixos.nix`: Added header comment documenting it as canonical and explaining why other copies exist
- `machine-types/server.nix`: Updated comment from "Enable flakes" to "intentional: type-server does not include os/nixos.nix"
- `machine-types/desktop.nix`: Updated comment from "Enable flakes (for rebuilding)" to "intentional: type-desktop does not include os/nixos.nix"

## Testing

- `check:lint` passes
- `test:nixos-eval` passes
- `test:darwin-eval` passes