### PR TITLE
chore: document installer implementations with purpose comments

### DIFF
--- a/packages/installer/default.nix
+++ b/packages/installer/default.nix
@@ -1,3 +1,29 @@
+# Purpose: Standalone `nix run` installer for bootstrapping NixOS from any machine.
+#
+# Invoked via: nix run github:funkymonkeymonk/nix#installer
+#
+# This is a SEPARATE implementation from targets/installer-iso/installer.nix.
+# The two installers serve different use cases:
+#
+#   packages/installer/ (THIS FILE)
+#   ─────────────────────────────────────────────────────────────────────────────
+#   • Delivery:  Standalone package/app — no ISO required
+#   • Interface: Plain bash (read/echo) — no external TUI tools (no gum)
+#   • Disk setup: Interactive guidance only — does NOT auto-partition
+#   • Workflow:   Two-stage — installs bootstrap first, then instructs user to
+#                 apply full config on next boot
+#   • Use when:  You already have a running NixOS Live USB / existing system and
+#                want to quickly apply this flake without building a custom ISO
+#
+#   targets/installer-iso/installer.nix
+#   ─────────────────────────────────────────────────────────────────────────────
+#   • Delivery:  Bundled inside the custom installer ISO image
+#   • Interface: Rich TUI via gum (styled prompts, spinners, confirmation dialogs)
+#   • Disk setup: Automated with disko — partitions and formats the disk for you
+#   • Workflow:   All-in-one — partitions, formats, and installs in a single run
+#   • Use when:  Installing on bare metal from the custom ISO
+#
+# References in flake.nix: packages.installer, apps.installer
 {pkgs, ...}:
 pkgs.writeScriptBin "nixos-flake-installer" ''
   #!${pkgs.bash}/bin/bash

--- a/targets/installer-iso/installer.nix
+++ b/targets/installer-iso/installer.nix
@@ -1,3 +1,32 @@
+# Purpose: ISO-bundled installer script for the custom NixOS installer image.
+#
+# Invoked automatically on TTY1 when booting from the installer ISO, or via
+# the dev-mode wrapper (nixos-installer-dev-mode) which can pull a fresh copy
+# from a specific git branch for testing.
+#
+# This is a SEPARATE implementation from packages/installer/default.nix.
+# The two installers serve different use cases:
+#
+#   targets/installer-iso/installer.nix (THIS FILE)
+#   ─────────────────────────────────────────────────────────────────────────────
+#   • Delivery:  Bundled inside the custom installer ISO (packages.iso)
+#   • Interface: Rich TUI via gum (styled prompts, spinners, confirmation dialogs)
+#   • Disk setup: Automated with disko — partitions and formats the disk for you
+#   • Network:   Prefers remote flake; falls back to the copy bundled on the ISO
+#   • Workflow:   All-in-one — partitions, formats, and installs in a single run
+#   • Use when:  Installing on bare metal from the custom ISO
+#
+#   packages/installer/ (standalone app)
+#   ─────────────────────────────────────────────────────────────────────────────
+#   • Delivery:  Standalone — run with `nix run github:funkymonkeymonk/nix#installer`
+#   • Interface: Plain bash (read/echo) — no external TUI tools required
+#   • Disk setup: Interactive guidance only — does NOT auto-partition
+#   • Workflow:   Two-stage — installs bootstrap first, then instructs user to
+#                 apply full config on next boot
+#   • Use when:  You already have a running NixOS Live USB / existing system
+#
+# References in flake.nix: nixosConfigurations.installer-iso → targets/installer-iso/default.nix
+#                           which includes this file via nixpkgs.config.packageOverrides
 {pkgs, ...}:
 pkgs.writeScriptBin "nixos-installer-iso" ''
     #!${pkgs.bash}/bin/bash

--- a/tests/test-installer.sh
+++ b/tests/test-installer.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Tests for installer consolidation audit
+# Verifies that both installer implementations exist and have clear purpose comments.
+#
+# Context: Two separate installers serve distinct purposes:
+#   1. packages/installer/ — standalone `nix run` installer (plain bash, no gum)
+#   2. targets/installer-iso/installer.nix — ISO-bundled installer (gum TUI, disko)
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0; FAIL=0
+
+assert() {
+  local desc="$1" cmd="$2"
+  if eval "$cmd" 2>/dev/null; then echo "  PASS: $desc"; PASS=$((PASS+1))
+  else echo "  FAIL: $desc"; FAIL=$((FAIL+1)); fi
+}
+
+echo "=== Installer consolidation tests ==="
+
+# Both implementations must exist (they serve different purposes)
+assert "packages/installer/default.nix exists" \
+  "test -f '$REPO_ROOT/packages/installer/default.nix'"
+
+assert "targets/installer-iso/installer.nix exists" \
+  "test -f '$REPO_ROOT/targets/installer-iso/installer.nix'"
+
+# Each file must have a purpose comment explaining why it exists separately
+assert "packages/installer/default.nix has purpose comment" \
+  "grep -q '# Purpose:' '$REPO_ROOT/packages/installer/default.nix'"
+
+assert "targets/installer-iso/installer.nix has purpose comment" \
+  "grep -q '# Purpose:' '$REPO_ROOT/targets/installer-iso/installer.nix'"
+
+# The standalone package produces nixos-flake-installer binary name
+assert "packages/installer produces nixos-flake-installer binary" \
+  "grep -q 'writeScriptBin.*nixos-flake-installer' '$REPO_ROOT/packages/installer/default.nix'"
+
+# The ISO installer produces nixos-installer-iso binary name
+assert "targets/installer-iso/installer.nix produces nixos-installer-iso binary" \
+  "grep -q 'writeScriptBin.*nixos-installer-iso' '$REPO_ROOT/targets/installer-iso/installer.nix'"
+
+# flake.nix references both correctly
+assert "flake.nix references packages/installer for standalone app" \
+  "grep -q 'packages/installer' '$REPO_ROOT/flake.nix'"
+
+assert "flake.nix references installer-iso NixOS config" \
+  "grep -q 'installer-iso' '$REPO_ROOT/flake.nix'"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Audited both installer implementations and determined they serve **distinct, complementary purposes** — neither is redundant.

**`packages/installer/default.nix`** (`nixos-flake-installer`):
- Standalone app — invoked via `nix run github:funkymonkeymonk/nix#installer`
- Plain bash (no gum), interactive text prompts
- Two-stage workflow: installs bootstrap config, then guides user to apply full config on next boot
- Works from any running NixOS live USB or existing NixOS system

**`targets/installer-iso/installer.nix`** (`nixos-installer-iso`):
- Bundled inside the custom ISO image — auto-runs on TTY1 at boot
- Rich TUI via gum (styled prompts, spinners, confirmation dialogs)
- Automated disk partitioning with disko
- Network-aware with local flake fallback for offline installs
- All-in-one bare-metal installation experience

**Changes made:**
- Added a `# Purpose:` comment block to each file documenting its role and contrasting it with the other
- Added `tests/test-installer.sh` to verify both files exist and carry clear documentation

## Testing
- `tests/test-installer.sh` passes (8/8)
- `devenv tasks run check:lint` passes
- Both Nix files parse cleanly (`nix eval --file`)