### PR TITLE
feat(aerospace): summon window to current workspace with edge dock

### DIFF
--- a/modules/home-manager/aerospace.nix
+++ b/modules/home-manager/aerospace.nix
@@ -5,7 +5,75 @@
   ...
 }: let
   cfg = config.myConfig;
+
+  # Script: summon an app to the focused workspace, dock it to the long edge
+  # (left on landscape monitors, top on portrait), and size it to 1/3 of that
+  # dimension. All tree manipulation uses --window-id, so focus never moves
+  # (no visible flashing). Multi-monitor aware via the focused monitor's name
+  # matched against system_profiler display data.
+  aerospace-summon = pkgs.writeShellScriptBin "aerospace-summon" ''
+    set -euo pipefail
+
+    AS=/run/current-system/sw/bin/aerospace
+    JQ=${pkgs.jq}/bin/jq
+    SP=/usr/sbin/system_profiler
+
+    BUNDLE_ID="''${1:-}"
+    if [ -z "$BUNDLE_ID" ]; then
+      echo "usage: aerospace-summon <bundle-id>" >&2
+      exit 2
+    fi
+
+    # Target window (first match for this bundle id)
+    WID=$("$AS" list-windows --all --json --format '%{window-id} %{app-bundle-id}' \
+      | "$JQ" -r --arg b "$BUNDLE_ID" \
+          'map(select(."app-bundle-id" == $b)) | .[0]."window-id" // empty')
+
+    if [ -z "$WID" ]; then
+      echo "aerospace-summon: no window for $BUNDLE_ID" >&2
+      exit 1
+    fi
+
+    # Focused workspace
+    WS=$("$AS" list-workspaces --focused --format '%{workspace}')
+
+    # Focused monitor name
+    MON_NAME=$("$AS" list-monitors --focused --format '%{monitor-name}')
+
+    # Resolve monitor pixel dimensions from system_profiler by display name.
+    # Falls back to 1920x1080 if the name isn't found (shouldn't happen).
+    read -r MON_W MON_H < <("$SP" SPDisplaysDataType -json 2>/dev/null \
+      | "$JQ" -r --arg n "$MON_NAME" '
+          [.SPDisplaysDataType[]?.spdisplays_ndrvs[]?
+           | select(._name == $n)
+           | ._spdisplays_pixels]
+          | .[0] // "1920 x 1080"' \
+      | ${pkgs.gnused}/bin/sed -E 's/ x / /')
+
+    # Pull window into current workspace (silent: no focus change)
+    "$AS" move-node-to-workspace --window-id "$WID" "$WS"
+
+    # Walk the window to the correct edge of the tree. `move` with --window-id
+    # manipulates the tree without moving focus. No-op at the edge.
+    if [ "$MON_W" -ge "$MON_H" ]; then
+      DIR=left
+      DIM=width
+      SIZE=$((MON_W / 3))
+    else
+      DIR=up
+      DIM=height
+      SIZE=$((MON_H / 3))
+    fi
+
+    for _ in $(${pkgs.coreutils}/bin/seq 1 10); do
+      "$AS" move "$DIR" --window-id "$WID" 2>/dev/null || true
+    done
+
+    "$AS" resize "$DIM" "$SIZE" --window-id "$WID" 2>/dev/null || true
+  '';
 in {
+  environment.systemPackages = [aerospace-summon];
+
   services.aerospace = {
     enable = true;
     package = pkgs.aerospace;
@@ -82,6 +150,9 @@ in {
         # Move current window to monitor
         shift-ctrl-alt-9 = "move-node-to-monitor --wrap-around prev";
         shift-ctrl-alt-0 = "move-node-to-monitor --wrap-around next";
+
+        # Summon Vivaldi to current workspace, dock to long edge at 1/3 size
+        shift-ctrl-alt-a = "exec-and-forget ${aerospace-summon}/bin/aerospace-summon com.vivaldi.Vivaldi";
       };
 
       on-window-detected = [


### PR DESCRIPTION
Adds shift-ctrl-alt-a binding that summons a specified app (Vivaldi) onto
the focused workspace, then docks it to the long edge of the focused monitor
at 1/3 size (left third on landscape, top third on portrait).

All tree manipulation uses aerospace --window-id so focus never moves to the
summoned window, eliminating the visible flash from prior focus-based
approaches. Monitor dimensions are resolved from system_profiler -json by
matching display name.