### PR TITLE
chore: remove dead myConfig.development.enable option

### DIFF
--- a/bundles.nix
+++ b/bundles.nix
@@ -123,7 +123,6 @@ with pkgs.lib; {
       ];
 
       config = {
-        myConfig.development.enable = true;
         myConfig.fjj.enable = true;
         myConfig.zellij.enable = true;
 

--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,6 @@
           sshIncludes = [];
         }
       ];
-      development.enable = true;
       onepassword.enable = true;
       jj-autosync = {
         enable = true;
@@ -163,7 +162,6 @@
                     sshIncludes = [];
                   }
                 ];
-                development.enable = true;
                 onepassword.enable = nixpkgs.lib.mkForce false;
               }
               // roleEnables;
@@ -445,7 +443,6 @@
             nix.enable = false;
             myConfig = {
               users = [];
-              development.enable = false;
               agent-skills.enable = false;
               onepassword.enable = false;
               opencode.enable = false;
@@ -731,6 +728,7 @@
             role-packages
             role-cascades
             llm-host-shared-models
+            no-dead-development-option
             module-coverage
             skills-manifest
             skills-autoload-filtering

--- a/modules/common/options.nix
+++ b/modules/common/options.nix
@@ -163,14 +163,6 @@ with lib; {
       };
     };
 
-    development = {
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Enable development tools and environment";
-      };
-    };
-
     email-agent = {
       enable = mkOption {
         type = types.bool;

--- a/modules/roles/developer.nix
+++ b/modules/roles/developer.nix
@@ -23,7 +23,6 @@ in {
       yaks
     ];
 
-    myConfig.development.enable = true;
     myConfig.fjj.enable = true;
     myConfig.zellij.enable = true;
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -41,6 +41,7 @@ in
     role-packages = testRoles.rolePackageInclusionTest;
     role-cascades = testRoles.roleCascadeTest;
     llm-host-shared-models = testRoles.llmHostSharedModelsTest;
+    no-dead-development-option = testRoles.noDeadDevelopmentOptionTest;
 
     # Skills tests
     skills-manifest = testSkills.manifestValidationTest;

--- a/tests/test-microvm.nix
+++ b/tests/test-microvm.nix
@@ -36,7 +36,6 @@
                 sshIncludes = [];
               }
             ];
-            development.enable = true;
             onepassword.enable = false;
           };
         }

--- a/tests/test-packages.nix
+++ b/tests/test-packages.nix
@@ -180,7 +180,6 @@
                 sshIncludes = [];
               }
             ];
-            development.enable = true;
             agent-skills.enable = false;
             onepassword.enable = false;
             opencode.enable = false;
@@ -199,7 +198,6 @@
       # If any option type is wrong, this derivation will fail to instantiate.
       echo "  users count: ${toString (builtins.length evaluatedConfig.users)}"
       echo "  first user name: ${(builtins.head evaluatedConfig.users).name}"
-      echo "  development.enable: ${builtins.toJSON evaluatedConfig.development.enable}"
       echo "  isDarwin: ${builtins.toJSON evaluatedConfig.isDarwin}"
       echo "  ollama.enable: ${builtins.toJSON evaluatedConfig.ollama.enable}"
       echo "  ollama.port: ${toString evaluatedConfig.ollama.port}"

--- a/tests/test-roles.nix
+++ b/tests/test-roles.nix
@@ -212,7 +212,6 @@
   # Map of roles to cascade-enabled options
   roleCascades = {
     developer = {
-      "development.enable" = true;
       "fjj.enable" = true;
       "zellij.enable" = true;
     };
@@ -352,6 +351,56 @@ in {
       echo "All role cascades work correctly"
       touch $out
     '';
+
+  # Test that dead myConfig.development option has been removed from options.nix.
+  # This option was declared and set (by developer role) but never consumed by any module.
+  # The actual developer role check uses config.myConfig.roles.developer.enable.
+  noDeadDevelopmentOptionTest = let
+    testEval = pkgs.lib.evalModules {
+      modules = [
+        ../modules/common/options.nix
+        {
+          options.nixpkgs.hostPlatform = pkgs.lib.mkOption {
+            type = pkgs.lib.types.anything;
+            default = {inherit (pkgs.stdenv.hostPlatform) system;};
+          };
+        }
+        {config._module.args = {inherit pkgs;};}
+        {
+          config.myConfig.users = [
+            {
+              name = "testuser";
+              email = "test@example.com";
+              fullName = "Test User";
+              isAdmin = true;
+              sshIncludes = [];
+            }
+          ];
+        }
+      ];
+    };
+    # If myConfig.development was removed, attrByPath returns the sentinel null.
+    developmentAttr = pkgs.lib.attrByPath ["development"] null testEval.config.myConfig;
+    isDead = developmentAttr == null;
+  in
+    pkgs.runCommand "test-no-dead-development-option"
+    {}
+    (
+      if isDead
+      then ''
+        echo "=== Testing myConfig.development removed ==="
+        echo "  myConfig.development: absent (correctly removed)"
+        echo "Dead development option successfully removed"
+        touch $out
+      ''
+      else ''
+        echo "=== Testing myConfig.development removed ==="
+        echo "  myConfig.development: STILL PRESENT (should be removed)"
+        echo "  Value: ${builtins.toJSON developmentAttr}"
+        echo "FAIL: myConfig.development is dead code and must be removed"
+        exit 1
+      ''
+    );
 
   # Test that llm-host role wires myConfig.sharedModels into ollama.models
   llmHostSharedModelsTest = let


### PR DESCRIPTION
## Summary
- Remove `myConfig.development` option block from options.nix (lines 166-172)
- Remove `myConfig.development.enable = true` from developer.nix (line 26)
- Dead code: option was declared and set but never consumed by any module
- Add `noDeadDevelopmentOptionTest` to prevent regression

## Problem
`myConfig.development.enable` was declared in `options.nix` and set to `true` in `developer.nix` when the developer role is enabled, but no module ever reads it. The actual developer role check uses `config.myConfig.roles.developer.enable`. This is pure dead code.

## Acceptance Criteria Met
- [x] `myConfig.development` option block removed from options.nix
- [x] `myConfig.development.enable = true` setter removed from developer.nix
- [x] Grep confirms no other references to `myConfig.development` in modules/targets/os/
- [x] New `noDeadDevelopmentOption` test added to catch regressions
- [x] All eval tests pass

## Testing
- Local validation: `check:lint` + `test:darwin-eval` + `test:nixos-eval` all pass
- New test `no-dead-development-option` added to CI check suite