### PR TITLE
chore: harden CI workflows with permissions, shared facter stub, and dynamic config discovery

### DIFF
--- a/.github/scripts/create-facter-stub.sh
+++ b/.github/scripts/create-facter-stub.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Creates /etc/nixos/facter.json stub for CI builds
+# Format: https://github.com/nix-community/nixos-facter
+set -euo pipefail
+
+sudo mkdir -p /etc/nixos
+sudo tee /etc/nixos/facter.json > /dev/null << 'FACTER_EOF'
+{
+  "version": 1,
+  "hardware": {
+    "system": { "uuid": "00000000-0000-0000-0000-000000000000" },
+    "cpu": [
+      {
+        "architecture": "x86_64",
+        "vendor_name": "GenuineIntel",
+        "features": ["vmx"]
+      }
+    ],
+    "memory": { "total_bytes": 8589934592 },
+    "disks": [{ "path": "/dev/sda", "size_bytes": 53687091200 }],
+    "network_interfaces": [{ "name": "eth0", "mac": "00:00:00:00:00:00" }],
+    "pci": [],
+    "scsi": []
+  },
+  "boot": { "efi_available": true },
+  "filesystems": [{ "mountpoint": "/", "device": "/dev/sda1", "fs_type": "ext4" }],
+  "virtualisation": "none"
+}
+FACTER_EOF
+echo "facter.json stub created at /etc/nixos/facter.json"

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -13,6 +13,9 @@ on:
   # Weekly ISO builds are handled by weekly-release.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -13,6 +13,9 @@ on:
     # Run weekly on Sundays at 3 AM UTC to prune stale cache entries
     - cron: '0 3 * * 0'
 
+permissions:
+  contents: read
+
 concurrency:
   group: cache-maintenance
   cancel-in-progress: false

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
   workflow_dispatch:
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -80,33 +82,7 @@ jobs:
           name: funkymonkeymonk
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Create stub facter.json
-        run: |
-          # Create stub facter.json for CI builds
-          # Format: https://github.com/nix-community/nixos-facter
-          sudo mkdir -p /etc/nixos
-          sudo tee /etc/nixos/facter.json > /dev/null << 'FACTER_EOF'
-          {
-            "version": 1,
-            "hardware": {
-              "system": { "uuid": "00000000-0000-0000-0000-000000000000" },
-              "cpu": [
-                {
-                  "architecture": "x86_64",
-                  "vendor_name": "GenuineIntel",
-                  "features": ["vmx"]
-                }
-              ],
-              "memory": { "total_bytes": 8589934592 },
-              "disks": [{ "path": "/dev/sda", "size_bytes": 53687091200 }],
-              "network_interfaces": [{ "name": "eth0", "mac": "00:00:00:00:00:00" }],
-              "pci": [],
-              "scsi": []
-            },
-            "boot": { "efi_available": true },
-            "filesystems": [{ "mountpoint": "/", "device": "/dev/sda1", "fs_type": "ext4" }],
-            "virtualisation": "none"
-          }
-          FACTER_EOF
+        run: bash .github/scripts/create-facter-stub.sh
       - name: Discover NixOS configurations
         id: discover
         run: |

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
+permissions:
+  contents: read
+  pull-requests: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -99,33 +102,7 @@ jobs:
             drv-${{ github.ref }}-
             drv-main-
       - name: Create stub facter.json
-        run: |
-          # Create stub facter.json for NixOS configs that use nixos-facter
-          # Format: https://github.com/nix-community/nixos-facter
-          sudo mkdir -p /etc/nixos
-          sudo tee /etc/nixos/facter.json > /dev/null << 'FACTER_EOF'
-          {
-            "version": 1,
-            "hardware": {
-              "system": { "uuid": "00000000-0000-0000-0000-000000000000" },
-              "cpu": [
-                {
-                  "architecture": "x86_64",
-                  "vendor_name": "GenuineIntel",
-                  "features": ["vmx"]
-                }
-              ],
-              "memory": { "total_bytes": 8589934592 },
-              "disks": [{ "path": "/dev/sda", "size_bytes": 53687091200 }],
-              "network_interfaces": [{ "name": "eth0", "mac": "00:00:00:00:00:00" }],
-              "pci": [],
-              "scsi": []
-            },
-            "boot": { "efi_available": true },
-            "filesystems": [{ "mountpoint": "/", "device": "/dev/sda1", "fs_type": "ext4" }],
-            "virtualisation": "none"
-          }
-          FACTER_EOF
+        run: bash .github/scripts/create-facter-stub.sh
       - name: Discover configurations
         id: discover
         run: |
@@ -197,11 +174,14 @@ jobs:
               DARWIN_CHANGED=$(printf '%s\n' "${DARWIN_CHANGED_CONFIGS[@]}" | jq -R . | jq -s .)
             fi
           else
-            # No cache exists, build all configs
-            echo "No cache found, will build all Darwin configs"
-            DARWIN_CHANGED='["core","darwin-server","wweaver"]'
+            # No cache exists, discover configs dynamically
+            echo "No cache found, discovering Darwin configs dynamically..."
+            DARWIN_CHANGED=$(nix eval .#darwinConfigurations \
+              --apply 'x: builtins.attrNames x' --json 2>/dev/null || echo '[]')
           fi
-          echo "darwin-changed=$DARWIN_CHANGED" >> $GITHUB_OUTPUT
+          echo "darwin-changed<<EOF" >> $GITHUB_OUTPUT
+          echo "$DARWIN_CHANGED" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
           echo "Darwin configs needing rebuild: $DARWIN_CHANGED"
           # Check NixOS configs
           NIXOS_CHANGED="[]"
@@ -223,11 +203,15 @@ jobs:
               NIXOS_CHANGED=$(printf '%s\n' "${NIXOS_CHANGED_CONFIGS[@]}" | jq -R . | jq -s .)
             fi
           else
-            # No cache exists, build all configs
-            echo "No cache found, will build all NixOS configs"
-            NIXOS_CHANGED='["bootstrap","installer-iso","type-desktop","type-server","zero"]'
+            # No cache exists, discover configs dynamically (exclude ARM - can't build on x86_64)
+            echo "No cache found, discovering NixOS configs dynamically..."
+            ALL_NIXOS=$(nix eval --impure .#nixosConfigurations \
+              --apply 'x: builtins.attrNames x' --json 2>/dev/null || echo '[]')
+            NIXOS_CHANGED=$(echo "$ALL_NIXOS" | jq '[.[] | select(test("-arm$") | not)]')
           fi
-          echo "nixos-changed=$NIXOS_CHANGED" >> $GITHUB_OUTPUT
+          echo "nixos-changed<<EOF" >> $GITHUB_OUTPUT
+          echo "$NIXOS_CHANGED" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
           echo "NixOS configs needing rebuild: $NIXOS_CHANGED"
           # Save current config lists to staging
           echo '${{ steps.discover.outputs.darwin-configs }}' > .drv-cache-staging/darwin-configs
@@ -301,33 +285,7 @@ jobs:
           name: funkymonkeymonk
           skipPush: true
       - name: Create stub facter.json
-        run: |
-          # Create stub facter.json for CI builds
-          # Format: https://github.com/nix-community/nixos-facter
-          sudo mkdir -p /etc/nixos
-          sudo tee /etc/nixos/facter.json > /dev/null << 'FACTER_EOF'
-          {
-            "version": 1,
-            "hardware": {
-              "system": { "uuid": "00000000-0000-0000-0000-000000000000" },
-              "cpu": [
-                {
-                  "architecture": "x86_64",
-                  "vendor_name": "GenuineIntel",
-                  "features": ["vmx"]
-                }
-              ],
-              "memory": { "total_bytes": 8589934592 },
-              "disks": [{ "path": "/dev/sda", "size_bytes": 53687091200 }],
-              "network_interfaces": [{ "name": "eth0", "mac": "00:00:00:00:00:00" }],
-              "pci": [],
-              "scsi": []
-            },
-            "boot": { "efi_available": true },
-            "filesystems": [{ "mountpoint": "/", "device": "/dev/sda1", "fs_type": "ext4" }],
-            "virtualisation": "none"
-          }
-          FACTER_EOF
+        run: bash .github/scripts/create-facter-stub.sh
       - name: Build ${{ matrix.config }}
         id: build
         run: |

--- a/tests/test-ci-workflows.sh
+++ b/tests/test-ci-workflows.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+assert() {
+  local desc="$1"
+  local cmd="$2"
+  if eval "$cmd" 2>/dev/null; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== CI Workflow Tests ==="
+
+# Test: all 4 workflows have permissions blocks
+for wf in build-iso.yml cache-maintenance.yml main-build.yml pr-validation.yml; do
+  assert "$wf has permissions block" \
+    "grep -q '^permissions:' '$REPO_ROOT/.github/workflows/$wf'"
+done
+
+# Test: shared facter stub script exists and is executable
+assert "facter stub script exists" \
+  "test -f '$REPO_ROOT/.github/scripts/create-facter-stub.sh'"
+assert "facter stub script is executable" \
+  "test -x '$REPO_ROOT/.github/scripts/create-facter-stub.sh'"
+
+# Test: no hardcoded config lists remain in pr-validation.yml
+assert "no hardcoded darwin list" \
+  "! grep -q 'DARWIN_CHANGED=.*core.*darwin-server.*wweaver' \
+  '$REPO_ROOT/.github/workflows/pr-validation.yml'"
+assert "no hardcoded nixos list" \
+  "! grep -q 'NIXOS_CHANGED=.*bootstrap.*installer-iso.*type-server' \
+  '$REPO_ROOT/.github/workflows/pr-validation.yml'"
+
+# Test: pr-validation uses dynamic discovery
+assert "pr-validation uses nix eval for darwin" \
+  "grep -q 'nix eval.*darwinConfigurations' \
+  '$REPO_ROOT/.github/workflows/pr-validation.yml'"
+assert "pr-validation uses nix eval for nixos" \
+  "grep -q 'nix eval.*nixosConfigurations' \
+  '$REPO_ROOT/.github/workflows/pr-validation.yml'"
+
+# Test: inline facter stubs are replaced with script calls in pr-validation.yml
+assert "pr-validation calls facter stub script (not inline)" \
+  "grep -q 'bash .github/scripts/create-facter-stub.sh' \
+  '$REPO_ROOT/.github/workflows/pr-validation.yml'"
+
+# Test: inline facter stub replaced with script call in main-build.yml
+assert "main-build calls facter stub script (not inline)" \
+  "grep -q 'bash .github/scripts/create-facter-stub.sh' \
+  '$REPO_ROOT/.github/workflows/main-build.yml'"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary
- Add least-privilege `permissions:` blocks to 4 workflows missing them
- Extract duplicated facter.json stub to shared `.github/scripts/create-facter-stub.sh`
- Replace hardcoded fallback config lists in pr-validation.yml with dynamic `nix eval` discovery

## Yaks Addressed
- Add explicit permissions blocks to all CI workflows
- Extract facter.json stub to shared CI script
- Replace hardcoded config fallback lists in pr-validation.yml

## Testing
- `tests/test-ci-workflows.sh` added (bash structural tests, 12 assertions)
- Local: `devenv tasks run check:lint` passed
- All 12 tests pass locally

## Changes Detail

### Yak 1: permissions blocks
Added `permissions: contents: read` to `build-iso.yml`, `cache-maintenance.yml`, `main-build.yml`.
Added `permissions: contents: read / pull-requests: read` to `pr-validation.yml`.

### Yak 2: shared facter stub
Created `.github/scripts/create-facter-stub.sh` with the JSON content that was copy-pasted in 3 places. Replaced all 3 inline stubs with `bash .github/scripts/create-facter-stub.sh`.

### Yak 3: dynamic config discovery
Replaced hardcoded `["core","darwin-server","wweaver"]` and `["bootstrap","installer-iso","type-desktop","type-server","zero"]` fallback lists with dynamic `nix eval .#darwinConfigurations` / `nix eval --impure .#nixosConfigurations` discovery, matching what `main-build.yml` already does.