### PR TITLE
chore: extract shared LLM env vars to modules/common/llm-client.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -774,6 +774,11 @@
             microvm-ip-uniqueness
             microvm-ssh
             microvm-dev-vm-stateversion
+            llm-client-opencode
+            llm-client-claude
+            llm-client-pi
+            llm-client-custom-host
+            llm-client-no-ai-roles
             ;
         }
         // nixpkgs.lib.optionalAttrs isLinux {

--- a/modules/common/llm-client.nix
+++ b/modules/common/llm-client.nix
@@ -1,0 +1,23 @@
+# Shared LLM client environment variables
+# Sets LLM_SERVER_HOST, LLM_SERVER_PORT, OPENCODE_ENDPOINT, and CLAUDE_API_BASE
+# when any AI agent role (claude, opencode, pi) is enabled.
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.myConfig.llmClient;
+  anyAiRoleActive =
+    config.myConfig.roles.claude.enable
+    || config.myConfig.roles.opencode.enable
+    || config.myConfig.roles.pi.enable;
+in {
+  config = lib.mkIf anyAiRoleActive {
+    environment.variables = {
+      LLM_SERVER_HOST = cfg.serverHost;
+      LLM_SERVER_PORT = cfg.serverPort;
+      OPENCODE_ENDPOINT = "http://${cfg.serverHost}:${cfg.serverPort}";
+      CLAUDE_API_BASE = "http://${cfg.serverHost}:${cfg.serverPort}";
+    };
+  };
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -12,6 +12,7 @@
     ./common/onepassword.nix
     ./common/cachix.nix
     ./common/motd.nix
+    ./common/llm-client.nix
 
     # Home-manager shared settings
     ./home-manager

--- a/modules/roles/claude.nix
+++ b/modules/roles/claude.nix
@@ -24,13 +24,6 @@ in {
       serverPort = lib.mkDefault "11434";
     };
 
-    environment.variables = {
-      LLM_SERVER_HOST = host;
-      LLM_SERVER_PORT = port;
-      OPENCODE_ENDPOINT = "http://${host}:${port}";
-      CLAUDE_API_BASE = "http://${host}:${port}";
-    };
-
     environment.shellAliases = {
       llm-status = "curl http://${host}:${port}/status";
     };

--- a/modules/roles/opencode.nix
+++ b/modules/roles/opencode.nix
@@ -23,13 +23,6 @@ in {
       serverPort = lib.mkDefault "11434";
     };
 
-    environment.variables = {
-      LLM_SERVER_HOST = host;
-      LLM_SERVER_PORT = port;
-      OPENCODE_ENDPOINT = "http://${host}:${port}";
-      CLAUDE_API_BASE = "http://${host}:${port}";
-    };
-
     environment.shellAliases = {
       llm-status = "curl http://${host}:${port}/status";
     };

--- a/modules/roles/pi.nix
+++ b/modules/roles/pi.nix
@@ -28,8 +28,6 @@ in {
     };
 
     environment.variables = {
-      LLM_SERVER_HOST = host;
-      LLM_SERVER_PORT = port;
       PI_CODING_AGENT_DIR = "$HOME/.pi/agent";
     };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -16,6 +16,7 @@
   testHomeManager = import ./test-home-manager.nix {inherit pkgs;};
   testWorkspaceSwitch = import ./test-workspace-switch.nix {inherit pkgs;};
   testMicrovm = import ./test-microvm.nix {inherit pkgs;};
+  testLlmClient = import ./test-llm-client.nix {inherit pkgs;};
 
   # VM tests only available on x86_64-linux (NixOS testing framework)
   inherit (pkgs.stdenv.hostPlatform) isLinux;
@@ -113,5 +114,12 @@ in
     microvm-ip-uniqueness = testMicrovm.microvmIpUniquenessTest;
     microvm-ssh = testMicrovm.mediaCenterSshTest;
     microvm-dev-vm-stateversion = testMicrovm.devVmStateVersionTest;
+
+    # LLM client module tests
+    llm-client-opencode = testLlmClient.llmClientOpencodeTest;
+    llm-client-claude = testLlmClient.llmClientClaudeTest;
+    llm-client-pi = testLlmClient.llmClientPiTest;
+    llm-client-custom-host = testLlmClient.llmClientCustomHostTest;
+    llm-client-no-ai-roles = testLlmClient.llmClientNoAiRolesTest;
   }
   // vmTests

--- a/tests/test-llm-client.nix
+++ b/tests/test-llm-client.nix
@@ -1,0 +1,355 @@
+# LLM client module tests
+# Verifies that modules/common/llm-client.nix sets the correct environment
+# variables when any AI agent role is enabled.
+{pkgs, ...}: let
+  inherit (pkgs) lib;
+
+  # Stub modules for evalModules - provide options needed by roles
+  stubModules = [
+    ../modules/common/options.nix
+    ../modules/common/llm-client.nix
+    ../modules/roles/default.nix
+    {
+      options.nixpkgs.hostPlatform = lib.mkOption {
+        type = lib.types.anything;
+        default = {inherit (pkgs.stdenv.hostPlatform) system;};
+      };
+      options.environment = {
+        systemPackages = lib.mkOption {
+          type = lib.types.listOf lib.types.package;
+          default = [];
+        };
+        variables = lib.mkOption {
+          type = lib.types.attrsOf lib.types.str;
+          default = {};
+        };
+        sessionVariables = lib.mkOption {
+          type = lib.types.attrsOf lib.types.str;
+          default = {};
+        };
+        shellAliases = lib.mkOption {
+          type = lib.types.attrsOf lib.types.str;
+          default = {};
+        };
+        etc = lib.mkOption {
+          type = lib.types.attrsOf lib.types.anything;
+          default = {};
+        };
+      };
+      options.programs = lib.mkOption {
+        type = lib.types.attrsOf lib.types.anything;
+        default = {};
+      };
+      options.homebrew = lib.mkOption {
+        type = lib.types.anything;
+        default = {};
+      };
+      options.microvm = lib.mkOption {
+        type = lib.types.anything;
+        default = {};
+      };
+      config.microvm.vms = {};
+    }
+    {
+      config._module.args = {inherit pkgs;};
+    }
+  ];
+
+  # Helper: evaluate with a given role enabled
+  evalWithRole = roleName:
+    (lib.evalModules {
+      modules =
+        stubModules
+        ++ [
+          {
+            config.myConfig = {
+              users = [
+                {
+                  name = "testuser";
+                  email = "test@example.com";
+                  fullName = "Test User";
+                  isAdmin = true;
+                  sshIncludes = [];
+                }
+              ];
+              roles.${roleName}.enable = true;
+            };
+          }
+        ];
+    })
+    .config;
+
+  # Evaluate with custom llmClient settings and opencode role enabled
+  evalWithCustomHost =
+    (lib.evalModules {
+      modules =
+        stubModules
+        ++ [
+          {
+            config.myConfig = {
+              users = [
+                {
+                  name = "testuser";
+                  email = "test@example.com";
+                  fullName = "Test User";
+                  isAdmin = true;
+                  sshIncludes = [];
+                }
+              ];
+              roles.opencode.enable = true;
+              llmClient = {
+                serverHost = "192.168.1.100";
+                serverPort = "11435";
+              };
+            };
+          }
+        ];
+    })
+    .config;
+
+  # Evaluate with NO AI roles enabled - env vars should NOT be set
+  evalWithNoAiRoles =
+    (lib.evalModules {
+      modules =
+        stubModules
+        ++ [
+          {
+            config.myConfig = {
+              users = [
+                {
+                  name = "testuser";
+                  email = "test@example.com";
+                  fullName = "Test User";
+                  isAdmin = true;
+                  sshIncludes = [];
+                }
+              ];
+              roles.developer.enable = true;
+            };
+          }
+        ];
+    })
+    .config;
+
+  opencodeVars = evalWithRole "opencode";
+  claudeVars = evalWithRole "claude";
+  piVars = evalWithRole "pi";
+  customVars = evalWithCustomHost;
+  noAiVars = evalWithNoAiRoles;
+
+  defaultExpectedHost = "127.0.0.1";
+  defaultExpectedPort = "11434";
+  defaultExpectedEndpoint = "http://127.0.0.1:11434";
+in {
+  # Test that LLM_SERVER_HOST and LLM_SERVER_PORT are set when opencode role is enabled
+  llmClientOpencodeTest =
+    pkgs.runCommand "test-llm-client-opencode"
+    {}
+    ''
+      echo "=== Testing llm-client env vars with opencode role ==="
+
+      ${
+        if opencodeVars.environment.variables.LLM_SERVER_HOST or null == defaultExpectedHost
+        then ''echo "  LLM_SERVER_HOST set correctly for opencode: OK"''
+        else ''
+          echo "  FAIL: LLM_SERVER_HOST not set correctly for opencode role"
+          echo "  expected: ${defaultExpectedHost}"
+          echo "  got: ${opencodeVars.environment.variables.LLM_SERVER_HOST or "NOT SET"}"
+          exit 1
+        ''
+      }
+
+      ${
+        if opencodeVars.environment.variables.LLM_SERVER_PORT or null == defaultExpectedPort
+        then ''echo "  LLM_SERVER_PORT set correctly for opencode: OK"''
+        else ''
+          echo "  FAIL: LLM_SERVER_PORT not set correctly for opencode role"
+          echo "  expected: ${defaultExpectedPort}"
+          echo "  got: ${opencodeVars.environment.variables.LLM_SERVER_PORT or "NOT SET"}"
+          exit 1
+        ''
+      }
+
+      ${
+        if opencodeVars.environment.variables.OPENCODE_ENDPOINT or null == defaultExpectedEndpoint
+        then ''echo "  OPENCODE_ENDPOINT set correctly for opencode: OK"''
+        else ''
+          echo "  FAIL: OPENCODE_ENDPOINT not set correctly for opencode role"
+          echo "  expected: ${defaultExpectedEndpoint}"
+          echo "  got: ${opencodeVars.environment.variables.OPENCODE_ENDPOINT or "NOT SET"}"
+          exit 1
+        ''
+      }
+
+      ${
+        if opencodeVars.environment.variables.CLAUDE_API_BASE or null == defaultExpectedEndpoint
+        then ''echo "  CLAUDE_API_BASE set correctly for opencode: OK"''
+        else ''
+          echo "  FAIL: CLAUDE_API_BASE not set correctly for opencode role"
+          echo "  expected: ${defaultExpectedEndpoint}"
+          echo "  got: ${opencodeVars.environment.variables.CLAUDE_API_BASE or "NOT SET"}"
+          exit 1
+        ''
+      }
+
+      echo "All llm-client opencode tests passed"
+      touch $out
+    '';
+
+  # Test that env vars are set when claude role is enabled
+  llmClientClaudeTest =
+    pkgs.runCommand "test-llm-client-claude"
+    {}
+    ''
+      echo "=== Testing llm-client env vars with claude role ==="
+
+      ${
+        if claudeVars.environment.variables.LLM_SERVER_HOST or null == defaultExpectedHost
+        then ''echo "  LLM_SERVER_HOST set correctly for claude: OK"''
+        else ''
+          echo "  FAIL: LLM_SERVER_HOST not set correctly for claude role"
+          exit 1
+        ''
+      }
+
+      ${
+        if claudeVars.environment.variables.LLM_SERVER_PORT or null == defaultExpectedPort
+        then ''echo "  LLM_SERVER_PORT set correctly for claude: OK"''
+        else ''
+          echo "  FAIL: LLM_SERVER_PORT not set correctly for claude role"
+          exit 1
+        ''
+      }
+
+      ${
+        if claudeVars.environment.variables.OPENCODE_ENDPOINT or null == defaultExpectedEndpoint
+        then ''echo "  OPENCODE_ENDPOINT set correctly for claude: OK"''
+        else ''
+          echo "  FAIL: OPENCODE_ENDPOINT not set correctly for claude role"
+          exit 1
+        ''
+      }
+
+      ${
+        if claudeVars.environment.variables.CLAUDE_API_BASE or null == defaultExpectedEndpoint
+        then ''echo "  CLAUDE_API_BASE set correctly for claude: OK"''
+        else ''
+          echo "  FAIL: CLAUDE_API_BASE not set correctly for claude role"
+          exit 1
+        ''
+      }
+
+      echo "All llm-client claude tests passed"
+      touch $out
+    '';
+
+  # Test that LLM_SERVER_HOST and LLM_SERVER_PORT are set when pi role is enabled
+  # (pi does NOT set OPENCODE_ENDPOINT or CLAUDE_API_BASE)
+  llmClientPiTest =
+    pkgs.runCommand "test-llm-client-pi"
+    {}
+    ''
+      echo "=== Testing llm-client env vars with pi role ==="
+
+      ${
+        if piVars.environment.variables.LLM_SERVER_HOST or null == defaultExpectedHost
+        then ''echo "  LLM_SERVER_HOST set correctly for pi: OK"''
+        else ''
+          echo "  FAIL: LLM_SERVER_HOST not set correctly for pi role"
+          exit 1
+        ''
+      }
+
+      ${
+        if piVars.environment.variables.LLM_SERVER_PORT or null == defaultExpectedPort
+        then ''echo "  LLM_SERVER_PORT set correctly for pi: OK"''
+        else ''
+          echo "  FAIL: LLM_SERVER_PORT not set correctly for pi role"
+          exit 1
+        ''
+      }
+
+      echo "All llm-client pi tests passed"
+      touch $out
+    '';
+
+  # Test that custom host/port are reflected in env vars
+  llmClientCustomHostTest =
+    pkgs.runCommand "test-llm-client-custom-host"
+    {}
+    ''
+      echo "=== Testing llm-client with custom serverHost/serverPort ==="
+
+      ${
+        if customVars.environment.variables.LLM_SERVER_HOST or null == "192.168.1.100"
+        then ''echo "  LLM_SERVER_HOST reflects custom host: OK"''
+        else ''
+          echo "  FAIL: LLM_SERVER_HOST should be 192.168.1.100"
+          echo "  got: ${customVars.environment.variables.LLM_SERVER_HOST or "NOT SET"}"
+          exit 1
+        ''
+      }
+
+      ${
+        if customVars.environment.variables.LLM_SERVER_PORT or null == "11435"
+        then ''echo "  LLM_SERVER_PORT reflects custom port: OK"''
+        else ''
+          echo "  FAIL: LLM_SERVER_PORT should be 11435"
+          echo "  got: ${customVars.environment.variables.LLM_SERVER_PORT or "NOT SET"}"
+          exit 1
+        ''
+      }
+
+      ${
+        if customVars.environment.variables.OPENCODE_ENDPOINT or null == "http://192.168.1.100:11435"
+        then ''echo "  OPENCODE_ENDPOINT uses custom host/port: OK"''
+        else ''
+          echo "  FAIL: OPENCODE_ENDPOINT should be http://192.168.1.100:11435"
+          echo "  got: ${customVars.environment.variables.OPENCODE_ENDPOINT or "NOT SET"}"
+          exit 1
+        ''
+      }
+
+      ${
+        if customVars.environment.variables.CLAUDE_API_BASE or null == "http://192.168.1.100:11435"
+        then ''echo "  CLAUDE_API_BASE uses custom host/port: OK"''
+        else ''
+          echo "  FAIL: CLAUDE_API_BASE should be http://192.168.1.100:11435"
+          echo "  got: ${customVars.environment.variables.CLAUDE_API_BASE or "NOT SET"}"
+          exit 1
+        ''
+      }
+
+      echo "All llm-client custom host tests passed"
+      touch $out
+    '';
+
+  # Test that env vars are NOT set when no AI roles are enabled
+  llmClientNoAiRolesTest =
+    pkgs.runCommand "test-llm-client-no-ai-roles"
+    {}
+    ''
+      echo "=== Testing llm-client env vars absent when no AI role enabled ==="
+
+      ${
+        if noAiVars.environment.variables ? LLM_SERVER_HOST
+        then ''
+          echo "  FAIL: LLM_SERVER_HOST should NOT be set when no AI role enabled"
+          exit 1
+        ''
+        else ''echo "  LLM_SERVER_HOST correctly absent: OK"''
+      }
+
+      ${
+        if noAiVars.environment.variables ? LLM_SERVER_PORT
+        then ''
+          echo "  FAIL: LLM_SERVER_PORT should NOT be set when no AI role enabled"
+          exit 1
+        ''
+        else ''echo "  LLM_SERVER_PORT correctly absent: OK"''
+      }
+
+      echo "All llm-client no-ai-roles tests passed"
+      touch $out
+    '';
+}


### PR DESCRIPTION
## Summary
- Create `modules/common/llm-client.nix` with shared LLM server env vars
- Remove duplicate `LLM_SERVER_HOST`/`LLM_SERVER_PORT` from `claude.nix`, `opencode.nix`, `pi.nix`
- Remove duplicate `OPENCODE_ENDPOINT`/`CLAUDE_API_BASE` from `claude.nix`, `opencode.nix`
- Module auto-activates when any AI agent role (claude, opencode, pi) is enabled
- Add `tests/test-llm-client.nix` with 5 BDD-style tests covering all role combinations

## Acceptance Criteria Met
- [x] New `modules/common/llm-client.nix` module created with shared env vars
- [x] Duplicate env var assignments removed from `claude.nix`, `opencode.nix`, `pi.nix`
- [x] Module auto-activates when any AI agent role is active
- [x] `LLM_SERVER_HOST`, `LLM_SERVER_PORT` set from llmClient options
- [x] `OPENCODE_ENDPOINT` and `CLAUDE_API_BASE` set from llmClient options
- [x] `devenv tasks run test:darwin-eval` and `test:nixos-eval` pass

## Testing
- Tests added: `llm-client-opencode`, `llm-client-claude`, `llm-client-pi`, `llm-client-custom-host`, `llm-client-no-ai-roles`
- Local validation: check:lint + test:darwin-eval + test:nixos-eval all pass