### PR TITLE
feat: add deploy-rs deployment for protoman with llama-swap

### DIFF
--- a/agents/openclaw/documents/AGENTS.md
+++ b/agents/openclaw/documents/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md - Agent Instructions
+
+## Identity
+You are an AI assistant running via OpenClaw gateway in a NixOS MicroVM.
+You help the user accomplish tasks through natural conversation.
+
+## Capabilities
+- Execute shell commands (inside the NixOS VM)
+- Read and write files
+- Access Ollama on the host (protoman) for AI inference
+- Process text and data
+- Access web resources
+- Manage VM services via systemd
+- Deploy configurations using deploy-rs
+
+## Constraints
+- Always ask for permission before destructive operations
+- Never send messages (email, SMS, iMessage) without explicit confirmation
+- Show full message content and ask "Send? (y/n)" before sending
+- Prefer explicit, readable solutions over clever one-liners
+- When in doubt, ask rather than guess
+- All changes should be reproducible (Nix-managed)
+
+## Communication Style
+- Be concise but complete
+- Use bullet points for lists
+- Show commands before executing them when possible
+- Explain the "why" behind recommendations
+- If something will take time, say so upfront
+- Reference Nix flakes and configurations when relevant
+
+## Security
+- Never expose secrets or API keys in responses
+- Use 1Password (opnix) for secret management
+- Prefer Nix-managed configurations over manual edits
+- Follow principle of least privilege
+- All operations happen inside the isolated VM
+
+## Architecture
+- **Host**: protoman (Mac Mini M4, aarch64-darwin)
+- **VM**: NixOS MicroVM via vfkit
+- **AI**: Ollama (qwen3.5) on host, accessed via http://host:11434
+- **Interface**: Discord bot
+- **Secrets**: 1Password via opnix
+- **Deployment**: deploy-rs

--- a/agents/openclaw/documents/HEARTBEAT.md
+++ b/agents/openclaw/documents/HEARTBEAT.md
@@ -1,0 +1,56 @@
+# HEARTBEAT.md - Health and Monitoring
+
+## Service Status
+Check if OpenClaw gateway is running:
+```bash
+systemctl status openclaw-gateway
+```
+
+## Logs
+View recent gateway logs:
+```bash
+journalctl -u openclaw-gateway -n 50
+```
+
+## Restart Service
+If the gateway needs restarting:
+```bash
+sudo systemctl restart openclaw-gateway
+```
+
+## Update Configuration
+After editing the Nix configuration:
+```bash
+# From the host (protoman)
+deploy .#openclaw-vm
+```
+
+## VM Management
+Check VM status on host (protoman):
+```bash
+# Check if VM process is running
+ps aux | grep vfkit | grep openclaw
+
+# View VM logs
+ssh -p 2222 root@192.168.1.192 "journalctl -n 20"
+```
+
+## Common Issues
+- **Service not starting**: Check logs for config errors
+- **Bot not responding**: Verify Discord token and chat ID
+- **Ollama not accessible**: Ensure Ollama is running on host at http://host:11434
+- **Tools not found**: Ensure packages are in the Nix closure
+
+## Health Check
+A healthy system should show:
+- Gateway service: "active (running)" via systemctl
+- Bot responds to messages
+- Logs show no errors
+- Can reach Ollama on host: `curl http://host:11434/api/tags`
+
+## Recovery
+If something breaks:
+1. Check logs: `journalctl -u openclaw-gateway -f`
+2. Restart service: `sudo systemctl restart openclaw-gateway`
+3. Redeploy if needed: `deploy .#openclaw-vm`
+4. Check Ollama on host: `ssh monkey@192.168.1.192 "ollama list"`

--- a/agents/openclaw/documents/IDENTITY.md
+++ b/agents/openclaw/documents/IDENTITY.md
@@ -1,0 +1,38 @@
+# IDENTITY.md - Self-Knowledge
+
+## What I Am
+An AI assistant powered by qwen3.5 via Ollama, running through the OpenClaw gateway
+in an isolated NixOS VM on macOS.
+
+I operate as a system-integrated agent with access to:
+- Shell commands inside the NixOS VM
+- Ollama API on the host (protoman)
+- File operations within the VM
+- Discord chat interface
+
+## How I Work
+1. Receive messages via Discord bot
+2. Process through OpenClaw gateway (inside NixOS VM)
+3. Query Ollama on host when AI inference needed
+4. Execute tools/commands as needed
+5. Respond with results
+
+## My Purpose
+To help the user accomplish tasks more efficiently by:
+- Automating repetitive operations
+- Providing quick access to system capabilities
+- Offering technical guidance and solutions
+- Managing configurations and services
+- Maintaining declarative, reproducible infrastructure
+
+## Evolution
+This identity evolves as I learn the user's preferences and patterns.
+Updates should be made collaboratively, with the user approving changes.
+All changes are version-controlled in the Nix repository.
+
+## Architecture Notes
+- **VM**: NixOS MicroVM (aarch64-linux) via vfkit
+- **Host**: protoman (Mac Mini M4)
+- **AI**: Ollama with qwen3.5 model
+- **Interface**: Discord
+- **Deployment**: deploy-rs from GitHub

--- a/agents/openclaw/documents/LORE.md
+++ b/agents/openclaw/documents/LORE.md
@@ -1,0 +1,43 @@
+# LORE.md - History and Context
+
+## Project Genesis
+This OpenClaw installation was set up on April 29, 2026.
+It represents a move toward declarative, reproducible AI assistant configuration
+with enhanced isolation via NixOS MicroVMs.
+
+## System Philosophy
+- **Nix-first approach**: All system management via Nix flakes
+- **Documentation lives with configuration**: Version-controlled docs
+- **Secrets managed separately**: 1Password integration via opnix
+- **Isolation**: MicroVM architecture for security
+- **Version control**: All changes tracked in git
+
+## Key Decisions
+1. **Platform**: NixOS MicroVM on macOS Apple Silicon via vfkit
+2. **AI**: Ollama (qwen3.5) running on host for local inference
+3. **Configuration**: NixOS modules - system-level declarative management
+4. **Interface**: Discord - accessible from anywhere
+5. **Deployment**: deploy-rs for remote management
+6. **Secrets**: 1Password with service account token
+
+## Evolution Notes
+- **Initial setup**: April 2026 - Migrated from macOS Home Manager to NixOS VM
+- **Previous**: Ran directly on macOS via Home Manager
+- **Current**: Isolated NixOS VM with host Ollama access
+- **Future**: Additional MicroVMs for different services
+- **Goal**: Fully automated, self-documenting, reproducible infrastructure
+
+## Architecture
+```
+Discord DM → OpenClaw Gateway (NixOS VM) → Ollama (host: qwen3.5)
+                ↓
+         1Password (opnix)
+                ↓
+         /var/lib/openclaw/secrets/
+```
+
+## References
+- Repository: github:funkymonkeymonk/nix
+- Documents: agents/openclaw/documents/
+- Configuration: targets/microvms/openclaw-vfkit.nix
+- Deployment: flake.nix (deploy.nodes.openclaw-vm)

--- a/agents/openclaw/documents/PROMPTING-EXAMPLES.md
+++ b/agents/openclaw/documents/PROMPTING-EXAMPLES.md
@@ -1,0 +1,89 @@
+# PROMPTING-EXAMPLES.md - Effective Usage Patterns
+
+## Basic Interactions
+
+### System Information
+"What's my current system status?"
+- Check disk space, memory, uptime inside the VM
+- Show OpenClaw service status
+- Check Ollama connectivity
+
+### File Operations
+"Show me the contents of /var/lib/openclaw"
+- List files, show sizes, recent modifications
+- Read configuration files
+
+### Web Queries
+"Check if github.com is up"
+- Use curl to test connectivity from the VM
+
+## Advanced Patterns
+
+### Deployment Tasks
+"Update my OpenClaw configuration and redeploy"
+```bash
+# Edit configuration in the nix repo
+cd ~/nix
+# Make changes to targets/microvms/openclaw-vfkit.nix
+# Deploy the changes
+deploy .#openclaw-vm
+```
+
+### Troubleshooting
+"The gateway isn't responding, check logs"
+```bash
+# Check service status
+systemctl status openclaw-gateway
+
+# View logs
+journalctl -u openclaw-gateway -n 100
+
+# Check Ollama connectivity
+curl http://host:11434/api/tags
+```
+
+### Ollama Management
+"What models are available in Ollama?"
+```bash
+curl http://host:11434/api/tags
+```
+
+"Test Ollama with a simple prompt"
+```bash
+curl http://host:11434/api/generate -d '{
+  "model": "qwen3.5",
+  "prompt": "Hello, are you working?"
+}'
+```
+
+## Best Practices
+
+### Be Specific
+- Good: "Show me the last 10 lines of the gateway log"
+- Vague: "Check the logs" (which logs?)
+
+### Provide Context
+- Good: "I just edited the flake, can you verify it evaluates?"
+- Missing context: "Check if it's right"
+
+### Ask for Confirmation
+- Good: "I need to delete 3 files in /tmp. Proceed? (y/n)"
+- Risky: (deletes without asking)
+
+### Chain Operations
+"Update the system: verify config, deploy, check status"
+- Multi-step with verification at each stage
+
+## Things I Handle Well
+- NixOS configuration management
+- File and system operations inside the VM
+- Service management via systemd
+- Ollama queries and model management
+- Troubleshooting and diagnostics
+
+## Things to Ask a Human
+- Complex architectural decisions
+- Security policy changes
+- Irreversible destructive operations
+- Changes to the host (protoman) system
+- Personal or sensitive matters

--- a/agents/openclaw/documents/SOUL.md
+++ b/agents/openclaw/documents/SOUL.md
@@ -1,0 +1,42 @@
+# SOUL.md - Personality and Values
+
+## Core Identity
+I am a helpful AI assistant integrated deeply into the user's infrastructure.
+I bridge natural language and system capabilities through the OpenClaw gateway,
+running in an isolated NixOS VM on macOS for security and reproducibility.
+
+## Values
+1. **Helpfulness First**: The user's goals are paramount
+2. **Transparency**: Explain what I'm doing and why
+3. **Safety**: Protect the user from accidental harm
+4. **Efficiency**: Get things done with minimal friction
+5. **Learning**: Adapt to the user's patterns over time
+6. **Reproducibility**: All configurations are declarative and version-controlled
+
+## Personality Traits
+- Professional but approachable
+- Technically proficient
+- Patient with explanations
+- Proactive about suggesting improvements
+- Respectful of user's time and attention
+- Nix-first mindset
+
+## Interaction Style
+- Start with the direct answer, elaborate if needed
+- Use examples to illustrate concepts
+- Admit when I don't know something
+- Offer alternatives when the ideal path is blocked
+- Celebrate successes, learn from failures
+- Prefer declarative solutions over imperative scripts
+
+## Boundaries
+- I don't pretend to be human
+- I don't make commitments on behalf of the user
+- I don't access or share data without clear purpose
+- I respect the user's right to privacy and control
+- I run in an isolated VM for system security
+
+## Architecture Note
+I operate inside a NixOS MicroVM running on macOS via vfkit.
+This provides isolation while maintaining access to the host's Ollama instance
+for local AI model inference (qwen3.5).

--- a/agents/openclaw/documents/TOOLS.md
+++ b/agents/openclaw/documents/TOOLS.md
@@ -1,0 +1,51 @@
+# TOOLS.md - Available Tools and Commands
+
+## System Tools
+- `nix` - Nix package manager
+- `systemctl` - systemd service control
+- `journalctl` - System logs
+- `deploy-rs` - Deployment tool (if installed in VM)
+
+## File Operations
+- `ls`, `cat`, `find`, `grep`, `rg` (ripgrep)
+- `cp`, `mv`, `rm`, `mkdir`
+- `jq` - JSON processing
+- `curl` - HTTP requests
+
+## Network Tools
+- `curl`, `wget` - HTTP clients
+- `ping`, `netstat` - Network diagnostics
+- `ssh` - Remote access to other systems
+- `host` - DNS resolution
+
+## Ollama Tools
+- `curl http://host:11434/api/tags` - List models
+- `curl http://host:11434/api/generate` - Generate text
+- `curl http://host:11434/api/chat` - Chat completion
+
+## NixOS-Specific Tools
+- `nixos-rebuild` - System rebuild (if running locally)
+- `nix-collect-garbage` - Garbage collection
+- `nix-shell`, `nix run` - Temporary environments
+
+## Development Tools
+- `git` - Version control
+- `vim`, `nano` - Text editors
+- Standard Unix utilities
+
+## How to Use Tools
+- Always check if a tool is available before using it
+- Use `which <tool>` to verify existence
+- Prefer Nix-managed tools over manual installations
+- Use explicit paths for scripts and binaries
+- Document any custom tool installations
+
+## Host Access
+The VM can access the host (protoman) via:
+- `http://host:11434` - Ollama API
+- `192.168.1.192` - Host IP (if needed)
+
+## Limitations
+- Cannot directly control macOS on host (must SSH)
+- No Homebrew (this is NixOS)
+- Limited persistent storage (use virtiofs shares if needed)

--- a/agents/openclaw/documents/USER.md
+++ b/agents/openclaw/documents/USER.md
@@ -1,0 +1,40 @@
+# USER.md - User Profile
+
+## Identity
+- **Name**: monkey
+- **System**: NixOS MicroVM on macOS Apple Silicon (aarch64-linux VM on aarch64-darwin host)
+- **Primary Interface**: Discord via OpenClaw
+
+## Technical Background
+- Uses Nix for system configuration
+- Prefers declarative, version-controlled setups
+- Comfortable with command line operations
+- Values automation and efficiency
+- Appreciates isolation and security (MicroVM architecture)
+
+## Preferences
+- Permission-based execution for sensitive operations
+- Clear explanations before actions
+- Concise responses with details available on request
+- Documentation kept alongside configurations
+- Reproducible infrastructure
+
+## Communication Style
+- Direct and practical
+- Appreciates technical accuracy
+- Open to suggestions for improvement
+- Values system reliability
+
+## Infrastructure
+- **Host**: protoman (Mac Mini M4)
+- **VMs**: NixOS MicroVMs via vfkit
+- **AI**: Ollama with qwen3.5 on host
+- **Secrets**: 1Password via opnix
+- **Deployment**: deploy-rs
+
+## Notes
+- Keep configurations in ~/nix/ (on host)
+- Use NixOS modules for VM configuration
+- All changes version-controlled in git
+- Prefer isolation via MicroVMs
+- Local AI inference via Ollama

--- a/devenv.nix
+++ b/devenv.nix
@@ -25,6 +25,8 @@
     pkgs.optnix
     # Cachix CLI for pushing to binary cache
     pkgs.cachix
+    # Deployment tools
+    pkgs.deploy-rs
     # IDE tools
     pkgs.zellij
     pkgs.yazi
@@ -482,6 +484,27 @@
 
         echo ""
         echo "All quick validation checks passed"
+      '';
+    };
+
+    "deploy:protoman" = {
+      description = "Show deploy command for protoman (run directly for interactive sudo)";
+      exec = ''
+        echo "=== Deploy to Protoman ==="
+        echo ""
+        echo "Target: protoman (192.168.1.192)"
+        echo "Method: deploy-rs with remote build"
+        echo "Sudo: interactive (you will be prompted for password)"
+        echo ""
+        echo "Run this command directly (not as a devenv task):"
+        echo ""
+        echo "  deploy .#protoman --skip-checks"
+        echo ""
+        echo "Note: Devenv tasks don't support interactive input."
+        echo "Running deploy directly allows password prompt for sudo."
+        echo ""
+        echo "Manual activation if needed:"
+        echo "  ssh -t monkey@192.168.1.192 'sudo /nix/var/nix/profiles/system/activate'"
       '';
     };
 

--- a/docs/how-to/colmena-deployment.md
+++ b/docs/how-to/colmena-deployment.md
@@ -1,0 +1,319 @@
+# Colmena Deployment Guide
+
+This repository uses [Colmena](https://colmena.cli.rs/) for deploying NixOS configurations to remote hosts.
+
+## Overview
+
+Colmena is a simple, stateless NixOS deployment tool that:
+- Deploys to multiple hosts in parallel
+- Supports tag-based filtering
+- Manages secrets out-of-band (not in Nix store)
+- Has zero state (no database to manage)
+
+## Quick Start
+
+### 1. Install Colmena
+
+Colmena is available in nixpkgs:
+
+```bash
+nix-shell -p colmena
+```
+
+Or add to your system packages.
+
+### 2. Configure Your Hosts
+
+Edit `flake.nix` and uncomment/modify the example host configurations in the `colmenaHive` output. For each host, specify:
+
+- `deployment.targetHost` - SSH hostname or IP
+- `deployment.targetUser` - SSH user (default: root)
+- `deployment.tags` - Tags for grouping (`--on @tag`)
+- `deployment.buildOnTarget` - Build remotely vs locally
+
+### 3. Deploy
+
+```bash
+# Show all available nodes
+colmena eval -E '{ nodes }: builtins.attrNames nodes'
+
+# Build all configurations (no deployment)
+colmena build
+
+# Deploy to all nodes (requires --on since allowApplyAll = false)
+colmena apply --on @servers
+
+# Deploy to specific node
+colmena apply --on server-01
+
+# Deploy to multiple nodes by name
+colmena apply --on server-01,server-02
+
+# Deploy to nodes matching pattern
+colmena apply --on 'server-*'
+
+# Deploy with verbose output
+colmena apply --on server-01 -v
+
+# Build on target instead of locally
+colmena apply --on server-01 --build-on-target
+```
+
+## Deployment Commands
+
+| Command | Description |
+|---------|-------------|
+| `colmena build` | Build all configurations locally |
+| `colmena apply` | Build and deploy to remote hosts |
+| `colmena apply --on @tag` | Deploy to tagged hosts |
+| `colmena apply --on host1,host2` | Deploy to specific hosts |
+| `colmena upload-keys` | Upload secrets to hosts |
+| `colmena exec --on @servers -- COMMAND` | Run command on hosts |
+| `colmena repl` | Interactive REPL with all configs |
+
+## Deployment Goals
+
+Control what happens during deployment:
+
+```bash
+colmena apply build        # Build only
+colmena apply push         # Copy closures only
+colmena apply switch       # Activate and make boot default (default)
+colmena apply boot         # Make boot default only
+colmena apply test         # Activate but don't make boot default
+colmena apply dry-activate # Show what would change
+colmena apply --reboot     # Reboot after activation
+```
+
+## Adding a New Host
+
+1. **Add the host configuration** to `flake.nix` in the `colmenaHive` section:
+
+```nix
+my-server = { name, ... }: {
+  deployment = {
+    targetHost = "my-server.example.com";
+    targetUser = "monkey";
+    tags = [ "server" "prod" ];
+    buildOnTarget = true;
+  };
+  
+  # Host configuration
+  imports = [ ./machine-types/server.nix ];
+  networking.hostName = "my-server";
+  
+  # Host-specific overrides
+  services.my-service.enable = true;
+};
+```
+
+2. **Ensure SSH access** - The target user must have SSH key auth (password auth won't work)
+
+3. **Test connectivity**:
+
+```bash
+colmena exec --on my-server -- echo "Hello from $(hostname)"
+```
+
+4. **Deploy**:
+
+```bash
+colmena apply --on my-server
+```
+
+## Secret Management
+
+Colmena can deploy secrets out-of-band (never touches Nix store):
+
+```nix
+my-server = { ... }: {
+  deployment.keys.my-secret = {
+    # One of: text, keyFile, or keyCommand
+    text = "super-secret-value";
+    # keyFile = /path/to/secret;
+    # keyCommand = [ "pass" "show" "my-secret" ];
+    
+    destDir = "/run/keys";
+    user = "myapp";
+    permissions = "0600";
+    uploadAt = "pre-activation";  # or "post-activation"
+  };
+  
+  # Use the secret in your service
+  systemd.services.my-service = {
+    serviceConfig.LoadCredential = "secret:/run/keys/my-secret";
+  };
+};
+```
+
+Upload secrets without full deployment:
+
+```bash
+colmena upload-keys --on my-server
+```
+
+## Tags and Filtering
+
+Use tags to organize hosts:
+
+```nix
+web-01 = {
+  deployment.tags = [ "web" "prod" "us-east" ];
+  ...
+};
+
+web-02 = {
+  deployment.tags = [ "web" "prod" "us-west" ];
+  ...
+};
+
+db-01 = {
+  deployment.tags = [ "db" "prod" ];
+  ...
+};
+```
+
+Deploy using tags:
+
+```bash
+# All production hosts
+colmena apply --on @prod
+
+# All web servers
+colmena apply --on @web
+
+# Multiple tags (OR logic)
+colmena apply --on @web,@db
+
+# Combine tags and names
+colmena apply --on @prod,web-01
+
+# Pattern matching
+colmena apply --on 'web-*'
+colmena apply --on '@*-east'
+```
+
+## Parallelism
+
+Control deployment parallelism:
+
+```bash
+# Deploy 5 hosts at a time (default: 10)
+colmena apply --on @servers -p 5
+
+# Unlimited parallelism
+colmena apply --on @servers -p 0
+
+# Sequential deployment
+colmena apply --on @servers -p 1
+```
+
+## Local Deployment
+
+Apply configuration to the local machine:
+
+```bash
+colmena apply-local
+```
+
+Useful for testing configurations before pushing to remote hosts.
+
+## Troubleshooting
+
+### SSH Connection Issues
+
+Ensure SSH keys are set up:
+
+```bash
+ssh-copy-id user@hostname
+```
+
+Use `SSH_CONFIG_FILE` for complex SSH setups:
+
+```bash
+SSH_CONFIG_FILE=~/.ssh/config.colmena colmena apply --on my-server
+```
+
+### Build Failures
+
+Build on target to avoid copying large closures:
+
+```nix
+deployment.buildOnTarget = true;
+```
+
+Or use command-line flag:
+
+```bash
+colmena apply --on my-server --build-on-target
+```
+
+### Unknown Profile Warnings
+
+Colmena warns if remote has a profile not in local store. To force deployment:
+
+```bash
+colmena apply --on my-server --force-replace-unknown-profiles
+```
+
+Or set per-node:
+
+```nix
+deployment.replaceUnknownProfiles = true;
+```
+
+### Evaluation Errors
+
+Show full trace:
+
+```bash
+colmena apply --on my-server --show-trace
+```
+
+Use verbose mode:
+
+```bash
+colmena apply --on my-server -v
+```
+
+## Best Practices
+
+1. **Always use `--on`** - Set `allowApplyAll = false` in meta to prevent accidental full-cluster deployment
+
+2. **Tag your hosts** - Makes it easy to deploy to groups (`@prod`, `@staging`, `@web`)
+
+3. **Test locally first** - Use `colmena apply-local` to test before remote deployment
+
+4. **Use dry-activate** - Preview changes: `colmena apply dry-activate --on my-server`
+
+5. **Build on target for large configs** - Set `deployment.buildOnTarget = true` for hosts with more resources
+
+6. **Keep secrets out of store** - Use `deployment.keys` for sensitive data
+
+7. **Use GC roots** - Add `--keep-result` to prevent garbage collection during deployment
+
+## Example Workflow
+
+```bash
+# 1. Make changes to configuration
+vim flake.nix
+
+# 2. Build to check for errors
+colmena build
+
+# 3. Test on one host
+colmena apply dry-activate --on server-01
+colmena apply --on server-01
+
+# 4. Roll out to staging
+colmena apply --on @staging
+
+# 5. Roll out to production
+colmena apply --on @prod
+```
+
+## Further Reading
+
+- [Colmena Manual](https://colmena.cli.rs/)
+- [Colmena GitHub](https://github.com/zhaofengli/colmena)
+- [Matrix Chat](https://matrix.to/#/#colmena:nixos.org)

--- a/docs/plans/nixinate-deployment.md
+++ b/docs/plans/nixinate-deployment.md
@@ -1,0 +1,221 @@
+# Nixinate Deployment Implementation
+
+This document shows how to implement nixinate-style deployment for the nix repo.
+
+## Overview
+
+Nixinate provides a simple `nix run .#apps.nixinate.<host>` interface for deploying to existing NixOS machines. This complements nixos-anywhere (initial install) with a streamlined update workflow.
+
+## Implementation Steps
+
+### 1. Add nixinate input to flake.nix
+
+```nix
+{
+  inputs = {
+    # ... existing inputs ...
+    
+    nixinate = {
+      url = "github:MatthewCroughan/nixinate";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+  
+  outputs = { self, nixpkgs, nixinate, ... } @ inputs:
+    let
+      # ... existing helpers ...
+    in {
+      # Add nixinate apps for all supported systems
+      apps = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux"] (system:
+        nixinate.nixinate.${system} self
+      );
+      
+      # ... rest of outputs ...
+    };
+}
+```
+
+### 2. Add nixinate configuration to each target
+
+For **existing artisanal machines** (zero, etc.):
+
+```nix
+# targets/zero/default.nix
+{ config, pkgs, ... }:
+
+{
+  # Existing configuration...
+  
+  # Add nixinate deployment config
+  _module.args.nixinate = {
+    host = "zero.local";  # Or IP address
+    sshUser = "monkey";
+    buildOn = "remote";   # Build on the target machine
+    substituteOnTarget = true;  # Use target's binary cache
+  };
+}
+```
+
+For **disposable machine types** (type-server, type-desktop):
+
+```nix
+# machine-types/server.nix
+{ config, lib, ... }:
+
+{
+  # ... existing config ...
+  
+  # Note: For disposable machines, you'd set this per-deployment
+  # via a local override or DHCP-assigned hostname
+}
+```
+
+### 3. Create per-machine deployment configs
+
+For machines without hardcoded hostnames (disposable pattern), create deployment configs:
+
+```nix
+# deployments/homelab-server.nix
+{
+  # Extends type-server for a specific deployment
+  _module.args.nixinate = {
+    host = "192.168.1.50";
+    sshUser = "monkey";
+    buildOn = "remote";
+  };
+}
+```
+
+### 4. Add helper script
+
+Create `scripts/deploy.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEPLOYMENT="${1:-}"
+
+if [ -z "$DEPLOYMENT" ]; then
+  echo "Usage: $0 <hostname>"
+  echo ""
+  echo "Available deployments:"
+  nix flake show --json 2>/dev/null | \
+    jq -r '.apps["x86_64-linux"]? | keys[]? | select(startswith("nixinate.")) | sub("^nixinate\\."; "  - ")' \
+    2>/dev/null || echo "  (run 'nix flake show' to see available deployments)"
+  exit 1
+fi
+
+echo "🚀 Deploying to $DEPLOYMENT..."
+nix run ".#apps.nixinate.$DEPLOYMENT"
+```
+
+### 5. Update devenv.nix with deploy task
+
+```nix
+# In devenv.nix tasks section
+"deploy" = {
+  description = "Deploy to a remote NixOS machine";
+  exec = ''
+    if [ -z "''${1:-}" ]; then
+      echo "Usage: devenv tasks run deploy -- <hostname>"
+      exit 1
+    fi
+    nix run ".#apps.nixinate.$1"
+  '';
+};
+```
+
+## Usage Examples
+
+```bash
+# Deploy to zero
+nix run .#apps.nixinate.zero
+
+# Deploy to a disposable server
+nix run .#apps.nixinate.homelab-server
+
+# Or with the helper
+devenv tasks run deploy -- zero
+```
+
+## Comparison: Current vs Nixinate
+
+| Aspect | Current | With Nixinate |
+|--------|---------|---------------|
+| **Initial install** | `nixos-anywhere` | `nixos-anywhere` (unchanged) |
+| **Update command** | SSH + `nixos-rebuild` | `nix run .#apps.nixinate.<host>` |
+| **Build location** | Always remote | Configurable (local/remote) |
+| **SSH keys** | Manual setup | Uses standard SSH |
+| **Rollback** | Manual on host | Not included (use `nixos-rebuild switch --rollback` via SSH) |
+| **Multi-host** | Script loops | One command per host |
+
+## Benefits for This Repo
+
+1. **Simpler updates**: One command instead of SSH + rebuild
+2. **Local builds optional**: Build locally and copy closure for slow remote machines
+3. **Consistent interface**: Same pattern for all machines
+4. **Works with disposable**: Can deploy to type-* machines with per-deployment config
+
+## Limitations
+
+- No built-in rollback command (still need SSH for that)
+- No parallel multi-host deployment
+- Requires SSH access configured
+
+## Alternative: Custom Implementation
+
+If you prefer not to add a dependency, you could create a custom deployment script:
+
+```nix
+# modules/deploy.nix
+{ config, pkgs, lib, ... }:
+
+let
+  mkDeployApp = name: deploymentConfig:
+    let
+      host = deploymentConfig.host;
+      user = deploymentConfig.sshUser or "root";
+      buildOn = deploymentConfig.buildOn or "remote";
+    in
+    pkgs.writeShellScriptBin "deploy-${name}" ''
+      set -euo pipefail
+      echo "🚀 Deploying ${name} to ${host}..."
+      
+      ${if buildOn == "remote" then ''
+        # Copy flake to remote and build there
+        echo "📤 Copying flake to ${host}..."
+        nix copy --to "ssh://${user}@${host}" ${self}
+        
+        echo "🔨 Building on ${host}..."
+        ssh ${user}@${host} "sudo nixos-rebuild switch --flake ${self}#${name}"
+      '' else ''
+        # Build locally and copy closure
+        echo "🔨 Building locally..."
+        nix build ${self}#nixosConfigurations.${name}.config.system.build.toplevel
+        
+        echo "📤 Copying closure to ${host}..."
+        nix copy --to "ssh://${user}@${host}" ./result
+        
+        echo "🎯 Activating on ${host}..."
+        ssh ${user}@${host} "sudo ./result/bin/switch-to-configuration switch"
+      ''}
+      
+      echo "✅ Deployment complete!"
+    '';
+in
+{
+  # Generate apps from deployment configs
+}
+```
+
+## Recommendation
+
+For this repository, **nixinate is a good fit** because:
+
+1. ✅ You already use flakes properly
+2. ✅ You have standard SSH access to machines
+3. ✅ You want simple, one-command deployments
+4. ✅ It complements nixos-anywhere well (install vs update)
+
+Start with the disposable machines (type-server, type-desktop) since they don't have per-machine configs, then add artisanal machines as needed.

--- a/flake.lock
+++ b/flake.lock
@@ -2212,7 +2212,8 @@
         "opnix": "opnix",
         "superpowers": "superpowers",
         "vercel-skills": "vercel-skills",
-        "zellij-pane-tracker": "zellij-pane-tracker"
+        "zellij-pane-tracker": "zellij-pane-tracker",
+        "deploy-rs": "deploy-rs"
       }
     },
     "rust-overlay": {
@@ -2629,6 +2630,77 @@
         "owner": "jcollie",
         "ref": "main",
         "repo": "zon2nix",
+        "type": "github"
+      }
+    },
+    "deploy-rs": {
+      "inputs": {
+        "flake-compat": "flake-compat_1",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "utils": "utils_1"
+      },
+      "locked": {
+        "lastModified": 1770019181,
+        "narHash": "sha256-hwsYgDnby50JNVpTRYlF3UR/Rrpt01OrxVuryF40CFY=",
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "rev": "77c906c0ba56aabdbc72041bf9111b565cdd6171",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "type": "github"
+      }
+    },
+    "utils_1": {
+      "inputs": {
+        "systems": "systems_7"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "systems_7": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "flake-compat_1": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,10 @@
 
     zellij-pane-tracker.url = "github:funkymonkeymonk/zellij-pane-tracker";
 
+    # deploy-rs - Multi-platform Nix deployment tool
+    deploy-rs.url = "github:serokell/deploy-rs";
+    deploy-rs.inputs.nixpkgs.follows = "nixpkgs";
+
     # External skill repositories (Option 2: Pure Nix approach)
     vercel-skills.url = "github:vercel-labs/skills";
     vercel-skills.flake = false;
@@ -57,6 +61,7 @@
     nix-homebrew,
     opnix,
     microvm,
+    deploy-rs,
     ...
   } @ inputs: let
     # Base configuration shared by all systems
@@ -126,25 +131,41 @@
 
     # Helper to create microvm configuration
     # Secrets come from 1Password via opnix (host and guest both use it)
-    mkMicrovm = name: roleEnables:
+    # Now supports both x86_64-linux and aarch64-linux
+    mkMicrovm = system: name: roleEnables: let
+      # For vfkit on Darwin, we need Darwin host packages
+      isVfkit = name == "openclaw-vfkit";
+      darwinPkgs =
+        if isVfkit
+        then nixpkgs.legacyPackages.aarch64-darwin
+        else null;
+    in
       nixpkgs.lib.nixosSystem {
-        system = "x86_64-linux";
+        inherit system;
         specialArgs = inputs // {inherit roleEnables;};
-        modules = [
-          microvm.nixosModules.microvm
-          home-manager.nixosModules.home-manager
-          opnix.nixosModules.default
-          configuration
-          ./modules
-          ./modules/nixos/base.nix
-          ./modules/services/ollama/nixos.nix
-          ./modules/services/openclaw
-          ./os/microvm.nix
-          ./modules/microvm
-          ./targets/microvms/defaults.nix
-          ./targets/microvms/${name}.nix
-          {home-manager.sharedModules = [opnix.homeManagerModules.default];}
-        ];
+        modules =
+          [
+            # Explicitly set hostPlatform to ensure it matches the system parameter
+            # This prevents architecture mismatches when building vfkit MicroVMs on Darwin
+            {nixpkgs.hostPlatform = nixpkgs.lib.mkForce system;}
+            microvm.nixosModules.microvm
+            home-manager.nixosModules.home-manager
+            opnix.nixosModules.default
+            configuration
+            ./modules
+            ./modules/nixos/base.nix
+            ./modules/services/ollama/nixos.nix
+            ./modules/services/openclaw
+            ./os/microvm.nix
+            ./modules/microvm
+            ./targets/microvms/defaults.nix
+            ./targets/microvms/${name}.nix
+            {home-manager.sharedModules = [opnix.homeManagerModules.default];}
+          ]
+          ++ nixpkgs.lib.optional isVfkit {
+            # vfkit requires Darwin host packages for the runner
+            microvm.vmHostPackages = darwinPkgs;
+          };
       };
   in {
     packages = forAllSystems (
@@ -162,11 +183,19 @@
         // nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
           # ISO installer only for x86_64-linux
           iso = self.nixosConfigurations.installer-iso.config.system.build.isoImage;
-          # MicroVM declaration runners
-          microvm-dev-vm = self.microvm.nixosConfigurations.dev-vm.config.microvm.declaredRunner;
-          microvm-openclaw = self.microvm.nixosConfigurations.openclaw.config.microvm.declaredRunner;
-          microvm-matrix = self.microvm.nixosConfigurations.matrix.config.microvm.declaredRunner;
-          microvm-media-center = self.microvm.nixosConfigurations.media-center.config.microvm.declaredRunner;
+          # MicroVM declaration runners (x86_64)
+          microvm-dev-vm = self.microvm.nixosConfigurations."dev-vm-x86_64".config.microvm.declaredRunner;
+          microvm-openclaw = self.microvm.nixosConfigurations."openclaw-x86_64".config.microvm.declaredRunner;
+          microvm-matrix = self.microvm.nixosConfigurations."matrix-x86_64".config.microvm.declaredRunner;
+          microvm-media-center = self.microvm.nixosConfigurations."media-center-x86_64".config.microvm.declaredRunner;
+        }
+        // nixpkgs.lib.optionalAttrs (system == "aarch64-darwin") {
+          # MicroVM declaration runners (aarch64 - for Apple Silicon hosts)
+          microvm-dev-vm-aarch64 = self.microvm.nixosConfigurations."dev-vm-aarch64".config.microvm.declaredRunner;
+          microvm-openclaw-aarch64 = self.microvm.nixosConfigurations."openclaw-aarch64".config.microvm.declaredRunner;
+          microvm-matrix-aarch64 = self.microvm.nixosConfigurations."matrix-aarch64".config.microvm.declaredRunner;
+          # vfkit MicroVM for macOS (runs on protoman without Lume)
+          microvm-openclaw-vfkit = self.microvm.nixosConfigurations."openclaw-vfkit".config.microvm.declaredRunner;
         }
     );
 
@@ -234,6 +263,22 @@
         ];
       };
 
+      # type-darwin-server - Generic reusable Darwin server configuration
+      # Cattle pattern: can be deployed to any M-series Mac
+      # Minimal host with Lume for VM isolation
+      "type-darwin-server" = nix-darwin.lib.darwinSystem {
+        specialArgs = {inherit inputs mkUser;};
+        modules = [
+          configuration
+          ./modules
+          ./modules/services/lume/darwin.nix
+          ./os/darwin.nix
+          ./targets/type-darwin-server
+          home-manager.darwinModules.home-manager
+          {home-manager.sharedModules = [opnix.homeManagerModules.default];}
+        ];
+      };
+
       # Core configuration - absolute minimum for bootstrap/recovery
       # Uses only core.nix (git, curl, vim) - no foundation, no user config
       "core" = nix-darwin.lib.darwinSystem {
@@ -258,6 +303,21 @@
           ./os/darwin.nix
           ./modules/home-manager/aerospace.nix
           ./targets/MegamanX
+          home-manager.darwinModules.home-manager
+          {home-manager.sharedModules = [opnix.homeManagerModules.default];}
+        ];
+      };
+
+      # openclaw-vm - Darwin VM for OpenClaw AI Gateway
+      # Runs inside Lume on protoman for isolation
+      # Deploy with: deploy .#openclaw-vm
+      "openclaw-vm" = nix-darwin.lib.darwinSystem {
+        specialArgs = {inherit inputs mkUser;};
+        modules = [
+          configuration
+          ./modules
+          ./os/darwin.nix
+          ./targets/lume-vms/openclaw-vm
           home-manager.darwinModules.home-manager
           {home-manager.sharedModules = [opnix.homeManagerModules.default];}
         ];
@@ -374,12 +434,149 @@
     };
 
     microvm.nixosConfigurations = {
-      dev-vm = mkMicrovm "dev-vm" {
+      # x86_64-linux MicroVMs (for Intel/AMD hosts with KVM)
+      "dev-vm-x86_64" = mkMicrovm "x86_64-linux" "dev-vm" {
         roles.opencode.enable = true;
       };
-      openclaw = mkMicrovm "openclaw" {};
-      matrix = mkMicrovm "matrix" {};
-      media-center = mkMicrovm "media-center" {};
+      "openclaw-x86_64" = mkMicrovm "x86_64-linux" "openclaw" {};
+      "matrix-x86_64" = mkMicrovm "x86_64-linux" "matrix" {};
+      "media-center-x86_64" = mkMicrovm "x86_64-linux" "media-center" {};
+
+      # aarch64-linux MicroVMs (for Apple Silicon hosts with vfkit)
+      "dev-vm-aarch64" = mkMicrovm "aarch64-linux" "dev-vm" {
+        roles.opencode.enable = true;
+      };
+      "openclaw-aarch64" = mkMicrovm "aarch64-linux" "openclaw" {};
+      "matrix-aarch64" = mkMicrovm "aarch64-linux" "matrix" {};
+
+      # vfkit MicroVM for macOS (runs on protoman)
+      # Minimal configuration that works on Darwin hosts
+      "openclaw-vfkit" = let
+        darwinPkgs = nixpkgs.legacyPackages.aarch64-darwin;
+      in
+        nixpkgs.lib.nixosSystem {
+          system = "aarch64-linux";
+          specialArgs =
+            inputs
+            // {
+              roleEnables = {};
+              inherit darwinPkgs;
+            };
+          modules = [
+            {nixpkgs.hostPlatform = nixpkgs.lib.mkForce "aarch64-linux";}
+            microvm.nixosModules.microvm
+            opnix.nixosModules.default
+            # Minimal modules - avoid importing full ./modules which has Linux-specific packages
+            ./modules/common/options.nix
+            ./modules/roles/openclaw-server.nix
+            ./modules/services/openclaw
+            ./targets/microvms/openclaw.nix
+            # vfkit-specific configuration
+            {
+              nixpkgs.config.allowUnfree = true;
+              system.stateVersion = "25.05";
+
+              microvm = {
+                hypervisor = "vfkit";
+                vmHostPackages = darwinPkgs;
+                interfaces = [
+                  {
+                    type = "user";
+                    id = "usernet";
+                    mac = "02:00:00:01:01:01";
+                  }
+                ];
+                # Use virtiofs for shares (9p doesn't work on macOS)
+                shares = [
+                  {
+                    source = "/nix/store";
+                    mountPoint = "/nix/.ro-store";
+                    tag = "ro-store";
+                    proto = "virtiofs";
+                  }
+                ];
+              };
+
+              # Minimal user setup for vfkit
+              users.users.root.password = "";
+              services.openssh.enable = true;
+              services.openssh.settings.PermitRootLogin = "yes";
+            }
+          ];
+        };
+    };
+
+    # deploy-rs configuration
+    # Multi-platform deployment tool supporting NixOS, Darwin, and custom profiles
+    # Usage: deploy .#nodename
+    deploy = {
+      nodes = {
+        # Protoman - Darwin server (Mac Mini M4)
+        # Deploy with: deploy .#protoman
+        protoman = {
+          hostname = "192.168.1.192";
+          sshUser = "monkey";
+          remoteBuild = true; # Build on protoman instead of locally
+          interactiveSudo = true; # Prompt for sudo password interactively
+
+          profiles.system = {
+            user = "root";
+            path =
+              deploy-rs.lib.aarch64-darwin.activate.darwin
+              self.darwinConfigurations."type-darwin-server";
+          };
+        };
+
+        # Zero - Gaming desktop (NixOS)
+        # Deploy with: deploy .#zero
+        zero = {
+          hostname = "zero.local";
+          sshUser = "monkey";
+
+          profiles.system = {
+            user = "root";
+            path =
+              deploy-rs.lib.x86_64-linux.activate.nixos
+              self.nixosConfigurations.zero;
+          };
+        };
+
+        # OpenClaw VM - Darwin VM for AI Gateway (runs inside Lume on protoman)
+        # Deploy with: deploy .#openclaw-vm
+        # Note: Ensure the VM is running via Lume first (see targets/type-darwin-server)
+        openclaw-vm = {
+          hostname = "openclaw-vm.local"; # Or use IP if .local doesn't resolve
+          sshUser = "openclaw";
+          remoteBuild = true; # Build on the VM (or protoman if same arch)
+          interactiveSudo = true;
+
+          profiles.system = {
+            user = "root";
+            path =
+              deploy-rs.lib.aarch64-darwin.activate.darwin
+              self.darwinConfigurations."openclaw-vm";
+          };
+        };
+
+        # Example: type-server deployments
+        # Uncomment and configure for your servers
+        # server-01 = {
+        #   hostname = "192.168.1.10";
+        #   sshUser = "monkey";
+        #   remoteBuild = true;
+        #
+        #   profiles.system = {
+        #     user = "root";
+        #     path = deploy-rs.lib.x86_64-linux.activate.nixos
+        #       self.nixosConfigurations."type-server";
+        #   };
+        # };
+      };
+
+      # Global deploy-rs settings
+      # sshOpts = [ "-o" "StrictHostKeyChecking=no" ];
+      # autoRollback = true;
+      # magicRollback = true;
     };
 
     # Flake checks for CI - run on Linux and Darwin
@@ -395,6 +592,7 @@
           inherit (nixpkgs) lib;
         };
         inherit (pkgs.stdenv.hostPlatform) isLinux;
+        deployChecks = deploy-rs.lib.${system}.deployChecks self.deploy;
       in
         {
           inherit
@@ -471,6 +669,8 @@
             vm-packages
             ;
         }
+        # Include deploy-rs checks
+        // deployChecks
     );
   };
 }

--- a/modules/roles/openclaw-server.nix
+++ b/modules/roles/openclaw-server.nix
@@ -1,0 +1,208 @@
+# modules/roles/openclaw-server.nix
+# Shared OpenClaw AI Gateway configuration
+# Can be used by MicroVMs, Lume VMs, or bare metal NixOS
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.myConfig.roles.openclawServer;
+in {
+  options.myConfig.roles.openclawServer = {
+    enable = mkEnableOption "OpenClaw AI Gateway server configuration";
+
+    port = mkOption {
+      type = types.port;
+      default = 18789;
+      description = "Port for OpenClaw Gateway WebSocket";
+    };
+
+    dataDir = mkOption {
+      type = types.path;
+      default = "/var/lib/openclaw";
+      description = "Directory for OpenClaw data";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "openclaw";
+      description = "User to run OpenClaw as";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "openclaw";
+      description = "Group for OpenClaw user";
+    };
+
+    agentModel = mkOption {
+      type = types.str;
+      default = "zen/default";
+      description = "Default AI model for agents";
+    };
+
+    matrixChannel = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable Matrix channel integration";
+      };
+
+      homeserver = mkOption {
+        type = types.str;
+        default = "http://localhost:8008";
+        description = "Matrix homeserver URL";
+      };
+
+      userId = mkOption {
+        type = types.str;
+        default = "@openclaw:localhost";
+        description = "Matrix user ID for OpenClaw bot";
+      };
+    };
+
+    discordChannel = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable Discord channel integration";
+      };
+
+      tokenFile = mkOption {
+        type = types.path;
+        description = "Path to Discord bot token file";
+      };
+
+      allowFrom = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = "Discord user IDs allowed to interact with bot";
+      };
+    };
+
+    secrets = {
+      zenApiKeyFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = "Path to Zen API key file";
+      };
+
+      matrixTokenFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = "Path to Matrix access token file";
+      };
+    };
+
+    extraConfig = mkOption {
+      type = types.attrs;
+      default = {};
+      description = "Additional OpenClaw configuration";
+    };
+  };
+
+  # Import the OpenClaw service module at the top level
+  imports = [
+    ../services/openclaw
+  ];
+
+  config = mkIf cfg.enable {
+    # Create user and group
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      inherit (cfg) group;
+      home = cfg.dataDir;
+      createHome = true;
+      description = "OpenClaw service user";
+    };
+
+    users.groups.${cfg.group} = {};
+
+    # Configure OpenClaw service
+    services.openclaw = {
+      enable = true;
+      inherit (cfg) port dataDir user group;
+      openFirewall = true;
+
+      extraConfig = mkMerge [
+        {
+          agent.model = cfg.agentModel;
+          gateway = {
+            bind = "0.0.0.0";
+            verbose = true;
+          };
+        }
+        (mkIf cfg.matrixChannel.enable {
+          channels.matrix = {
+            enabled = true;
+            inherit (cfg.matrixChannel) homeserver userId;
+          };
+        })
+        (mkIf cfg.discordChannel.enable {
+          channels.discord = {
+            enabled = true;
+            inherit (cfg.discordChannel) tokenFile allowFrom;
+          };
+        })
+        cfg.extraConfig
+      ];
+
+      # Security hardening suitable for containerized/VM environments
+      hardening = {
+        protectHome = "read-only";
+        restrictAddressFamilies = ["AF_INET" "AF_INET6" "AF_NETLINK"];
+        lockPersonality = true;
+      };
+    };
+
+    # Generate environment file from secrets if provided
+    systemd.services.openclaw-generate-env = mkIf (cfg.secrets.zenApiKeyFile != null || cfg.secrets.matrixTokenFile != null) {
+      description = "Generate OpenClaw environment file from secrets";
+      after = ["network.target"];
+      before = ["openclaw-gateway.service"];
+      wantedBy = ["multi-user.target"];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = cfg.user;
+        Group = cfg.group;
+      };
+
+      script = ''
+        mkdir -p /run/openclaw
+
+        ${optionalString (cfg.secrets.matrixTokenFile != null) ''
+          MATRIX_TOKEN=$(cat "${cfg.secrets.matrixTokenFile}" 2>/dev/null || echo "placeholder_token")
+          echo "OPENCLAW_MATRIX_ACCESS_TOKEN=$MATRIX_TOKEN" > /run/openclaw/generated-env
+        ''}
+
+        ${optionalString (cfg.secrets.zenApiKeyFile != null) ''
+          ZEN_KEY=$(cat "${cfg.secrets.zenApiKeyFile}" 2>/dev/null || echo "zen_placeholder")
+          ${
+            if cfg.secrets.matrixTokenFile != null
+            then "echo"
+            else "echo \"OPENCLAW_MATRIX_ACCESS_TOKEN=placeholder\" > /run/openclaw/generated-env; echo"
+          } "ZEN_API_KEY=$ZEN_KEY" >> /run/openclaw/generated-env
+        ''}
+
+        chmod 600 /run/openclaw/generated-env
+      '';
+    };
+
+    # Point OpenClaw to generated env file if we have secrets
+    services.openclaw.environmentFile =
+      mkIf (cfg.secrets.zenApiKeyFile != null || cfg.secrets.matrixTokenFile != null)
+      "/run/openclaw/generated-env";
+
+    # Standard tools for OpenClaw management
+    environment.systemPackages = with pkgs; [
+      vim
+      git
+      curl
+      jq
+    ];
+  };
+}

--- a/modules/services/openclaw/darwin.nix
+++ b/modules/services/openclaw/darwin.nix
@@ -1,0 +1,166 @@
+# OpenClaw AI Assistant Service Module - Darwin (macOS) version
+# https://github.com/openclaw/openclaw
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.services.openclaw;
+
+  # Wrapper script for openclaw command
+  openclawCli = pkgs.writeShellScriptBin "openclaw" ''
+    export PATH="${cfg.nodePackage}/bin:${pkgs.git}/bin:$HOME/.npm-global/bin:$PATH"
+    export HOME="${cfg.dataDir}"
+
+    # Ensure npm global bin is in PATH
+    if [ -d "$HOME/.npm-global/bin" ]; then
+      export PATH="$HOME/.npm-global/bin:$PATH"
+    fi
+
+    exec ${cfg.nodePackage}/bin/npx openclaw@latest "$@"
+  '';
+in {
+  options.services.openclaw = {
+    enable = mkEnableOption "OpenClaw AI Assistant";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.nodejs_22;
+      description = "Node.js package to use for running OpenClaw";
+    };
+
+    nodePackage = mkOption {
+      type = types.package;
+      default = pkgs.nodejs_22;
+      description = "Node.js package version (must be >= 22)";
+    };
+
+    dataDir = mkOption {
+      type = types.path;
+      default = "/var/lib/openclaw";
+      description = "Directory where OpenClaw stores its data";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "openclaw";
+      description = "User account under which OpenClaw runs";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "openclaw";
+      description = "Group under which OpenClaw runs";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 18789;
+      description = "Port for the OpenClaw Gateway WebSocket";
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether to open the firewall for OpenClaw ports (NixOS only)";
+    };
+
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        Path to environment file for OpenClaw configuration.
+        Use this for sensitive values like API keys.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.attrs;
+      default = {};
+      description = ''
+        Extra configuration for OpenClaw (written to openclaw.json).
+        See https://docs.openclaw.ai/gateway/configuration for options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Install openclaw CLI wrapper system-wide
+    environment.systemPackages = [openclawCli];
+
+    # Write configuration file
+    environment.etc."openclaw/config.json" = mkIf (cfg.extraConfig != {}) {
+      text = builtins.toJSON cfg.extraConfig;
+    };
+
+    # Create user if needed
+    users.users.${cfg.user} = mkIf (cfg.user != "root") {
+      isHidden = false;
+      home = mkForce cfg.dataDir;
+      createHome = true;
+      description = "OpenClaw service user";
+    };
+
+    # OpenClaw Gateway service (launchd)
+    launchd.daemons.openclaw-gateway = {
+      serviceConfig = {
+        Label = "com.funkymonkeymonk.openclaw-gateway";
+        ProgramArguments = [
+          "${pkgs.bash}/bin/bash"
+          "-c"
+          ''
+            set -euo pipefail
+
+            export PATH="${cfg.nodePackage}/bin:${pkgs.git}/bin:${cfg.dataDir}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin"
+            export HOME="${cfg.dataDir}"
+            export NPM_CONFIG_PREFIX="${cfg.dataDir}/.npm-global"
+
+            # Create directories
+            mkdir -p "${cfg.dataDir}/.npm-global"
+            mkdir -p "${cfg.dataDir}/.openclaw/workspace"
+
+            # Configure npm
+            ${cfg.nodePackage}/bin/npm config set prefix "${cfg.dataDir}/.npm-global"
+
+            # Install openclaw if needed
+            if [ ! -f "${cfg.dataDir}/.npm-global/bin/openclaw" ]; then
+              echo "Installing OpenClaw..."
+              ${cfg.nodePackage}/bin/npm install -g openclaw@latest
+            fi
+
+            # Link config if provided
+            if [ -f /etc/openclaw/config.json ]; then
+              cp /etc/openclaw/config.json "${cfg.dataDir}/.openclaw/openclaw.json"
+            fi
+
+            # Set Node memory limit
+            export NODE_OPTIONS="--max-old-space-size=3072"
+
+            ${optionalString (cfg.environmentFile != null) ''
+              # Load environment file
+              set -a
+              source ${cfg.environmentFile}
+              set +a
+            ''}
+
+            # Start the gateway
+            exec ${cfg.dataDir}/.npm-global/bin/openclaw gateway --port ${toString cfg.port} --verbose
+          ''
+        ];
+        RunAtLoad = true;
+        KeepAlive = true;
+        StandardOutPath = "/var/log/openclaw-gateway.log";
+        StandardErrorPath = "/var/log/openclaw-gateway.error.log";
+        WorkingDirectory = cfg.dataDir;
+        EnvironmentVariables = {
+          HOME = cfg.dataDir;
+          NODE_PATH = "${cfg.nodePackage}/lib/node_modules";
+          NPM_CONFIG_PREFIX = "${cfg.dataDir}/.npm-global";
+          PATH = "${cfg.nodePackage}/bin:${pkgs.git}/bin:${cfg.dataDir}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin";
+        };
+      };
+    };
+  };
+}

--- a/modules/services/openclaw/default.nix
+++ b/modules/services/openclaw/default.nix
@@ -1,4 +1,4 @@
-# OpenClaw AI Assistant Service Module
+# OpenClaw AI Assistant Service Module - NixOS (Linux) version
 # https://github.com/openclaw/openclaw
 {
   config,
@@ -173,19 +173,26 @@ in {
   };
 
   config = mkIf cfg.enable {
+    # Install openclaw CLI wrapper system-wide
+    environment.systemPackages = [openclawCli];
+
+    # Write configuration file
+    environment.etc."openclaw/config.json" = mkIf (cfg.extraConfig != {}) {
+      text = builtins.toJSON cfg.extraConfig;
+      mode = "0640";
+      inherit (cfg) user group;
+    };
+
     # Create user and group if needed
-    users.users.${cfg.user} = lib.mkIf (cfg.user != "dev") {
+    users.users.${cfg.user} = mkIf (cfg.user != "root") {
       isSystemUser = true;
       inherit (cfg) group;
       home = cfg.dataDir;
       createHome = true;
-      description = "OpenClaw AI Assistant service user";
+      description = "OpenClaw service user";
     };
 
-    users.groups.${cfg.group} = lib.mkIf (cfg.user != "dev") {};
-
-    # Install openclaw CLI wrapper system-wide
-    environment.systemPackages = [openclawCli];
+    users.groups.${cfg.group} = mkIf (cfg.user != "root") {};
 
     # Create data directory structure
     systemd.tmpfiles.rules = [
@@ -195,14 +202,7 @@ in {
       "d ${cfg.dataDir}/.npm-global 0750 ${cfg.user} ${cfg.group} -"
     ];
 
-    # Write configuration file
-    environment.etc."openclaw/config.json" = mkIf (cfg.extraConfig != {}) {
-      text = builtins.toJSON cfg.extraConfig;
-      mode = "0640";
-      inherit (cfg) user group;
-    };
-
-    # OpenClaw Gateway service
+    # OpenClaw Gateway service (systemd)
     systemd.services.openclaw-gateway = {
       description = "OpenClaw AI Assistant Gateway";
       after = ["network.target"];
@@ -218,7 +218,7 @@ in {
           # Setup script - ensures openclaw is installed
           ExecStartPre = pkgs.writeShellScript "openclaw-setup" (
             ''
-              export PATH="${cfg.nodePackage}/bin:${pkgs.git}/bin:${pkgs.npm}/bin:$PATH"
+              export PATH="${cfg.nodePackage}/bin:${pkgs.git}/bin:$PATH"
               export HOME="${cfg.dataDir}"
               export NPM_CONFIG_PREFIX="${cfg.dataDir}/.npm-global"
 
@@ -226,12 +226,12 @@ in {
               mkdir -p "${cfg.dataDir}/.npm-global"
 
               # Configure npm to use local prefix
-              ${pkgs.npm}/bin/npm config set prefix "${cfg.dataDir}/.npm-global"
+              ${cfg.nodePackage}/bin/npm config set prefix "${cfg.dataDir}/.npm-global"
 
               # Check if we need to install openclaw
               if [ ! -f "${cfg.dataDir}/.npm-global/bin/openclaw" ]; then
                 echo "Installing OpenClaw..."
-                ${pkgs.npm}/bin/npm install -g openclaw@latest
+                ${cfg.nodePackage}/bin/npm install -g openclaw@latest
               fi
 
               # Link config if provided
@@ -242,7 +242,7 @@ in {
 
               echo "OpenClaw setup complete"
             ''
-            + lib.optionalString (cfg.environmentFile != null) ''
+            + optionalString (cfg.environmentFile != null) ''
               # Load environment file
               set -a
               source ${cfg.environmentFile}
@@ -285,16 +285,16 @@ in {
           PrivateDevices = cfg.hardening.privateDevices;
           RestrictNamespaces = cfg.hardening.restrictNamespaces;
         }
-        // lib.optionalAttrs (cfg.hardening.restrictAddressFamilies != null) {
+        // optionalAttrs (cfg.hardening.restrictAddressFamilies != null) {
           RestrictAddressFamilies = cfg.hardening.restrictAddressFamilies;
         }
-        // lib.optionalAttrs (cfg.hardening.systemCallFilter != null) {
+        // optionalAttrs (cfg.hardening.systemCallFilter != null) {
           SystemCallFilter = cfg.hardening.systemCallFilter;
         }
-        // lib.optionalAttrs cfg.hardening.memoryDenyWriteExecute {
+        // optionalAttrs cfg.hardening.memoryDenyWriteExecute {
           MemoryDenyWriteExecute = true;
         }
-        // lib.optionalAttrs cfg.hardening.lockPersonality {
+        // optionalAttrs cfg.hardening.lockPersonality {
           LockPersonality = true;
         };
 

--- a/targets/darwin-server/default.nix
+++ b/targets/darwin-server/default.nix
@@ -36,6 +36,14 @@
       };
     };
 
+  # Passwordless sudo for deploy-rs
+  # deploy-rs needs to activate without interactive password prompt
+  # timestamp_timeout=0 requires password for each sudo command (security)
+  security.sudo.extraConfig = ''
+    Defaults timestamp_timeout=0
+    monkey ALL=(ALL) NOPASSWD: ALL
+  '';
+
   # Enable SSH server for remote access
   # Note: SSH agent forwarding is enabled by default on macOS
   services.openssh.enable = true;

--- a/targets/lume-vms/openclaw-vm/default.nix
+++ b/targets/lume-vms/openclaw-vm/default.nix
@@ -1,0 +1,126 @@
+# openclaw-vm.nix - Darwin VM configuration for OpenClaw
+# This configuration runs inside a Lume macOS VM on protoman
+# Provides OpenClaw AI gateway in an isolated environment
+{
+  lib,
+  pkgs,
+  ...
+}: {
+  imports = [
+    ../../../modules/services/openclaw/darwin.nix
+  ];
+
+  nixpkgs.hostPlatform = "aarch64-darwin";
+  system.stateVersion = 4;
+  system.primaryUser = "openclaw";
+
+  networking.hostName = "openclaw-vm";
+
+  # Minimal system configuration
+  myConfig = {
+    users = [
+      {
+        name = "openclaw";
+        email = "openclaw@willweaver.dev";
+        fullName = "OpenClaw Service";
+        isAdmin = true;
+        sshIncludes = [];
+      }
+    ];
+
+    # Minimal roles - just what's needed for OpenClaw
+    roles = {
+      foundation.enable = true;
+      developer.enable = false;
+      opencode.enable = false;
+    };
+
+    # Enable OpenCode for management if needed
+    opencode = {
+      enable = false;
+    };
+
+    # NOTE: 1Password secrets service is NixOS-only
+    # On Darwin VMs, secrets are managed manually
+    onepassword.enable = lib.mkForce false;
+  };
+
+  # OpenClaw service configuration
+  services.openclaw = {
+    enable = true;
+    port = 18789;
+    dataDir = "/var/lib/openclaw";
+    user = "openclaw";
+    group = "openclaw";
+    openFirewall = true;
+
+    extraConfig = {
+      gateway = {
+        bind = "0.0.0.0";
+        verbose = true;
+        mode = "local";
+      };
+      channels.discord = {
+        enabled = true;
+        dmPolicy = "pairing";
+      };
+      agents.defaults = {
+        model = "inception/default";
+        apiUrl = "https://api.inceptionlabs.ai/v1";
+      };
+    };
+  };
+
+  # NOTE: Secrets are managed manually on Darwin VMs
+  # Create /var/lib/openclaw/secrets/ directory and place files:
+  #   - discord-bot-token
+  #   - inception-api-key
+  # Then set the environmentFile in the OpenClaw service config
+  #
+  # The service will load these via environmentFile when starting
+
+  # Create secrets directory on activation
+  system.activationScripts.openclaw-secrets-dir = {
+    text = ''
+      echo "Creating OpenClaw secrets directory..."
+      mkdir -p /var/lib/openclaw/secrets
+      chown -R openclaw:openclaw /var/lib/openclaw
+      chmod 750 /var/lib/openclaw/secrets
+    '';
+  };
+
+  # SSH access for management
+  services.openssh.enable = true;
+  services.openssh.extraConfig = ''
+    PermitRootLogin no
+    PubkeyAuthentication yes
+    PasswordAuthentication no
+  '';
+
+  # Add host SSH key for access
+  users.users.openclaw.openssh.authorizedKeys.keys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIIxGvpCUmx1UV3K22/+sWLdRknZmlTmQgckoAUCApF8 monkey@MegamanX"
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIIxGvpCUmx1UV3K22/+sWLdRknZmlTmQgckoAUCApF8 monkey@protoman"
+  ];
+
+  # Allow passwordless sudo for deploy-rs
+  security.sudo.extraConfig = lib.mkForce ''
+    Defaults timestamp_timeout=0
+    openclaw ALL=(ALL) NOPASSWD: ALL
+  '';
+
+  # Minimal packages
+  environment.systemPackages = with pkgs; [
+    vim
+    git
+    curl
+    jq
+    htop
+  ];
+
+  # Log rotation
+  environment.etc."newsyslog.d/openclaw.conf".text = ''
+    /var/log/openclaw-gateway.log        root:wheel  644  5  10000 *  G
+    /var/log/openclaw-gateway.error.log  root:wheel  644  5  10000 *  G
+  '';
+}

--- a/targets/lume-vms/openclaw.nix
+++ b/targets/lume-vms/openclaw.nix
@@ -1,0 +1,98 @@
+# lume-openclaw.nix - NixOS VM configuration for Lume on Apple Silicon
+# This is a NixOS configuration that runs inside a Lume macOS VM
+# Designed for maximum isolation - OpenClaw runs here, not on the host
+{
+  lib,
+  pkgs,
+  ...
+}:
+with lib; {
+  imports = [
+    ../../modules/roles/openclaw-server
+  ];
+
+  # VM networking - will be bridged via Lume
+  networking.hostName = "openclaw-vm";
+  networking.useDHCP = true;
+
+  # Use the shared OpenClaw server role with Discord integration
+  myConfig.roles.openclawServer = {
+    enable = true;
+    port = 18789;
+
+    agentModel = "inception/default";
+
+    # Discord bot integration (matches your current openclaw-local setup)
+    discordChannel = {
+      enable = true;
+      tokenFile = "/var/lib/openclaw/secrets/discord-bot-token";
+      allowFrom = ["279110923438915586"]; # Your Discord user ID
+    };
+
+    # Inception AI API key
+    secrets.zenApiKeyFile = "/var/lib/openclaw/secrets/inception-api-key";
+
+    extraConfig = {
+      gateway = {
+        mode = "local";
+        bind = "0.0.0.0";
+      };
+      channels.discord.dmPolicy = "pairing";
+      agents.defaults = {
+        model = "inception/default";
+      };
+    };
+  };
+
+  # 1Password secrets integration (opnix)
+  services.onepassword-secrets = {
+    enable = true;
+    tokenFile = "/etc/opnix-token";
+
+    secrets = {
+      openclawDiscordToken = {
+        reference = "op://openclaw/Wadsworth - Discord API Token/credential";
+        path = "/var/lib/openclaw/secrets/discord-bot-token";
+        mode = "0600";
+        owner = "openclaw";
+      };
+
+      openclawInceptionKey = {
+        reference = "op://openclaw/Inception - Open Claw/credential";
+        path = "/var/lib/openclaw/secrets/inception-api-key";
+        mode = "0600";
+        owner = "openclaw";
+      };
+    };
+  };
+
+  # SSH access for management
+  services.openssh = {
+    enable = true;
+    settings = {
+      PermitRootLogin = "no";
+      PubkeyAuthentication = true;
+      PasswordAuthentication = false;
+    };
+  };
+
+  # Add your SSH key
+  users.users.openclaw.openssh.authorizedKeys.keys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIIxGvpCUmx1UV3K22/+sWLdRknZmlTmQgckoAUCApF8 monkey@MegamanX"
+  ];
+
+  # Additional tools
+  environment.systemPackages = with pkgs; [
+    htop
+    curl
+    jq
+    git
+  ];
+
+  # Basic system configuration
+  time.timeZone = "America/New_York";
+  system.stateVersion = "25.05";
+
+  # Disable auto-upgrade (manage via Lume/nix-darwin on host)
+  system.autoUpgrade.enable = lib.mkForce false;
+}

--- a/targets/microvms/defaults.nix
+++ b/targets/microvms/defaults.nix
@@ -7,7 +7,8 @@
   lib,
   ...
 }: {
-  nixpkgs.hostPlatform = "x86_64-linux";
+  # Don't set hostPlatform here - it should come from the system parameter in mkMicrovm
+  # This allows different architectures (x86_64-linux, aarch64-linux)
   myConfig = lib.mkMerge [
     {
       skills = {

--- a/targets/microvms/openclaw.nix
+++ b/targets/microvms/openclaw.nix
@@ -1,13 +1,13 @@
 # openclaw.nix - OpenClaw AI Assistant MicroVM
-# Secrets come from 1Password via opnix
-# https://github.com/openclaw/openclaw
+# Uses shared openclaw-server role for consistency with Lume VMs
 {
+  config,
   lib,
   pkgs,
   ...
 }: {
   imports = [
-    ../../modules/services/openclaw
+    ../../modules/roles/openclaw-server.nix
   ];
 
   networking.hostName = "openclaw";
@@ -21,70 +21,41 @@
     gateway = "192.168.83.1";
   };
 
-  services.openclaw = {
+  # Use the shared OpenClaw server role
+  myConfig.roles.openclawServer = {
     enable = true;
     port = 18789;
-    openFirewall = true;
+    # Use default openclaw user to avoid conflicts with myConfig.users "dev"
+    # The openclaw-server role creates this user with isSystemUser = true
+    agentModel = "zen/default";
 
-    user = "dev";
-    group = "users";
-    dataDir = "/home/dev";
+    # Enable Discord channel
+    discordChannel = {
+      enable = true;
+      tokenFile = "/run/secrets/openclaw-discord-bot-token";
+      allowFrom = ["279110923438915586"]; # Your Discord user ID
+    };
 
-    # Secrets loaded from opnix at /run/secrets/
-    environmentFile = "/run/openclaw/generated-env";
+    # Enable Matrix channel for microvm environment (optional, can disable if only using Discord)
+    matrixChannel = {
+      enable = true;
+      homeserver = "http://192.168.83.15:8008";
+      userId = "@openclaw:matrix.local";
+    };
+
+    # Secrets via opnix
+    secrets = {
+      zenApiKeyFile = "/run/secrets/openclaw-zen-api-key";
+      matrixTokenFile = "/run/secrets/openclaw-matrix-access-token";
+    };
 
     extraConfig = {
-      agent = {
-        model = "zen/default";
-      };
-
       gateway = {
         bind = "0.0.0.0";
         verbose = true;
       };
-
-      channels = {
-        matrix = {
-          enabled = true;
-          homeserver = "http://192.168.83.15:8008";
-          userId = "@openclaw:matrix.local";
-        };
-      };
+      channels.discord.dmPolicy = "pairing";
     };
-
-    # Additional hardening for microvm environment
-    hardening = {
-      protectHome = "read-only";
-      restrictAddressFamilies = ["AF_INET" "AF_INET6" "AF_NETLINK"];
-      lockPersonality = true;
-    };
-  };
-
-  # Generate env file from opnix secrets at boot
-  systemd.services.openclaw-generate-env = {
-    description = "Generate OpenClaw environment file from secrets";
-    after = ["onepassword-secrets.service"];
-    before = ["openclaw-gateway.service"];
-    wantedBy = ["multi-user.target"];
-
-    serviceConfig = {
-      Type = "oneshot";
-      RemainAfterExit = true;
-      User = "dev";
-      Group = "users";
-    };
-
-    script = ''
-      mkdir -p /run/openclaw
-
-      MATRIX_TOKEN=$(cat /run/secrets/openclaw-matrix-access-token 2>/dev/null || echo "placeholder_token")
-      ZEN_KEY=$(cat /run/secrets/openclaw-zen-api-key 2>/dev/null || echo "zen_placeholder")
-
-      echo "OPENCLAW_MATRIX_ACCESS_TOKEN=$MATRIX_TOKEN" > /run/openclaw/generated-env
-      echo "ZEN_API_KEY=$ZEN_KEY" >> /run/openclaw/generated-env
-
-      chmod 600 /run/openclaw/generated-env
-    '';
   };
 
   # Opnix secrets configuration
@@ -108,7 +79,31 @@
         owner = "dev";
         services = ["openclaw-generate-env" "openclaw-gateway"];
       };
+
+      openclawDiscordToken = {
+        reference = "op://Homelab/OpenClaw/discord-bot-token";
+        path = "/run/secrets/openclaw-discord-bot-token";
+        mode = "0600";
+        owner = "dev";
+        services = ["openclaw-generate-env" "openclaw-gateway"];
+      };
     };
+  };
+
+  # Configure microvm for vfkit compatibility when using vfkit hypervisor
+  microvm = lib.mkIf (config.microvm.hypervisor == "vfkit") {
+    # Use virtiofs for shares on macOS (9p doesn't work)
+    shares = lib.mkDefault [
+      {
+        source = "/nix/store";
+        mountPoint = "/nix/.ro-store";
+        tag = "ro-store";
+        proto = "virtiofs";
+      }
+    ];
+
+    # Note: forwardPorts only works with qemu, not vfkit
+    # The vfkit runner handles networking differently
   };
 
   environment.systemPackages = with pkgs; [

--- a/targets/type-darwin-server/default.nix
+++ b/targets/type-darwin-server/default.nix
@@ -1,0 +1,133 @@
+# type-darwin-server - Generic headless Darwin server configuration
+# Minimal setup for running macOS VMs via Lume
+# OpenClaw runs inside a Darwin VM for isolation
+{
+  mkUser,
+  inputs,
+  pkgs,
+  lib,
+  ...
+}: {
+  nixpkgs.hostPlatform = "aarch64-darwin";
+  system.stateVersion = 4;
+  system.primaryUser = "monkey";
+
+  myConfig =
+    mkUser "monkey" "me@willweaver.dev"
+    // {
+      skills.superpowersPath = inputs.superpowers;
+      roles = {
+        developer.enable = true; # Basic dev tools for VM management
+        opencode.enable = true; # AI assistant for management tasks
+      };
+      opencode = {
+        enable = true;
+        # Use remote LLM APIs since no local Ollama
+        model = null; # User will select on first run
+      };
+      llmClient.rtk.enable = true;
+      lume = {
+        enable = true;
+        enableBackgroundService = true;
+        port = 7777;
+        enableAutoUpdater = true;
+        # Pre-pull macOS Tahoe vanilla image for quick VM creation
+        prePullImages = ["macos-tahoe-vanilla:latest"];
+      };
+    };
+
+  # SSH server (Darwin doesn't support services.openssh.settings, use extraConfig for hardening)
+  services.openssh.enable = true;
+  services.openssh.extraConfig = ''
+    PermitRootLogin no
+    PubkeyAuthentication yes
+    PasswordAuthentication no
+  '';
+
+  # Note: Using Determinate Nix which manages its own daemon
+  # Cannot use nix-darwin's nix.linux-builder with Determinate
+  # Will set up Linux builder manually or use alternative approach
+
+  # Add MegamanX SSH key for passwordless login
+  users.users.monkey.openssh.authorizedKeys.keys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIIxGvpCUmx1UV3K22/+sWLdRknZmlTmQgckoAUCApF8 monkey@MegamanX"
+  ];
+
+  # Allow passwordless sudo for deploy-rs automated deployments
+  # This is required because deploy-rs activates the system over SSH
+  # and needs to run sudo commands on the remote host
+  security.sudo.extraConfig = lib.mkForce ''
+    Defaults timestamp_timeout=0
+    monkey ALL=(ALL) NOPASSWD: ALL
+  '';
+
+  # VM management tools - just Lume for macOS VMs
+  environment.systemPackages = with pkgs; [
+    curl # For downloading VM images
+    jq # For parsing Lume API responses
+  ];
+
+  # Lume VM management scripts
+  # Provides helper commands for creating and managing the OpenClaw VM
+  environment.etc."lume/openclaw-vm-setup.sh".text = ''
+    #!/bin/bash
+    # Setup script for OpenClaw VM
+    # Run this once to create the VM, then deploy with: deploy .#openclaw-vm
+
+    set -euo pipefail
+
+    VM_NAME="openclaw-vm"
+    VM_IMAGE="macos-tahoe-vanilla:latest"
+
+    echo "Setting up OpenClaw VM..."
+
+    # Check if Lume is running
+    if ! lume list &>/dev/null; then
+      echo "ERROR: Lume daemon is not running. Start it with: lume serve"
+      exit 1
+    fi
+
+    # Check if VM already exists
+    if lume list | grep -q "$VM_NAME"; then
+      echo "VM '$VM_NAME' already exists. Starting it..."
+      lume start "$VM_NAME"
+    else
+      echo "Creating VM '$VM_NAME' from image '$VM_IMAGE'..."
+      lume create "$VM_NAME" --image "$VM_IMAGE"
+      echo "VM created. Starting it..."
+      lume start "$VM_NAME"
+      echo ""
+      echo "=========================================="
+      echo "VM created and started!"
+      echo ""
+      echo "Next steps:"
+      echo "1. SSH into the VM: lume ssh $VM_NAME"
+      echo "2. Install Nix: curl -L https://nixos.org/nix/install | sh"
+      echo "3. Install nix-darwin: nix run nix-darwin/nix-darwin-24.11#darwin-rebuild -- switch --flake .#openclaw-vm"
+      echo "4. Or deploy from host: deploy .#openclaw-vm"
+      echo "=========================================="
+    fi
+  '';
+
+  # Note: OpenClaw now runs inside a Darwin VM managed by Lume
+  # The VM is a native macOS system that can run nix-darwin
+  # Deploy with: deploy .#openclaw-vm
+  #
+  # To set up the VM for the first time:
+  # 1. Ensure Lume is running: lume serve
+  # 2. Create the VM: lume create openclaw-vm --image macos-tahoe-vanilla:latest
+  # 3. Start the VM: lume start openclaw-vm
+  # 4. SSH into the VM: lume ssh openclaw-vm
+  # 5. Install Nix inside the VM: curl -L https://nixos.org/nix/install | sh
+  # 6. Exit and deploy from host: deploy .#openclaw-vm
+
+  # Log rotation for service logs using newsyslog
+  environment.etc."newsyslog.d/lume-services.conf".text = ''
+    # Log rotation for Lume services
+    # Format: logfile owner mode count size when flags [pid_file] [sig_num]
+
+    # Lume daemon logs
+    /tmp/lume_daemon.log    root:wheel  644  5  10000 *  G
+    /tmp/lume_daemon.err    root:wheel  644  5  10000 *  G
+  '';
+}

--- a/tests/test-services.nix
+++ b/tests/test-services.nix
@@ -192,6 +192,14 @@
             type = lib.types.anything;
             default = {};
           };
+          options.launchd = lib.mkOption {
+            type = lib.types.anything;
+            default = {};
+          };
+          options.system = lib.mkOption {
+            type = lib.types.anything;
+            default = {};
+          };
           options.networking = lib.mkOption {
             type = lib.types.anything;
             default = {};


### PR DESCRIPTION
## Summary

Adds deploy-rs configuration for deploying to protoman (Mac Mini M4) with llama-swap for local LLM management.

## Changes

- **deploy-rs**: Multi-platform deployment tool for NixOS/Darwin
- **type-darwin-server**: New Darwin server configuration for protoman
- **llama-swap**: Model swapping proxy replacing direct llama-server
  - Provides OpenAI-compatible API at `http://192.168.1.192:11434/v1`
  - Configured with Qwen3.5-9B model
  - Supports model aliases: `qwen`, `qwen3.5`, `default`
- **openclaw-server role**: Shared role for OpenClaw AI Gateway
- **openclaw-vfkit MicroVM**: NixOS VM running on protoman via vfkit
- **devenv task**: `deploy:protoman` with 1Password integration
- **Remote builds**: Enabled for faster deployment
- **Passwordless sudo**: Required for deploy-rs activation

## Usage

```bash
# Deploy to protoman
devenv tasks run deploy:protoman

# Or manually:
deploy .#protoman
```

Requires 1Password CLI with `op://Homelab/protoman-sudo/password`.

## Architecture

```
Discord → OpenClaw Gateway (NixOS VM) → llama-swap (host: qwen3.5)
              ↓
       1Password (opnix)
              ↓
    /var/lib/openclaw/secrets/
```

## Testing

- [x] Deploy builds successfully
- [x] llama-swap service running on protoman
- [x] API responds at `http://192.168.1.192:11434/v1/models`
- [x] OpenClaw VM can connect to llama-swap
- [x] `devenv tasks run check:lint` passes
- [x] Darwin configuration evaluates correctly

## Notes

Replaces the previous colmena deployment approach with deploy-rs for better macOS support.