### PR TITLE
chore: replace types.attrs with types.attrsOf types.anything in options.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -780,6 +780,7 @@
             llm-client-custom-host
             llm-client-no-ai-roles
             entertainment-nixos
+            typed-attrs-options
             ;
         }
         // nixpkgs.lib.optionalAttrs isLinux {

--- a/modules/common/options.nix
+++ b/modules/common/options.nix
@@ -678,7 +678,7 @@ with lib; {
         };
 
         settings = mkOption {
-          type = types.attrs;
+          type = types.attrsOf types.anything;
           default = {};
           description = ''
             Mods configuration written to $XDG_CONFIG_HOME/mods/mods.yml.
@@ -1032,7 +1032,7 @@ with lib; {
       };
 
       extraSettings = mkOption {
-        type = types.attrs;
+        type = types.attrsOf types.anything;
         default = {};
         description = "Additional Claude Code settings";
       };
@@ -1102,7 +1102,7 @@ with lib; {
       };
 
       settings = mkOption {
-        type = types.attrs;
+        type = types.attrsOf types.anything;
         default = {};
         description = ''
           Pi settings.json configuration.
@@ -1209,7 +1209,7 @@ with lib; {
       };
 
       themes = mkOption {
-        type = types.attrsOf types.attrs;
+        type = types.attrsOf (types.attrsOf types.anything);
         default = {};
         description = ''
           Custom themes as attribute set.

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -17,6 +17,7 @@
   testWorkspaceSwitch = import ./test-workspace-switch.nix {inherit pkgs;};
   testMicrovm = import ./test-microvm.nix {inherit pkgs;};
   testLlmClient = import ./test-llm-client.nix {inherit pkgs;};
+  testNixosModules = import ./test-nixos-modules.nix {inherit pkgs;};
 
   # VM tests only available on x86_64-linux (NixOS testing framework)
   inherit (pkgs.stdenv.hostPlatform) isLinux;
@@ -122,5 +123,8 @@ in
     llm-client-pi = testLlmClient.llmClientPiTest;
     llm-client-custom-host = testLlmClient.llmClientCustomHostTest;
     llm-client-no-ai-roles = testLlmClient.llmClientNoAiRolesTest;
+
+    # NixOS module option tests
+    typed-attrs-options = testNixosModules.typedAttrsOptionsTest;
   }
   // vmTests

--- a/tests/test-nixos-modules.nix
+++ b/tests/test-nixos-modules.nix
@@ -1,0 +1,105 @@
+# Tests for NixOS module options
+# Verifies typed attrset options accept expected value types
+{pkgs, ...}: let
+  inherit (pkgs) lib;
+
+  # Stubs for evaluating options.nix in isolation (no platform-specific modules)
+  baseStubs = [
+    ../modules/common/options.nix
+    {
+      options.nixpkgs.hostPlatform = lib.mkOption {
+        type = lib.types.anything;
+        default = {inherit (pkgs.stdenv.hostPlatform) system;};
+      };
+      config._module.args = {inherit pkgs;};
+      config.myConfig.users = [
+        {
+          name = "testuser";
+          email = "test@example.com";
+          fullName = "Test User";
+          isAdmin = true;
+          sshIncludes = [];
+        }
+      ];
+    }
+  ];
+
+  # Evaluate options.nix with attrsOf anything values for the typed options
+  typedAttrsEval =
+    (lib.evalModules {
+      modules =
+        baseStubs
+        ++ [
+          {
+            config.myConfig.charm.mods.settings = {
+              some_key = "value";
+              nested = {key = 42;};
+            };
+            config.myConfig.claude-code.extraSettings = {
+              theme = "dark";
+              autoApprove = true;
+            };
+            config.myConfig.pi.settings = {
+              model = "gpt-4o";
+              maxTokens = 4096;
+            };
+            config.myConfig.pi.themes = {
+              dark = {
+                background = "#000000";
+                foreground = "#ffffff";
+              };
+            };
+          }
+        ];
+    })
+    .config;
+in {
+  # Test: types.attrsOf types.anything options accept arbitrary attrsets
+  # Verifies that mods.settings, claude-code.extraSettings, pi.settings, and
+  # pi.themes accept nested attrset values without type errors.
+  typedAttrsOptionsTest =
+    pkgs.runCommand "test-typed-attrs-options"
+    {}
+    ''
+      echo "=== Testing typed attrset options ==="
+
+      ${
+        if typedAttrsEval.myConfig.charm.mods.settings.some_key == "value"
+        then ''echo "  mods.settings accepts string value: OK"''
+        else ''
+          echo "  FAIL: mods.settings value mismatch"
+          exit 1
+        ''
+      }
+
+      ${
+        if typedAttrsEval.myConfig.claude-code.extraSettings.theme == "dark"
+        then ''echo "  claude-code.extraSettings accepts string value: OK"''
+        else ''
+          echo "  FAIL: claude-code.extraSettings value mismatch"
+          exit 1
+        ''
+      }
+
+      ${
+        if typedAttrsEval.myConfig.pi.settings.model == "gpt-4o"
+        then ''echo "  pi.settings accepts string value: OK"''
+        else ''
+          echo "  FAIL: pi.settings value mismatch"
+          exit 1
+        ''
+      }
+
+      ${
+        if typedAttrsEval.myConfig.pi.themes.dark.background == "#000000"
+        then ''echo "  pi.themes accepts nested attrset: OK"''
+        else ''
+          echo "  FAIL: pi.themes value mismatch"
+          exit 1
+        ''
+      }
+
+      echo "All typed attrset option tests passed"
+      touch $out
+    '';
+}


### PR DESCRIPTION
## Summary

- Replace 4 untyped `types.attrs` usages with `types.attrsOf types.anything`
- Affected options: `charm.mods.settings`, `claude-code.extraSettings`, `pi.settings`, `pi.themes`
- Documents intent and improves error messages for type mismatches

## Testing

- Added `typed-attrs-options` eval test
- `devenv tasks run check:lint` passes
- `devenv tasks run test:darwin-eval` passes
- `devenv tasks run test:nixos-eval` passes