### PR TITLE
chore: move inline machine config from flake.nix to targets/

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -129,7 +129,7 @@
     mkMicrovm = name: roleEnables:
       nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
-        specialArgs = inputs;
+        specialArgs = inputs // {inherit roleEnables;};
         modules = [
           microvm.nixosModules.microvm
           home-manager.nixosModules.home-manager
@@ -141,31 +141,9 @@
           ./modules/services/openclaw
           ./os/microvm.nix
           ./modules/microvm
+          ./targets/microvms/defaults.nix
           ./targets/microvms/${name}.nix
           {home-manager.sharedModules = [opnix.homeManagerModules.default];}
-          {
-            nixpkgs.hostPlatform = "x86_64-linux";
-            myConfig =
-              {
-                skills = {
-                  superpowersPath = inputs.superpowers;
-                  externalInputs = {
-                    inherit (inputs) vercel-skills;
-                  };
-                };
-                users = [
-                  {
-                    name = "dev";
-                    email = "dev@localhost";
-                    fullName = "Development User";
-                    isAdmin = true;
-                    sshIncludes = [];
-                  }
-                ];
-                onepassword.enable = nixpkgs.lib.mkForce false;
-              }
-              // roleEnables;
-          }
         ];
       };
   in {
@@ -225,6 +203,7 @@
 
     darwinConfigurations = {
       "wweaver" = nix-darwin.lib.darwinSystem {
+        specialArgs = {inherit inputs mkUser;};
         modules = [
           configuration
           nix-homebrew.darwinModules.nix-homebrew
@@ -237,167 +216,13 @@
           ./targets/wweaver
           home-manager.darwinModules.home-manager
           {home-manager.sharedModules = [opnix.homeManagerModules.default];}
-          {
-            nixpkgs.hostPlatform = "aarch64-darwin";
-            system.stateVersion = 4;
-            system.primaryUser = "wweaver";
-
-            myConfig =
-              mkUser "wweaver" "wweaver@justworks.com"
-              // {
-                skills = {
-                  superpowersPath = inputs.superpowers;
-                  externalInputs = {
-                    inherit (inputs) vercel-skills;
-                  };
-                };
-                onepassword.sudoPasswordRef = "op://Employee/wweaver Sudo Password/password";
-                roles = {
-                  developer.enable = true;
-                  desktop.enable = true;
-                  workstation.enable = true;
-                  entertainment.enable = true;
-                  llm-host.enable = true;
-                  opencode.enable = true;
-                  pi.enable = true;
-                  homebrew.enable = true;
-                };
-                ollama = {
-                  # Bind to all interfaces so Docker containers can access Ollama
-                  host = "0.0.0.0";
-                };
-                vane = {
-                  enable = true;
-                  autoStart = true;
-                  # Local Ollama for fast local models
-                  ollamaUrl = "http://host.docker.internal:11434";
-                  # LiteLLM for external/cloud models - configure via web UI
-                  openaiBaseUrl = "https://litellm.justworksai.net";
-                  # Embedded SearxNG for web search
-                  embeddedSearxng = true;
-                  # Chat model (balanced speed/quality)
-                  defaultModel = "qwen3.5";
-                  # Embedding model for vector search
-                  embeddingModel = "nomic-embed-text";
-                  # Good resources for M4 Pro (14 cores, 48GB RAM)
-                  colima = {
-                    cpu = 6;
-                    memory = 12;
-                    disk = 60;
-                  };
-                };
-                opencode = {
-                  enable = true;
-                  model = "just-llms/claude-sonnet-4-6";
-                  disabledProviders = ["opencode"];
-                  extraMcpServers = {
-                    github = {
-                      type = "remote";
-                      url = "https://api.githubcopilot.com/mcp/";
-                      enabled = false;
-                    };
-                    jira = {
-                      type = "remote";
-                      url = "https://mcp.atlassian.com/v1/mcp";
-                      enabled = false;
-                    };
-                    confluence = {
-                      type = "remote";
-                      url = "https://mcp.atlassian.com/v1/mcp";
-                      enabled = false;
-                    };
-                  };
-                  commands = {
-                    diataxis = {
-                      description = "Audit and rewrite documentation using the Diataxis framework";
-                      template = ''
-                        Load the diataxis-docs skill and use it to audit and restructure the documentation in this project.
-
-                        Follow the Diataxis framework to organize content into:
-                        - Tutorials (learning-oriented)
-                        - How-to guides (goal-oriented)
-                        - Reference (information-oriented)
-                        - Explanation (understanding-oriented)
-
-                        $ARGUMENTS
-                      '';
-                    };
-                    workspace = {
-                      description = "Create a jj workspace for isolated work with fast sync enabled";
-                      template = ''
-                        Create a jj workspace session for isolated development work.
-
-                        Run this command:
-                        ```bash
-                        jj-workspace-session start $ARGUMENTS
-                        ```
-
-                        Then report the workspace name and path to the user, and cd into the workspace directory.
-
-                        If no arguments provided, this starts session tracking in the current workspace.
-                        If a name is provided (e.g., "feat/auth" or "fix/bug"), it creates a new workspace.
-                        A second argument can specify the base branch (defaults to main).
-
-                        Examples:
-                        - /workspace feat/user-auth      -> Creates feat/user-auth-<date>-<id> from main
-                        - /workspace fix/bug develop     -> Creates fix/bug-<date>-<id> from develop
-                        - /workspace                     -> Starts session in current workspace
-                      '';
-                    };
-                  };
-                  providers = {
-                    just-llms = {
-                      npm = "@ai-sdk/openai-compatible";
-                      name = "Just LLMs";
-                      baseURL = "https://litellm.justworksai.net";
-                      onePasswordItem = "op://Justworks/Justworks LiteLLM/wweaver-poweruser-key";
-                      dynamicModels = true;
-                      models = {
-                        "us.anthropic.claude-opus-4-5-20251101-v1:0" = {
-                          name = "Claude Opus 4.5 (Bedrock)";
-                        };
-                      };
-                    };
-                    ollama = {
-                      npm = "@ai-sdk/openai-compatible";
-                      name = "Ollama (local)";
-                      baseURL = "http://localhost:11434/v1";
-                      models = {
-                        "qwen3.5:latest" = {name = "Qwen 3.5 (7B)";};
-                        "qwen3.5:2b" = {name = "Qwen 3.5 (2B)";};
-                      };
-                    };
-                  };
-                };
-                claude-code = {
-                  enable = false;
-                  mcpServers = {
-                    github = {
-                      type = "remote";
-                      url = "https://api.githubcopilot.com/mcp/";
-                      enabled = true;
-                    };
-                    jira = {
-                      type = "remote";
-                      url = "https://mcp.atlassian.com/v1/mcp";
-                      enabled = false;
-                    };
-                    confluence = {
-                      type = "remote";
-                      url = "https://mcp.atlassian.com/v1/mcp";
-                      enabled = false;
-                    };
-                  };
-                };
-                llmClient.rtk.enable = true;
-              };
-          }
         ];
       };
 
       # Darwin server - headless macOS server for VM hosting
       # Uses Lume for macOS VMs, no local LLMs
       "darwin-server" = nix-darwin.lib.darwinSystem {
+        specialArgs = {inherit inputs mkUser;};
         modules = [
           configuration
           ./modules
@@ -406,26 +231,6 @@
           ./targets/darwin-server
           home-manager.darwinModules.home-manager
           {home-manager.sharedModules = [opnix.homeManagerModules.default];}
-          {
-            nixpkgs.hostPlatform = "aarch64-darwin";
-            system.stateVersion = 4;
-            system.primaryUser = "monkey";
-            myConfig =
-              mkUser "monkey" "me@willweaver.dev"
-              // {
-                skills.superpowersPath = inputs.superpowers;
-                roles = {
-                  developer.enable = true;
-                  opencode.enable = true;
-                };
-                opencode = {
-                  enable = true;
-                  # Use remote LLM APIs since no local Ollama
-                  model = null; # User will select on first run
-                };
-                llmClient.rtk.enable = true;
-              };
-          }
         ];
       };
 
@@ -437,22 +242,12 @@
           ./modules/common/core.nix
           ./modules/common/options.nix
           ./targets/core
-          (_: {
-            nixpkgs.hostPlatform = "aarch64-darwin";
-            system.stateVersion = 4;
-            nix.enable = false;
-            myConfig = {
-              users = [];
-              agent-skills.enable = false;
-              onepassword.enable = false;
-              opencode.enable = false;
-            };
-          })
         ];
       };
 
       # MegamanX - personal desktop/workstation
       "MegamanX" = nix-darwin.lib.darwinSystem {
+        specialArgs = {inherit inputs mkUser;};
         modules = [
           configuration
           nix-homebrew.darwinModules.nix-homebrew
@@ -465,41 +260,6 @@
           ./targets/MegamanX
           home-manager.darwinModules.home-manager
           {home-manager.sharedModules = [opnix.homeManagerModules.default];}
-          {
-            nixpkgs.hostPlatform = "aarch64-darwin";
-            system.stateVersion = 4;
-            system.primaryUser = "monkey";
-
-            myConfig =
-              mkUser "monkey" "me@willweaver.dev"
-              // {
-                skills.superpowersPath = inputs.superpowers;
-                roles = {
-                  developer.enable = true;
-                  desktop.enable = true;
-                  workstation.enable = true;
-                  entertainment.enable = true;
-                  llm-host.enable = true;
-                  opencode.enable = true;
-                  pi.enable = true;
-                  homebrew.enable = true;
-                };
-                ollama = {
-                  # Bind to all interfaces so Docker containers can access Ollama
-                  host = "0.0.0.0";
-                };
-                vane = {
-                  enable = true;
-                  # Uses default Ollama URL (host.docker.internal:11434)
-                  # Enable embedded SearxNG for web search
-                  embeddedSearxng = true;
-                  # Chat model - deepseek for reasoning tasks
-                  defaultModel = "deepseek-r1:14b";
-                  # Embedding model for vector search
-                  embeddingModel = "nomic-embed-text";
-                };
-              };
-          }
         ];
       };
     };
@@ -522,7 +282,7 @@
 
       "zero" = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
-        specialArgs = {inherit inputs;};
+        specialArgs = {inherit inputs mkUser;};
         modules = [
           configuration
           ./modules
@@ -536,32 +296,6 @@
           ./targets/zero
           home-manager.nixosModules.home-manager
           {home-manager.sharedModules = [opnix.homeManagerModules.default];}
-          {
-            nixpkgs.hostPlatform = "x86_64-linux";
-            system.stateVersion = "25.05";
-            myConfig =
-              mkUser "monkey" "me@willweaver.dev"
-              // {
-                skills.superpowersPath = inputs.superpowers;
-                roles = {
-                  developer.enable = true;
-                  desktop.enable = true;
-                  opencode.enable = true;
-                };
-                desktop = {
-                  enable = true;
-                  autoLoginUser = "monkey";
-                };
-                gaming.enable = true;
-                streaming.enable = true;
-                llmEndpoints = {
-                  MegamanX = {
-                    host = "MegamanX.local";
-                    port = "4000";
-                  };
-                };
-              };
-          }
         ];
       };
 
@@ -571,7 +305,7 @@
 
       "type-desktop" = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
-        specialArgs = inputs;
+        specialArgs = inputs // {inherit inputs;};
         modules = [
           configuration
           ./modules
@@ -583,26 +317,12 @@
           inputs.disko.nixosModules.disko
           ./disk-configs/single-disk-ext4.nix
 
-          # Machine type configuration
+          # Machine type configuration (includes myConfig defaults and SSH keys)
           ./machine-types/desktop.nix
-
-          {
-            myConfig = {
-              skills.superpowersPath = inputs.superpowers;
-              autoUpgrade.flakeUrl = "github:funkymonkeymonk/nix#type-desktop";
-            };
-          }
 
           # Ghostty terminfo for SSH support
           # https://github.com/ghostty-org/ghostty/discussions/5753
           ./modules/nixos/ghostty-terminfo.nix
-
-          # SSH key for initial access (replace with your key)
-          {
-            users.users.root.openssh.authorizedKeys.keys = [
-              "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIIxGvpCUmx1UV3K22/+sWLdRknZmlTmQgckoAUCApF8 monkey@MegamanX"
-            ];
-          }
         ];
       };
 
@@ -610,7 +330,7 @@
       # Minimal required fields: system architecture, SSH authorized keys
       "type-server" = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
-        specialArgs = inputs;
+        specialArgs = inputs // {inherit inputs;};
         modules = [
           configuration
           microvm.nixosModules.microvm
@@ -626,37 +346,16 @@
           # Hardware detection via nixos-facter (module is in nixpkgs)
           # The facter.json file should be generated on the target machine
           # CI builds use --impure with a stub file
-          {
-            hardware.facter.reportPath = "/etc/nixos/facter.json";
-            myConfig = {
-              skills.superpowersPath = inputs.superpowers;
-              autoUpgrade.flakeUrl = "github:funkymonkeymonk/nix#type-server";
-            };
-          }
 
-          # Machine type configuration
+          # Machine type configuration (includes myConfig, hardware.facter, SSH keys)
           ./machine-types/server.nix
-
-          # REQUIRED: Configure at least one user with SSH access
-          {
-            users.users.root.openssh.authorizedKeys.keys = []; # Root SSH disabled
-            users.users.monkey = {
-              isNormalUser = true;
-              extraGroups = ["wheel"];
-              useDefaultShell = true;
-              openssh.authorizedKeys.keys = [
-                # MegamanX deploy key
-                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIIxGvpCUmx1UV3K22/+sWLdRknZmlTmQgckoAUCApF8 monkey@MegamanX"
-              ];
-            };
-          }
         ];
       };
 
       # ARM64 server variant
       "type-server-arm" = nixpkgs.lib.nixosSystem {
         system = "aarch64-linux";
-        specialArgs = inputs;
+        specialArgs = inputs // {inherit inputs;};
         modules = [
           configuration
           microvm.nixosModules.microvm
@@ -668,27 +367,8 @@
           inputs.disko.nixosModules.disko
           ./disk-configs/single-disk-ext4.nix
 
-          {
-            hardware.facter.reportPath = "/etc/nixos/facter.json";
-            myConfig = {
-              skills.superpowersPath = inputs.superpowers;
-              autoUpgrade.flakeUrl = "github:funkymonkeymonk/nix#type-server-arm";
-            };
-          }
-
-          ./machine-types/server.nix
-
-          {
-            users.users.root.openssh.authorizedKeys.keys = [];
-            users.users.monkey = {
-              isNormalUser = true;
-              extraGroups = ["wheel"];
-              useDefaultShell = true;
-              openssh.authorizedKeys.keys = [
-                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIIxGvpCUmx1UV3K22/+sWLdRknZmlTmQgckoAUCApF8 monkey@MegamanX"
-              ];
-            };
-          }
+          # Machine type configuration (includes myConfig, hardware.facter, SSH keys)
+          ./machine-types/server-arm.nix
         ];
       };
     };

--- a/machine-types/desktop.nix
+++ b/machine-types/desktop.nix
@@ -1,12 +1,17 @@
 # Generic desktop configuration for gaming/workstations
 # Uses nixos-facter for automatic hardware detection
 # No hardware-configuration.nix required!
-{...}: {
+{inputs, ...}: {
   imports = [
     # Hardware detection - replaces hardware-configuration.nix
     # This is populated automatically during installation
     # { hardware.facter.reportPath = ./facter.json; }
   ];
+
+  myConfig = {
+    skills.superpowersPath = inputs.superpowers;
+    autoUpgrade.flakeUrl = "github:funkymonkeymonk/nix#type-desktop";
+  };
 
   # Allow unfree packages (Steam, NVIDIA drivers, etc.)
   nixpkgs.config.allowUnfree = true;
@@ -62,6 +67,11 @@
       PasswordAuthentication = false;
     };
   };
+
+  # SSH keys for initial access (replace with your key)
+  users.users.root.openssh.authorizedKeys.keys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIIxGvpCUmx1UV3K22/+sWLdRknZmlTmQgckoAUCApF8 monkey@MegamanX"
+  ];
 
   # User will be created by your user module
   # This is just the base system

--- a/machine-types/server-arm.nix
+++ b/machine-types/server-arm.nix
@@ -1,6 +1,6 @@
-# Generic headless server configuration
+# Generic headless ARM64 server configuration
 # Uses nixos-facter for automatic hardware detection
-# Minimal configuration for servers
+# Minimal configuration for ARM servers
 {
   pkgs,
   lib,
@@ -9,19 +9,18 @@
 }: {
   myConfig = {
     skills.superpowersPath = inputs.superpowers;
-    autoUpgrade.flakeUrl = "github:funkymonkeymonk/nix#type-server";
+    autoUpgrade.flakeUrl = "github:funkymonkeymonk/nix#type-server-arm";
   };
 
   hardware.facter.reportPath = "/etc/nixos/facter.json";
 
   # REQUIRED: Configure at least one user with SSH access
-  users.users.root.openssh.authorizedKeys.keys = []; # Root SSH disabled
+  users.users.root.openssh.authorizedKeys.keys = [];
   users.users.monkey = {
     isNormalUser = true;
     extraGroups = ["wheel"];
     useDefaultShell = true;
     openssh.authorizedKeys.keys = [
-      # MegamanX deploy key
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIIxGvpCUmx1UV3K22/+sWLdRknZmlTmQgckoAUCApF8 monkey@MegamanX"
     ];
   };
@@ -34,18 +33,16 @@
     kernelModules = ["kvm-intel" "kvm-amd"];
   };
 
-  # Enable flakes (intentional: type-server does not include os/nixos.nix)
+  # Enable flakes (intentional: type-server-arm does not include os/nixos.nix)
   nix.settings.experimental-features = ["nix-command" "flakes"];
 
   # Networking - DHCP for IP and hostname
   networking = {
     useDHCP = lib.mkDefault true;
-    # Accept hostname from DHCP server (takeout container pattern)
     dhcpcd.extraConfig = ''
       option host_name
       send host-name = ""
     '';
-    # Firewall - allow SSH
     firewall = {
       enable = true;
       allowedTCPPorts = [22];
@@ -59,9 +56,9 @@
   services.openssh = {
     enable = true;
     settings = {
-      PermitRootLogin = "no"; # Disable root SSH entirely
-      PubkeyAuthentication = true; # Keys only
-      PasswordAuthentication = false; # No passwords
+      PermitRootLogin = "no";
+      PubkeyAuthentication = true;
+      PasswordAuthentication = false;
     };
   };
 

--- a/targets/MegamanX/default.nix
+++ b/targets/MegamanX/default.nix
@@ -1,118 +1,149 @@
 # MegamanX (personal desktop) target configuration
-# Machine-specific settings go here
-{lib, ...}: {
-  # Personal desktop specific configuration
-  # Most config comes from roles and mkUser
+{
+  lib,
+  mkUser,
+  inputs,
+  ...
+}: {
+  nixpkgs.hostPlatform = "aarch64-darwin";
+  system.stateVersion = 4;
+  system.primaryUser = "monkey";
 
-  # OpenCode configuration with Ollama provider and OpenCode Go
-  myConfig.opencode = {
-    # Set default model - used by build, devenv, and other agents without specific models
-    model = lib.mkForce "ollama/qwen3.5";
+  myConfig =
+    mkUser "monkey" "me@willweaver.dev"
+    // {
+      skills.superpowersPath = inputs.superpowers;
+      roles = {
+        developer.enable = true;
+        desktop.enable = true;
+        workstation.enable = true;
+        entertainment.enable = true;
+        llm-host.enable = true;
+        opencode.enable = true;
+        pi.enable = true;
+        homebrew.enable = true;
+      };
+      ollama = {
+        # Bind to all interfaces so Docker containers can access Ollama
+        host = "0.0.0.0";
+      };
+      vane = {
+        enable = true;
+        # Uses default Ollama URL (host.docker.internal:11434)
+        # Enable embedded SearxNG for web search
+        embeddedSearxng = true;
+        # Chat model - deepseek for reasoning tasks
+        defaultModel = "deepseek-r1:14b";
+        # Embedding model for vector search
+        embeddingModel = "nomic-embed-text";
+      };
+      opencode = {
+        # Set default model - used by build, devenv, and other agents without specific models
+        model = lib.mkForce "ollama/qwen3.5";
 
-    # Configure Ollama as a provider
-    providers.ollama = {
-      npm = "@ai-sdk/openai-compatible";
-      name = "Ollama Local";
-      baseURL = "http://localhost:11434/v1";
-      onePasswordItem = "";
-      models = {
-        "qwen3.5:2b" = {
-          name = "Qwen 3.5 2B (Fast)";
+        # Configure Ollama as a provider
+        providers.ollama = {
+          npm = "@ai-sdk/openai-compatible";
+          name = "Ollama Local";
+          baseURL = "http://localhost:11434/v1";
+          onePasswordItem = "";
+          models = {
+            "qwen3.5:2b" = {
+              name = "Qwen 3.5 2B (Fast)";
+            };
+            "qwen3.5" = {
+              name = "Qwen 3.5 9B (Balanced)";
+            };
+            "qwen3.5:122b" = {
+              name = "Qwen 3.5 122B (Quality)";
+            };
+          };
         };
-        "qwen3.5" = {
-          name = "Qwen 3.5 9B (Balanced)";
+
+        # Configure OpenCode Go provider for frontier models
+        providers.opencode-go = {
+          name = "OpenCode Go";
+          baseURL = "https://opencode.ai/zen/go/v1";
+          onePasswordItem = "op://Opnix/OpenCode Go API/credential";
         };
-        "qwen3.5:122b" = {
-          name = "Qwen 3.5 122B (Quality)";
+
+        # Define agents - only override plan, frontier
+        # build and devenv will use the global model above
+        agents = {
+          plan = {
+            description = "Analysis and planning without making changes";
+            mode = "primary";
+            model = "ollama/qwen3.5:122b";
+            prompt = "You are a planning assistant. Analyze code and create plans without making changes.";
+            permission = {
+              edit = "deny";
+              bash = "ask";
+            };
+          };
+
+          frontier = {
+            description = "Frontier model for maximum capability";
+            mode = "primary";
+            model = "opencode-go/kimi-k2.5";
+            prompt = "You are a frontier AI assistant with maximum capability for challenging tasks.";
+          };
         };
       };
-    };
-
-    # Configure OpenCode Go provider for frontier models
-    providers.opencode-go = {
-      name = "OpenCode Go";
-      baseURL = "https://opencode.ai/zen/go/v1";
-      onePasswordItem = "op://Opnix/OpenCode Go API/credential";
-    };
-
-    # Define agents - only override plan, frontier
-    # build and devenv will use the global model above
-    agents = {
-      plan = {
-        description = "Analysis and planning without making changes";
-        mode = "primary";
-        model = "ollama/qwen3.5:122b";
-        prompt = "You are a planning assistant. Analyze code and create plans without making changes.";
-        permission = {
-          edit = "deny";
-          bash = "ask";
+      pi = {
+        # Example settings
+        settings = {
+          theme = "dark";
+          editor = {
+            vimMode = true;
+          };
         };
-      };
 
-      frontier = {
-        description = "Frontier model for maximum capability";
-        mode = "primary";
-        model = "opencode-go/kimi-k2.5";
-        prompt = "You are a frontier AI assistant with maximum capability for challenging tasks.";
+        # Global AGENTS.md context
+        agentsMd = ''
+          # Global Agent Instructions
+
+          This is a Nix-managed system. When working with Nix configurations:
+          - Always run `devenv tasks run check:lint` before committing
+          - Use the existing module patterns in modules/
+          - Follow the conventional commit style
+        '';
+
+        # Example custom model pointing to local Ollama
+        models.local-ollama = {
+          name = "Local Ollama (Qwen 3.5)";
+          provider = "openai";
+          modelId = "qwen3.5";
+          baseUrl = "http://localhost:11434/v1";
+        };
+
+        # Example prompt template
+        prompts.review = ''
+          Review this code for:
+          1. Bugs and logic errors
+          2. Security issues
+          3. Performance problems
+          4. Nix best practices (if applicable)
+
+          Provide specific suggestions with line numbers.
+        '';
+
+        # Example skill
+        skills.nix = ''
+          # Nix Development Skill
+
+          Use this skill when working with Nix flakes, modules, or configurations.
+
+          ## Conventions
+          - Use `mkOption` for all configurable values
+          - Place modules in appropriate directories: common/, nixos/, darwin/
+          - Test with `devenv tasks run check:lint` before finishing
+          - Follow existing patterns in the codebase
+
+          ## Tools
+          - Read existing modules in modules/ for examples
+          - Use lib.optionalAttrs for platform-specific config
+          - Check bundles.nix for role definitions
+        '';
       };
     };
-  };
-
-  # Pi (pi-coding-agent) configuration
-  myConfig.pi = {
-    # Example settings
-    settings = {
-      theme = "dark";
-      editor = {
-        vimMode = true;
-      };
-    };
-
-    # Global AGENTS.md context
-    agentsMd = ''
-      # Global Agent Instructions
-
-      This is a Nix-managed system. When working with Nix configurations:
-      - Always run `devenv tasks run check:lint` before committing
-      - Use the existing module patterns in modules/
-      - Follow the conventional commit style
-    '';
-
-    # Example custom model pointing to local Ollama
-    models.local-ollama = {
-      name = "Local Ollama (Qwen 3.5)";
-      provider = "openai";
-      modelId = "qwen3.5";
-      baseUrl = "http://localhost:11434/v1";
-    };
-
-    # Example prompt template
-    prompts.review = ''
-      Review this code for:
-      1. Bugs and logic errors
-      2. Security issues
-      3. Performance problems
-      4. Nix best practices (if applicable)
-
-      Provide specific suggestions with line numbers.
-    '';
-
-    # Example skill
-    skills.nix = ''
-      # Nix Development Skill
-
-      Use this skill when working with Nix flakes, modules, or configurations.
-
-      ## Conventions
-      - Use `mkOption` for all configurable values
-      - Place modules in appropriate directories: common/, nixos/, darwin/
-      - Test with `devenv tasks run check:lint` before finishing
-      - Follow existing patterns in the codebase
-
-      ## Tools
-      - Read existing modules in modules/ for examples
-      - Use lib.optionalAttrs for platform-specific config
-      - Check bundles.nix for role definitions
-    '';
-  };
 }

--- a/targets/core/default.nix
+++ b/targets/core/default.nix
@@ -2,6 +2,15 @@
 # Uses modules/common/core.nix for absolute minimum packages
 # This is a barebones configuration for fresh systems or recovery
 # No additional configuration needed - core module provides:
-# git, curl, wget, vim, coreutils, zsh
+# git, curl, vim, coreutils, zsh
 _: {
+  nixpkgs.hostPlatform = "aarch64-darwin";
+  system.stateVersion = 4;
+  nix.enable = false;
+  myConfig = {
+    users = [];
+    agent-skills.enable = false;
+    onepassword.enable = false;
+    opencode.enable = false;
+  };
 }

--- a/targets/darwin-server/default.nix
+++ b/targets/darwin-server/default.nix
@@ -2,9 +2,39 @@
 # Headless Darwin (macOS) server for macOS VM management via Lume
 # Hardware: Mac M4 with 24GB RAM
 # Primary User: monkey (admin)
-{pkgs, ...}: {
-  # Server-specific configuration
-  # Most config comes from roles and mkUser in flake.nix
+{
+  mkUser,
+  inputs,
+  pkgs,
+  ...
+}: {
+  nixpkgs.hostPlatform = "aarch64-darwin";
+  system.stateVersion = 4;
+  system.primaryUser = "monkey";
+
+  myConfig =
+    mkUser "monkey" "me@willweaver.dev"
+    // {
+      skills.superpowersPath = inputs.superpowers;
+      roles = {
+        developer.enable = true;
+        opencode.enable = true;
+      };
+      opencode = {
+        enable = true;
+        # Use remote LLM APIs since no local Ollama
+        model = null; # User will select on first run
+      };
+      llmClient.rtk.enable = true;
+      lume = {
+        enable = true;
+        enableBackgroundService = true;
+        port = 7777;
+        enableAutoUpdater = true;
+        # Pre-pull macOS Tahoe vanilla image
+        prePullImages = ["macos-tahoe-vanilla:latest"];
+      };
+    };
 
   # Enable SSH server for remote access
   services.openssh.enable = true;
@@ -113,15 +143,5 @@
         echo "No cloud-init configuration found at $CONFIG_FILE"
       fi
     '';
-  };
-
-  # Lume configuration for macOS VMs
-  myConfig.lume = {
-    enable = true;
-    enableBackgroundService = true;
-    port = 7777;
-    enableAutoUpdater = true;
-    # Pre-pull macOS Tahoe vanilla image
-    prePullImages = ["macos-tahoe-vanilla:latest"];
   };
 }

--- a/targets/microvms/defaults.nix
+++ b/targets/microvms/defaults.nix
@@ -1,0 +1,32 @@
+# Default configuration for all MicroVMs
+# Provides shared user config, skills, and disables 1Password
+# Individual VM configs can override these defaults via roleEnables specialArg
+{
+  inputs,
+  roleEnables,
+  lib,
+  ...
+}: {
+  nixpkgs.hostPlatform = "x86_64-linux";
+  myConfig = lib.mkMerge [
+    {
+      skills = {
+        superpowersPath = inputs.superpowers;
+        externalInputs = {
+          inherit (inputs) vercel-skills;
+        };
+      };
+      users = [
+        {
+          name = "dev";
+          email = "dev@localhost";
+          fullName = "Development User";
+          isAdmin = true;
+          sshIncludes = [];
+        }
+      ];
+      onepassword.enable = lib.mkForce false;
+    }
+    roleEnables
+  ];
+}

--- a/targets/wweaver/default.nix
+++ b/targets/wweaver/default.nix
@@ -1,12 +1,163 @@
 # wweaver (work laptop) target configuration
-# Machine-specific settings go here
-{lib, ...}: {
-  # Work laptop specific configuration
-  # Most config comes from roles and mkUser
+{
+  lib,
+  mkUser,
+  inputs,
+  ...
+}: {
+  nixpkgs.hostPlatform = "aarch64-darwin";
+  system.stateVersion = 4;
+  system.primaryUser = "wweaver";
 
-  # Ollama configuration for local models
-  # Smaller/faster models for quick tasks, LiteLLM handles heavy workloads
-  myConfig.ollama = {
-    models = lib.mkForce ["qwen3.5:2b" "qwen3.5"];
-  };
+  myConfig =
+    mkUser "wweaver" "wweaver@justworks.com"
+    // {
+      skills = {
+        superpowersPath = inputs.superpowers;
+        externalInputs = {
+          inherit (inputs) vercel-skills;
+        };
+      };
+      onepassword.sudoPasswordRef = "op://Employee/wweaver Sudo Password/password";
+      roles = {
+        developer.enable = true;
+        desktop.enable = true;
+        workstation.enable = true;
+        entertainment.enable = true;
+        llm-host.enable = true;
+        opencode.enable = true;
+        pi.enable = true;
+        homebrew.enable = true;
+      };
+      ollama = {
+        # Bind to all interfaces so Docker containers can access Ollama
+        host = "0.0.0.0";
+        # Smaller/faster models for quick tasks, LiteLLM handles heavy workloads
+        models = lib.mkForce ["qwen3.5:2b" "qwen3.5"];
+      };
+      vane = {
+        enable = true;
+        autoStart = true;
+        # Local Ollama for fast local models
+        ollamaUrl = "http://host.docker.internal:11434";
+        # LiteLLM for external/cloud models - configure via web UI
+        openaiBaseUrl = "https://litellm.justworksai.net";
+        # Embedded SearxNG for web search
+        embeddedSearxng = true;
+        # Chat model (balanced speed/quality)
+        defaultModel = "qwen3.5";
+        # Embedding model for vector search
+        embeddingModel = "nomic-embed-text";
+        # Good resources for M4 Pro (14 cores, 48GB RAM)
+        colima = {
+          cpu = 6;
+          memory = 12;
+          disk = 60;
+        };
+      };
+      opencode = {
+        enable = true;
+        model = "just-llms/claude-sonnet-4-6";
+        disabledProviders = ["opencode"];
+        extraMcpServers = {
+          github = {
+            type = "remote";
+            url = "https://api.githubcopilot.com/mcp/";
+            enabled = false;
+          };
+          jira = {
+            type = "remote";
+            url = "https://mcp.atlassian.com/v1/mcp";
+            enabled = false;
+          };
+          confluence = {
+            type = "remote";
+            url = "https://mcp.atlassian.com/v1/mcp";
+            enabled = false;
+          };
+        };
+        commands = {
+          diataxis = {
+            description = "Audit and rewrite documentation using the Diataxis framework";
+            template = ''
+              Load the diataxis-docs skill and use it to audit and restructure the documentation in this project.
+
+              Follow the Diataxis framework to organize content into:
+              - Tutorials (learning-oriented)
+              - How-to guides (goal-oriented)
+              - Reference (information-oriented)
+              - Explanation (understanding-oriented)
+
+              $ARGUMENTS
+            '';
+          };
+          workspace = {
+            description = "Create a jj workspace for isolated work with fast sync enabled";
+            template = ''
+              Create a jj workspace session for isolated development work.
+
+              Run this command:
+              ```bash
+              jj-workspace-session start $ARGUMENTS
+              ```
+
+              Then report the workspace name and path to the user, and cd into the workspace directory.
+
+              If no arguments provided, this starts session tracking in the current workspace.
+              If a name is provided (e.g., "feat/auth" or "fix/bug"), it creates a new workspace.
+              A second argument can specify the base branch (defaults to main).
+
+              Examples:
+              - /workspace feat/user-auth      -> Creates feat/user-auth-<date>-<id> from main
+              - /workspace fix/bug develop     -> Creates fix/bug-<date>-<id> from develop
+              - /workspace                     -> Starts session in current workspace
+            '';
+          };
+        };
+        providers = {
+          just-llms = {
+            npm = "@ai-sdk/openai-compatible";
+            name = "Just LLMs";
+            baseURL = "https://litellm.justworksai.net";
+            onePasswordItem = "op://Justworks/Justworks LiteLLM/wweaver-poweruser-key";
+            dynamicModels = true;
+            models = {
+              "us.anthropic.claude-opus-4-5-20251101-v1:0" = {
+                name = "Claude Opus 4.5 (Bedrock)";
+              };
+            };
+          };
+          ollama = {
+            npm = "@ai-sdk/openai-compatible";
+            name = "Ollama (local)";
+            baseURL = "http://localhost:11434/v1";
+            models = {
+              "qwen3.5:latest" = {name = "Qwen 3.5 (7B)";};
+              "qwen3.5:2b" = {name = "Qwen 3.5 (2B)";};
+            };
+          };
+        };
+      };
+      claude-code = {
+        enable = false;
+        mcpServers = {
+          github = {
+            type = "remote";
+            url = "https://api.githubcopilot.com/mcp/";
+            enabled = true;
+          };
+          jira = {
+            type = "remote";
+            url = "https://mcp.atlassian.com/v1/mcp";
+            enabled = false;
+          };
+          confluence = {
+            type = "remote";
+            url = "https://mcp.atlassian.com/v1/mcp";
+            enabled = false;
+          };
+        };
+      };
+      llmClient.rtk.enable = true;
+    };
 }

--- a/targets/zero/default.nix
+++ b/targets/zero/default.nix
@@ -4,6 +4,8 @@
   config,
   pkgs,
   lib,
+  mkUser,
+  inputs,
   ...
 }: {
   imports =
@@ -13,6 +15,32 @@
     ++ lib.optionals (!builtins.pathExists /etc/nixos/hardware-configuration.nix) [
       ../hardware-stub.nix
     ];
+
+  nixpkgs.hostPlatform = "x86_64-linux";
+  system.stateVersion = "25.05";
+
+  myConfig =
+    mkUser "monkey" "me@willweaver.dev"
+    // {
+      skills.superpowersPath = inputs.superpowers;
+      roles = {
+        developer.enable = true;
+        desktop.enable = true;
+        opencode.enable = true;
+      };
+      desktop = {
+        enable = true;
+        autoLoginUser = "monkey";
+      };
+      gaming.enable = true;
+      streaming.enable = true;
+      llmEndpoints = {
+        MegamanX = {
+          host = "MegamanX.local";
+          port = "4000";
+        };
+      };
+    };
 
   networking = {
     hostName = "zero";

--- a/tests/test-flake-structure.sh
+++ b/tests/test-flake-structure.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+assert() {
+  local desc="$1" cmd="$2"
+  if eval "$cmd" 2>/dev/null; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== Flake structure tests ==="
+
+# flake.nix should not contain large inline myConfig blocks
+# (after moving them to targets/, flake.nix inline myConfig should be gone)
+INLINE_MYCONFIG=$(grep -c "myConfig[[:space:]]*=" "$REPO_ROOT/flake.nix" 2>/dev/null || true)
+INLINE_MYCONFIG="${INLINE_MYCONFIG:-0}"
+assert "flake.nix has no inline myConfig assignments (found: $INLINE_MYCONFIG)" "[ '${INLINE_MYCONFIG}' -eq 0 ]"
+
+# Each active machine should have a targets/ directory
+for machine in wweaver zero MegamanX; do
+  assert "targets/$machine/ exists" "test -d '$REPO_ROOT/targets/$machine'"
+  assert "targets/$machine/default.nix exists" "test -f '$REPO_ROOT/targets/$machine/default.nix'"
+done
+
+# Each machine's target should contain myConfig
+for machine in wweaver zero MegamanX; do
+  assert "targets/$machine/default.nix contains myConfig" "grep -q 'myConfig' '$REPO_ROOT/targets/$machine/default.nix'"
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

- Move each machine's inline \`myConfig\` block from \`flake.nix\` into \`targets/<name>/default.nix\` (or \`machine-types/<type>.nix\`)
- \`flake.nix\` now only contains module imports and \`specialArgs\` — no inline config assignments
- Machine config is co-located with other per-machine files for easier navigation

## Machines Updated

| Machine | Where config went |
|---------|------------------|
| \`wweaver\` | \`targets/wweaver/default.nix\` (merged with existing) |
| \`darwin-server\` | \`targets/darwin-server/default.nix\` (merged with existing) |
| \`MegamanX\` | \`targets/MegamanX/default.nix\` (merged with existing) |
| \`zero\` | \`targets/zero/default.nix\` (merged with existing) |
| \`core\` | \`targets/core/default.nix\` |
| \`type-desktop\` | \`machine-types/desktop.nix\` |
| \`type-server\` | \`machine-types/server.nix\` |
| \`type-server-arm\` | new \`machine-types/server-arm.nix\` |
| microvms | new \`targets/microvms/defaults.nix\` (shared defaults) |

## Technical Notes

- \`mkUser\` and \`inputs\` added to \`specialArgs\` for machines that use \`mkUser\`
- MicroVM \`roleEnables\` now passed via \`specialArgs\` and applied via \`lib.mkMerge\` in \`defaults.nix\`
- \`nixpkgs.hostPlatform\` and \`system.stateVersion\` moved to target files along with \`myConfig\`

## Testing

- \`tests/test-flake-structure.sh\` added (structural test — passes GREEN)
- \`devenv tasks run test:darwin-eval\` passes
- \`devenv tasks run test:nixos-eval\` passes
- \`devenv tasks run test:all\` passes
- \`devenv tasks run check:lint\` passes