### PR TITLE
chore: consolidate programs.zsh.enable to single location

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -747,6 +747,7 @@
             email-separation
             onepassword-guard
             onepassword-config-output
+            zsh-enable-single-location
             sketchybar-options
             sketchybar-custom-options
             sketchybar-theme

--- a/modules/common/core.nix
+++ b/modules/common/core.nix
@@ -11,7 +11,4 @@
     coreutils # Basic Unix utilities
     vim # Emergency editor
   ];
-
-  # Essential shell
-  programs.zsh.enable = true;
 }

--- a/modules/roles/foundation.nix
+++ b/modules/roles/foundation.nix
@@ -54,8 +54,6 @@ in {
         myConfig.onepassword.enable = true;
         myConfig.syncthing.enable = true;
 
-        programs.zsh.enable = true;
-
         environment.variables = {
           EDITOR = "helix";
           VISUAL = "helix";

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -66,6 +66,9 @@ in
     onepassword-guard = testPackages.onepasswordGuardTest;
     onepassword-config-output = testPackages.onepasswordConfigOutputTest;
 
+    # Structural / deduplication tests
+    zsh-enable-single-location = testPackages.zshEnableSingleLocationTest;
+
     # Sketchybar tests
     sketchybar-options = testSketchybar.sketchybarOptionsTest;
     sketchybar-custom-options = testSketchybar.sketchybarCustomOptionsTest;

--- a/tests/test-packages.nix
+++ b/tests/test-packages.nix
@@ -458,4 +458,49 @@
       echo "1Password config output test passed"
       touch $out
     '';
+
+  # Test that programs.zsh.enable is set in exactly one location (shell.nix)
+  # This is a structural test to prevent redundant duplicate assignments.
+  zshEnableSingleLocationTest =
+    pkgs.runCommand "test-zsh-enable-single-location"
+    {
+      src = ../.;
+    }
+    ''
+      echo "=== Testing programs.zsh.enable single location ==="
+
+      # Count occurrences across the three files that previously had duplicates
+      foundation_count=$(grep -c "programs\.zsh\.enable" $src/modules/roles/foundation.nix || true)
+      shell_count=$(grep -c "programs\.zsh\.enable" $src/modules/common/shell.nix || true)
+      core_count=$(grep -c "programs\.zsh\.enable" $src/modules/common/core.nix || true)
+      total=$((foundation_count + shell_count + core_count))
+
+      echo "  modules/roles/foundation.nix:   $foundation_count occurrence(s)"
+      echo "  modules/common/shell.nix:        $shell_count occurrence(s)"
+      echo "  modules/common/core.nix:         $core_count occurrence(s)"
+      echo "  Total across three files:        $total"
+
+      # Canonical location must have the setting
+      if [ "$shell_count" -ne 1 ]; then
+        echo "  FAIL: modules/common/shell.nix should have exactly 1 occurrence (got $shell_count)"
+        exit 1
+      fi
+      echo "  modules/common/shell.nix has exactly 1 occurrence: OK"
+
+      # Duplicates must be absent
+      if [ "$foundation_count" -ne 0 ]; then
+        echo "  FAIL: modules/roles/foundation.nix should have 0 occurrences (got $foundation_count)"
+        exit 1
+      fi
+      echo "  modules/roles/foundation.nix has 0 occurrences: OK"
+
+      if [ "$core_count" -ne 0 ]; then
+        echo "  FAIL: modules/common/core.nix should have 0 occurrences (got $core_count)"
+        exit 1
+      fi
+      echo "  modules/common/core.nix has 0 occurrences: OK"
+
+      echo "programs.zsh.enable single-location check passed"
+      touch $out
+    '';
 }


### PR DESCRIPTION
## Summary
- Remove duplicate \`programs.zsh.enable = true\` from \`modules/roles/foundation.nix\` and \`modules/common/core.nix\`
- Canonical location remains \`modules/common/shell.nix\` (the zsh-specific module)
- No behavior change; Nix module system merges duplicate option assignments identically

## Acceptance Criteria Met
- \`programs.zsh.enable\` exists in exactly one location (\`shell.nix\`)
- Duplicates removed from \`foundation.nix\` and \`core.nix\`
- All eval tests pass

## Testing
- TDD: wrote \`zsh-enable-single-location\` test first (RED), then removed duplicates (GREEN)
- Local validation: \`check:lint\` + \`test:darwin-eval\` + \`test:nixos-eval\` all pass
- New check wired into \`tests/default.nix\` and \`flake.nix\` CI checks