### PR TITLE
feat(developer): add temporal-cli to developer role

### DIFF
--- a/modules/roles/developer.nix
+++ b/modules/roles/developer.nix
@@ -19,6 +19,7 @@ in {
       gh-dash
       gomuks
       slidev-cli
+      temporal-cli
       yaks
     ];
 


### PR DESCRIPTION
Adds `temporal-cli` (v1.6.2) to the developer role packages.

Available in nixpkgs as `temporal-cli` — the official CLI for running Temporal Server and interacting with Workflows, Activities, and Namespaces.