### PR TITLE
feat: add blocked-by context parsing to yak-triage.sh

### DIFF
--- a/modules/home-manager/skills/internal/shave-yaks/scripts/yak-triage.sh
+++ b/modules/home-manager/skills/internal/shave-yaks/scripts/yak-triage.sh
@@ -6,12 +6,19 @@
 #   - Have no children of their own (leaf nodes)
 #   - Are not tagged with any blocking tag (e.g. @needs-human, @needs-e2e-vm)
 #   - Are not already wip (claimed by another agent)
+#   - Do not have a non-empty "## Blocked By" section in their context markdown
+#
+# Context is parsed directly from the JSON returned by `yx ls --format json`;
+# no extra `yx context` calls are needed. A yak is considered semantically
+# blocked if its context contains "## Blocked By" followed by non-whitespace
+# content on the next line.
 #
 # Usage:
-#   ./yak-triage.sh                  # Print actionable yaks as JSON array
-#   ./yak-triage.sh --names          # Print just the names, one per line
-#   ./yak-triage.sh --count          # Print count only
-#   ./yak-triage.sh --max N          # Limit output to N yaks (default: unlimited)
+#   ./yak-triage.sh                   # Print actionable yaks as JSON array
+#   ./yak-triage.sh --names           # Print just the names, one per line
+#   ./yak-triage.sh --count           # Print count only
+#   ./yak-triage.sh --max N           # Limit output to N yaks (default: unlimited)
+#   ./yak-triage.sh --include-blocked # Include yaks blocked by "## Blocked By" (debug)
 #
 # Exit codes:
 #   0 - found actionable yaks
@@ -22,11 +29,13 @@ set -euo pipefail
 # Parse args
 MODE="json"
 MAX=0
+INCLUDE_BLOCKED=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --names) MODE="names" ;;
-        --count) MODE="count" ;;
-        --max)   MAX="$2"; shift ;;
+        --names)           MODE="names" ;;
+        --count)           MODE="count" ;;
+        --max)             MAX="$2"; shift ;;
+        --include-blocked) INCLUDE_BLOCKED=true ;;
         *) echo "Unknown arg: $1" >&2; exit 1 ;;
     esac
     shift
@@ -44,16 +53,36 @@ BLOCKING_TAGS=(
 # Get all yaks as flat JSON
 all_yaks=$(yx ls --format json 2>/dev/null)
 
-# Filter to actionable leaf yaks using Python (available everywhere)
-actionable=$(python3 - "$all_yaks" "${BLOCKING_TAGS[@]}" <<'PYEOF'
-import json, sys
+# Filter to actionable leaf yaks using Python (available everywhere).
+# Also filters out semantically blocked yaks (## Blocked By in context)
+# unless INCLUDE_BLOCKED is "true".
+actionable=$(python3 - "$all_yaks" "$INCLUDE_BLOCKED" "${BLOCKING_TAGS[@]}" <<'PYEOF'
+import json, sys, re
 
 raw = sys.argv[1]
-blocking_tags = set(sys.argv[2:])
+include_blocked = sys.argv[2].lower() == "true"
+blocking_tags = set(sys.argv[3:])
 
 yaks = json.loads(raw)
 
-def is_actionable(yak):
+def has_blocked_by(context):
+    """Return True if context has a non-empty '## Blocked By' section."""
+    if not context:
+        return False
+    lines = context.splitlines()
+    for i, line in enumerate(lines):
+        if re.match(r'^## Blocked By\s*$', line, re.IGNORECASE):
+            # Look at the next non-empty line
+            for j in range(i + 1, len(lines)):
+                next_line = lines[j].strip()
+                if next_line and not next_line.startswith("#"):
+                    return True
+                elif next_line.startswith("##"):
+                    # Hit the next section header with no content
+                    break
+    return False
+
+def is_actionable(yak, include_blocked):
     # Must be todo state
     if yak.get("state") != "todo":
         return False
@@ -66,6 +95,9 @@ def is_actionable(yak):
     # Must not have blocking tags
     tags = set(yak.get("tags", []))
     if tags & blocking_tags:
+        return False
+    # Must not have a non-empty "## Blocked By" section in context
+    if not include_blocked and has_blocked_by(yak.get("context")):
         return False
     return True
 
@@ -81,7 +113,7 @@ def flatten(yaks):
     return result
 
 flat = flatten(yaks)
-actionable = [y for y in flat if is_actionable(y)]
+actionable = [y for y in flat if is_actionable(y, include_blocked)]
 print(json.dumps(actionable, indent=2))
 PYEOF
 )


### PR DESCRIPTION
## Summary
- Enhanced `yak-triage.sh` to filter out semantically blocked yaks by parsing `## Blocked By` sections in yak context markdown
- Added `--include-blocked` flag for debugging (shows blocked yaks)
- Updated header comment to document new behavior

## Problem
Triage was reporting false positives — yaks as "actionable" when their context had a `## Blocked By` section, because the yx metadata didn't reflect this dependency.

## Solution
The Python filter now calls `has_blocked_by()` which parses the `context` field (already present in `yx ls --format json` output) for a `## Blocked By` heading followed by non-empty non-heading content. No extra `yx context` calls needed.

## Acceptance Criteria Met
- [x] `yak-triage.sh` parses context from existing JSON output (no extra calls)
- [x] If context contains `## Blocked By` with non-empty content, yak is excluded
- [x] Performance: only uses context already in the JSON payload
- [x] `--include-blocked` flag added for debugging
- [x] Script header updated to document new behavior

## Testing
- Tests written first (TDD RED → GREEN)
- `check:lint` ✓
- `test:darwin-eval` ✓