### PR TITLE
fix(ci): use PAT for weekly-release PR creation to trigger CI

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT so the PR created later is attributed to a human account,
+          # bypassing the GitHub bot-approval gate that blocks CI on bot PRs.
+          token: ${{ secrets.RELEASE_PAT }}
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v21
         with:
@@ -164,8 +166,7 @@ jobs:
             --repo ${{ github.repository }}
           echo "Auto-merge enabled for PR #$pr_number"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # Summary
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
   summary:
     name: Release Summary
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The weekly-release workflow creates PRs using `GITHUB_TOKEN`, which is attributed to the `github-actions[bot]` account. GitHub's security model requires explicit approval before running CI jobs on PRs opened by bots, so the `PR Validation` workflow was triggering with `action_required` and 0 jobs executed — leaving the PR with no CI results and stalled auto-merge.

## Changes

- **`.github/workflows/weekly-release.yml`**: Swap `GITHUB_TOKEN` → `RELEASE_PAT` on the checkout step and the `create-pr` step env. The `close-existing` step keeps `GITHUB_TOKEN` (no workflow-triggering side effects).
- **Branch protection** (already applied): Added `Build Report` as a required status check on `main`, so auto-merge waits for CI to pass before merging.

## Required

A `RELEASE_PAT` secret must exist in the repo (fine-grained PAT with Contents + Pull requests + Workflows read/write on this repo). ✅ Already added.