### PR TITLE
fix: add system.stateVersion to dev-vm.nix microvm target

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -775,6 +775,7 @@
             microvm-firewall
             microvm-ip-uniqueness
             microvm-ssh
+            microvm-dev-vm-stateversion
             ;
         }
         // nixpkgs.lib.optionalAttrs isLinux {

--- a/targets/microvms/dev-vm.nix
+++ b/targets/microvms/dev-vm.nix
@@ -29,4 +29,6 @@
 
   # Time zone
   time.timeZone = "America/New_York";
+
+  system.stateVersion = "25.05";
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -111,5 +111,6 @@ in
     microvm-firewall = testMicrovm.mediaCenterFirewallTest;
     microvm-ip-uniqueness = testMicrovm.microvmIpUniquenessTest;
     microvm-ssh = testMicrovm.mediaCenterSshTest;
+    microvm-dev-vm-stateversion = testMicrovm.devVmStateVersionTest;
   }
   // vmTests

--- a/tests/test-microvm.nix
+++ b/tests/test-microvm.nix
@@ -231,4 +231,20 @@ in {
       echo "SSH configuration tests passed"
       touch $out
     '';
+
+  # Test that dev-vm has stateVersion set
+  devVmStateVersionTest =
+    pkgs.runCommand "test-dev-vm-has-stateversion"
+    {src = ../.;}
+    ''
+      echo "=== Testing dev-vm has system.stateVersion ==="
+
+      if ! grep -q 'stateVersion.*25\.05' $src/targets/microvms/dev-vm.nix; then
+        echo "FAIL: dev-vm.nix is missing system.stateVersion = \"25.05\""
+        exit 1
+      fi
+
+      echo "PASS: dev-vm.nix has stateVersion = \"25.05\""
+      touch $out
+    '';
 }


### PR DESCRIPTION
## Summary
- Add `system.stateVersion = "25.05"` to `targets/microvms/dev-vm.nix`
- All four microvm targets now have consistent stateVersion
- Prevents NixOS upgrade warnings from missing stateVersion
- Adds `devVmStateVersionTest` test to verify the fix

## Acceptance Criteria Met
- `stateVersion = "25.05"` present in dev-vm.nix
- All microvm targets have same stateVersion
- `test:nixos-eval` passes

## Testing
- Local validation: `check:lint` ✓ and `test:nixos-eval` ✓
- TDD: test written first (RED verified), then implementation (GREEN verified)