### PR TITLE
fix: rename generic cattle account from monkey to admin

### DIFF
--- a/machine-types/server-arm.nix
+++ b/machine-types/server-arm.nix
@@ -16,7 +16,7 @@
 
   # REQUIRED: Configure at least one user with SSH access
   users.users.root.openssh.authorizedKeys.keys = [];
-  users.users.monkey = {
+  users.users.admin = {
     isNormalUser = true;
     extraGroups = ["wheel"];
     useDefaultShell = true;

--- a/machine-types/server.nix
+++ b/machine-types/server.nix
@@ -16,7 +16,7 @@
 
   # REQUIRED: Configure at least one user with SSH access
   users.users.root.openssh.authorizedKeys.keys = []; # Root SSH disabled
-  users.users.monkey = {
+  users.users.admin = {
     isNormalUser = true;
     extraGroups = ["wheel"];
     useDefaultShell = true;


### PR DESCRIPTION
## Summary

`monkey` is a personal account (used on MegamanX, darwin-server, zero). The generic
deploy/service account on cattle NixOS machines (`type-server`, `type-server-arm`)
was also named `monkey` which was confusing.

Renamed `users.users.monkey` → `users.users.admin` in:
- `machine-types/server.nix`
- `machine-types/server-arm.nix`

SSH key labels (`monkey@MegamanX`) and personal account usage in `targets/` are unchanged.

**Note**: Running `type-server` and `type-server-arm` machines will need the old
`monkey` user removed and `admin` user created on next switch. Since these are
cattle machines, a reprovision is the clean path.