### PR TITLE
fix: add persistent-workspaces and config-version 2 to aerospace

### DIFF
--- a/modules/home-manager/aerospace.nix
+++ b/modules/home-manager/aerospace.nix
@@ -11,9 +11,13 @@ in {
     package = pkgs.aerospace;
 
     settings = {
+      "config-version" = 2;
+
       after-startup-command = [
         "layout tiles horizontal" # Root container horizontal
       ];
+
+      persistent-workspaces = ["1.Main" "2.Comms" "3.Dash" "4.Distracted"];
 
       gaps = {
         inner.horizontal = 0;


### PR DESCRIPTION
## Summary

- Add `config-version = 2` to aerospace settings (required for newer versions)
- Add `persistent-workspaces` configuration for consistent workspace layout: Main, Comms, Dash, Distracted