### PR TITLE
feat(skills): add iterating-nix-embedded-scripts

### DIFF
--- a/modules/home-manager/skills/internal/iterating-nix-embedded-scripts/SKILL.md
+++ b/modules/home-manager/skills/internal/iterating-nix-embedded-scripts/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: iterating-nix-embedded-scripts
+description: Use when iterating on shell scripts embedded in Nix modules via writeShellScriptBin, writeShellApplication, writeScriptBin, or writeText — avoids slow build/switch cycles for every edit
+---
+
+# Iterating on Nix-embedded shell scripts
+
+## Overview
+
+Shell scripts defined inside Nix derivations (`pkgs.writeShellScriptBin` et al.) normally force a full `darwin-rebuild switch` / `nixos-rebuild switch` per change — 30s to 5 min per iteration.
+
+**Core principle:** Use `nix build` to materialize the script into `/nix/store` with all interpolations resolved, and run it from there. Edit the Nix source directly, rebuild, run. Never hand-extract — Nix escaping (`''${`, `''$`, `'''`) and `${pkgs.xxx}` interpolation are easy to get wrong.
+
+## When to Use
+
+- Editing a `writeShellScriptBin`, `writeShellApplication`, `writeScriptBin`, `writeScript`, or `writeText`-backed script inside a flake
+- About to run `darwin-rebuild switch` / `nixos-rebuild switch` just to test a one-line shell change
+- About to hand-copy a script body to `/tmp` to iterate on it
+- Unsure whether the bug is in shell logic or in Nix interpolations
+
+**Do not use for:** Nix expressions that aren't producing runnable scripts (modules, options, services). Those need eval tests or `nix flake check`, not script execution.
+
+## Workflow
+
+1. **Find the derivation.** Usually in `config.environment.systemPackages` (NixOS/Darwin system module) or `config.home.packages` (home-manager). If defined in a `let` binding, filter the list by `pname` / `name`.
+
+2. **Build with an out-link:**
+   ```bash
+   nix build --impure --out-link /tmp/<name>-result --expr '
+     let
+       flake = builtins.getFlake (toString /ABS/PATH/TO/FLAKE);
+       syspkgs = flake.darwinConfigurations.<host>.config.environment.systemPackages;
+     in builtins.head (builtins.filter
+       (p: (p.pname or p.name or "") == "<script-name>") syspkgs)
+   '
+   ```
+   `/tmp/<name>-result/bin/<script-name>` is runnable and fully interpolated.
+
+3. **Iterate:** edit the `.nix` file → rerun the `nix build` → execute the result. ~10–15s per cycle (mostly flake eval; the build step itself is ~1–2s).
+
+4. **You're already "reimported."** You were editing the Nix source the whole time. Nothing to sync back. When happy, run your normal `switch` once.
+
+## Helper
+
+Bundled `nix-script-iter` wraps the filter-and-build pattern:
+
+```bash
+nix-script-iter <flake-path> <config-name> <script-pname> [-- <script-args>]
+```
+
+Run `nix-script-iter` with no args for usage.
+
+## Common Pitfalls
+
+**Don't hand-extract the script body.** Manual transcription drops `${pkgs.xxx}` interpolations and mangles escape sequences. Always let `nix build` produce the runnable script.
+
+**Nonexistent nixpkgs paths fail fast with `nix build`.** Example: `${pkgs.darwin.system_profiler}` looks plausible but doesn't exist (`system_profiler` is a macOS system binary at `/usr/sbin/system_profiler`). `nix build` errors in ~2s; `darwin-rebuild switch` would take much longer to reveal the same bug.
+
+**Use `--impure`.** Flake eval reads from git HEAD without it. `--impure` lets it read the working tree so you don't have to commit every iteration.
+
+**Multiple derivations with the same `pname`.** Tighten the filter — include `version`, or traverse a precise attribute path instead of scanning `systemPackages`.
+
+## Real-World Impact
+
+Aerospace summon script (~60 lines): `darwin-rebuild switch` is 2–5 min; this loop is ~13s per cycle. Catches mistakes like `pkgs.darwin.system_profiler` (nonexistent attr) in 2s.

--- a/modules/home-manager/skills/internal/iterating-nix-embedded-scripts/nix-script-iter
+++ b/modules/home-manager/skills/internal/iterating-nix-embedded-scripts/nix-script-iter
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# nix-script-iter — fast iteration loop for shell scripts embedded in Nix flakes.
+#
+# Usage:
+#   nix-script-iter <flake-path> <config-name> <script-pname> [-- <script-args>...]
+#
+# Example:
+#   nix-script-iter ~/nix wweaver aerospace-summon -- com.vivaldi.Vivaldi
+#
+# What it does:
+#   1. Resolves the script derivation by filtering
+#      darwinConfigurations.<config-name>.config.environment.systemPackages
+#      for a package whose pname matches.
+#   2. Builds it with a stable symlink under /tmp.
+#   3. Executes the resulting binary with any passed-through arguments.
+#
+# Loop: edit the Nix source → re-run this command. ~1–3s per rebuild.
+#
+# Assumptions:
+#   - Darwin flake layout (swap darwinConfigurations for nixosConfigurations as needed).
+#   - Script is installed via environment.systemPackages. For home-manager scripts,
+#     adapt the --expr to walk home-manager.users.<you>.home.packages.
+
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  cat >&2 <<EOF
+usage: nix-script-iter <flake-path> <config-name> <script-pname> [-- <args>...]
+
+  flake-path    absolute or relative path to the flake root
+  config-name   the darwinConfigurations / nixosConfigurations attribute name
+  script-pname  the pname (or name) of the writeShellScriptBin / writeShellApplication
+
+  -- <args>     everything after -- is passed to the built script
+EOF
+  exit 2
+fi
+
+FLAKE_PATH="$1"
+CONFIG_NAME="$2"
+SCRIPT_PNAME="$3"
+shift 3
+
+if [ "$#" -gt 0 ] && [ "$1" = "--" ]; then
+  shift
+fi
+
+# Resolve to absolute path for nix eval (builtins.getFlake requires abs path)
+FLAKE_ABS="$(cd "$FLAKE_PATH" && pwd)"
+
+OUT_LINK="/tmp/nix-script-iter-${SCRIPT_PNAME}"
+
+# Try darwinConfigurations first, fall back to nixosConfigurations.
+# Using --expr keeps this portable across flake attr layouts.
+EXPR='
+  let
+    flake = builtins.getFlake (toString FLAKE_ABS_PLACEHOLDER);
+    cfg =
+      flake.darwinConfigurations.CONFIG_PLACEHOLDER.config
+        or flake.nixosConfigurations.CONFIG_PLACEHOLDER.config;
+    pkgs = cfg.environment.systemPackages;
+    match = builtins.filter
+      (p: (p.pname or p.name or "") == "PNAME_PLACEHOLDER") pkgs;
+  in
+    if match == [] then
+      throw "no package with pname=PNAME_PLACEHOLDER found in environment.systemPackages"
+    else
+      builtins.head match
+'
+
+EXPR="${EXPR//FLAKE_ABS_PLACEHOLDER/$FLAKE_ABS}"
+EXPR="${EXPR//CONFIG_PLACEHOLDER/$CONFIG_NAME}"
+EXPR="${EXPR//PNAME_PLACEHOLDER/$SCRIPT_PNAME}"
+
+echo "→ building $SCRIPT_PNAME from $FLAKE_ABS#$CONFIG_NAME …" >&2
+nix build --impure --out-link "$OUT_LINK" --expr "$EXPR"
+
+BIN="$OUT_LINK/bin/$SCRIPT_PNAME"
+if [ ! -x "$BIN" ]; then
+  echo "nix-script-iter: built but no executable at $BIN" >&2
+  echo "contents of $OUT_LINK/bin:" >&2
+  ls -la "$OUT_LINK/bin" >&2 || true
+  exit 1
+fi
+
+echo "→ running $BIN $*" >&2
+exec "$BIN" "$@"

--- a/modules/home-manager/skills/manifest.nix
+++ b/modules/home-manager/skills/manifest.nix
@@ -196,4 +196,14 @@
       list = ["shave"];
     };
   };
+
+  "iterating-nix-embedded-scripts" = {
+    description = "Use when iterating on shell scripts embedded in Nix modules via writeShellScriptBin, writeShellApplication, writeScriptBin, or writeText — avoids slow build/switch cycles for every edit";
+    roles = ["developer" "opencode" "claude"];
+    source = {
+      type = "internal";
+      path = ./internal/iterating-nix-embedded-scripts;
+    };
+    deps = [];
+  };
 }


### PR DESCRIPTION
Adds a new skill documenting a fast iteration loop for shell scripts embedded
in Nix derivations (writeShellScriptBin / writeShellApplication / etc.). Uses
nix build with an out-link to materialize the interpolated script in the Nix
store, avoiding full darwin-rebuild switch per change.

Bundles nix-script-iter, a small helper that filters
environment.systemPackages for a named pname, builds it, and runs it.

Registered with roles developer/opencode/claude.