### PR TITLE
docs: standardize jj workspace workflow for humans and agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -436,6 +436,76 @@ If `.jj/` directory exists:
 4. Use `jj describe` for commit messages
 5. Never mix git and jj commands
 
+### Workspace Workflow (Agents Must Use Workspaces)
+
+Workspaces isolate each change in flight. **Agents MUST use workspaces for all non-trivial changes.**
+
+#### Workspace Location
+
+Workspaces live in `~/workspaces/` (not inside the repository as sibling directories):
+
+```
+~/workspaces/
+  feat-auth-20260512-a1b2/     ← workspace directory
+  fix-bug-20260512-c3d4/       ← another workspace
+```
+
+Use `fjj` to create workspaces from any directory:
+
+```bash
+fjj feat/my-topic              # Create workspace from main
+fjj fix/bug-name develop       # Create workspace from develop
+fjj list                       # Show all workspaces
+fjj clean                      # Remove merged/stale workspaces
+```
+
+#### Agent Workspace Naming
+
+Agent workspace names encode agent identity and purpose:
+
+```
+feat/agent-<agent-id>-<topic>     # e.g. feat/agent-openclaw-hostid-fix
+fix/agent-<agent-id>-<topic>      # e.g. fix/agent-openclaw-lint-error
+```
+
+This lets humans distinguish agent workspaces from human workspaces at a glance.
+
+#### Example Workflow: Create → Work → Finish → Clean
+
+```bash
+# 1. Create workspace (stored in ~/workspaces/, NOT in repo)
+fjj feat/agent-openclaw-my-feature
+
+# 2. cd into the workspace
+cd ~/workspaces/feat-agent-openclaw-my-feature-<date>-<id>
+
+# 3. Work and commit (the working copy IS a commit — no git add needed)
+# ... make changes ...
+jj describe -m "feat: add my feature"
+
+# 4. Validate from repo root (devenv tasks require repo root)
+cd /path/to/repo && devenv tasks run check:lint
+
+# 5. Push and create PR (from workspace dir)
+cd ~/workspaces/feat-agent-openclaw-my-feature-<date>-<id>
+jj bookmark set feat/my-feature -r @
+jj git push --bookmark feat/my-feature
+gh pr create --head feat/my-feature
+
+# 6. After PR is merged: clean up
+jj workspace forget feat-agent-openclaw-my-feature-<date>-<id>
+rm -rf ~/workspaces/feat-agent-openclaw-my-feature-<date>-<id>
+```
+
+#### Session TTL
+
+`jj-workspace-session` manages fast sync (every 5 min) during active sessions. Sessions auto-expire after 30 minutes of inactivity. Prune expired sessions with:
+
+```bash
+jj-workspace-session prune
+jj-workspace-session status   # Show active sessions
+```
+
 ### Commit-First Workflow (Required)
 
 **This repository does NOT use `allow-dirty`** - Nix flakes require a clean git state.

--- a/modules/home-manager/skills/external/jj/SKILL.md
+++ b/modules/home-manager/skills/external/jj/SKILL.md
@@ -169,9 +169,29 @@ Rules:
 
 ## Workspaces (OpenCode sessions)
 
-Workspaces let you isolate work and enable fast background sync.
+Workspaces isolate work in flight and enable fast background sync.
+**All workspaces live in `~/workspaces/`** — never as sibling directories inside the repo.
 
-### Starting a session
+### Workspace location
+
+```
+~/workspaces/
+  feat-auth-20260512-a1b2/     ← workspace directory
+  fix-bug-20260512-c3d4/       ← another workspace
+```
+
+### Creating a workspace
+
+Use `fjj` (Fast JJ) from any directory:
+
+```bash
+fjj feat/my-topic              # Create workspace from main
+fjj fix/bug-name develop       # Create workspace from develop branch
+fjj list                       # Show all workspaces
+fjj clean                      # Remove merged/stale workspaces
+```
+
+Or with the `/workspace` slash command in OpenCode:
 
 ```
 /workspace feat/user-auth        # Create workspace from main
@@ -179,20 +199,16 @@ Workspaces let you isolate work and enable fast background sync.
 /workspace                       # Enable fast sync in current workspace
 ```
 
-Or CLI:
-```bash
-jj-workspace-session start feat/auth
-jj-workspace-session start
+### Agent workspace naming
+
+Agent workspace names encode agent identity:
+
+```
+feat/agent-<agent-id>-<topic>     # e.g. feat/agent-openclaw-auth-fix
+fix/agent-<agent-id>-<topic>      # e.g. fix/agent-openclaw-lint
 ```
 
-### What happens
-
-1. **Workspace created**: `feat/auth-20260223-a1b2` (type/topic-date-id).
-2. **Fast sync enabled**: repository syncs every 5 minutes (vs hourly).
-3. **Main stays clean**: your work is isolated, main auto-syncs with upstream.
-4. **Session TTL**: auto-expires after 30 minutes of inactivity (resets on each sync).
-
-### Session commands
+### Session commands (fast sync)
 
 ```bash
 jj-workspace-session start [type/topic] [base]
@@ -203,22 +219,38 @@ jj-workspace-session sync      # Manual sync
 jj-workspace-session prune     # Remove expired sessions
 ```
 
-### Ending a session
+### What happens when a session starts
+
+1. **Workspace created**: `feat/auth-20260223-a1b2` (type/topic-date-id).
+2. **Fast sync enabled**: repository syncs every 5 minutes (vs hourly).
+3. **Main stays clean**: your work is isolated, main auto-syncs with upstream.
+4. **Session TTL**: auto-expires after 30 minutes of inactivity (resets on each sync).
+
+### Full workflow: Create → Work → Finish → Clean
 
 ```bash
-jj-workspace-session stop
-jj-workspace remove <name>     # When fully done
-```
+# 1. Create workspace
+fjj feat/agent-openclaw-my-feature
 
-### Workspace commands
+# 2. cd into workspace
+cd ~/workspaces/feat-agent-openclaw-my-feature-<date>-<id>
 
-```bash
-jj-workspace create feat/user-auth      # Creates feat/user-auth-<date>-<id>
-jj-workspace create fix/bug develop
-jj-workspace list
-jj-workspace remove <name>
-jj-workspace clean                       # Remove all
-jj-workspace status
+# 3. Work and commit (working copy IS a commit)
+# ... make changes ...
+jj describe -m "feat: add my feature"
+
+# 4. Validate (devenv tasks run from repo root)
+cd /path/to/repo && devenv tasks run check:lint
+
+# 5. Push and create PR
+cd ~/workspaces/feat-agent-openclaw-my-feature-<date>-<id>
+jj bookmark set feat/my-feature -r @
+jj git push --bookmark feat/my-feature
+gh pr create --head feat/my-feature
+
+# 6. Clean up after merge
+jj workspace forget feat-agent-openclaw-my-feature-<date>-<id>
+rm -rf ~/workspaces/feat-agent-openclaw-my-feature-<date>-<id>
 ```
 
 ## Background Auto-Sync

--- a/modules/home-manager/skills/external/jj/commands/workspace.md
+++ b/modules/home-manager/skills/external/jj/commands/workspace.md
@@ -5,18 +5,26 @@ agent: build
 
 Manage jj workspaces for isolating work.
 
-Use the jj skill for reference. The script is at `jj-workspace` in PATH.
+Workspaces live in `~/workspaces/` — never as sibling directories inside the repo.
 
-Run: `jj-workspace $ARGUMENTS`
+Use `fjj` to create and manage workspaces:
 
-Commands:
-- `create <type/topic> [base]` - Create new workspace (e.g., feat/user-auth)
-- `list` - Show all workspaces
-- `remove <name>` - Remove a workspace
-- `clean` - Remove all workspaces  
-- `status` - Status of all workspaces
+```bash
+fjj feat/my-topic              # Create workspace from main
+fjj fix/bug-name develop       # Create workspace from develop branch
+fjj list                       # Show all workspaces
+fjj clean                      # Remove merged/stale workspaces
+```
 
 Naming convention: `<type>/<topic>-<date>-<id>`
 Types: feat, fix, hotfix, chore, release
+
+**Agent naming**: `feat/agent-<agent-id>-<topic>` (e.g. `feat/agent-openclaw-auth-fix`)
+
+After PR is merged, clean up:
+```bash
+jj workspace forget <workspace-name>
+rm -rf ~/workspaces/<workspace-name>
+```
 
 If no arguments, show workspace list and ask what they want to do.


### PR DESCRIPTION
## Summary
- Documents that workspaces live in `~/workspaces/` (via `fjj`), not as repo siblings
- Adds agent workspace naming convention: `feat/agent-<agent-id>-<topic>`
- Adds create→work→finish→clean example workflow to AGENTS.md
- Updates jj SKILL.md workspace section with correct location and `fjj` usage
- Updates `/workspace` command docs to use `fjj` instead of the non-existent `jj-workspace`

## Motivation
The yak backlog had open questions about where fjj stores workspaces. This confirms and documents:
- **Location**: `~/workspaces/` (configurable via `FJJ_WORKSPACE_ROOT`)
- **Not**: `~/.jj/workspaces/` (as was incorrectly stated in some docs)
- **Tool**: `fjj` creates workspaces; `jj-workspace` command does not exist in PATH

## Acceptance Criteria Met
- [x] Workspace location documented in AGENTS.md
- [x] fjj/workspace confirmed to use `~/workspaces/` fixed location
- [x] Agent workspace naming convention documented
- [x] `/workspace` OpenCode command docs updated (uses fjj)
- [x] jj skill updated with correct location guidance
- [x] Example workflow added to AGENTS.md

## Testing
- `check:lint` ✓
- `test:darwin-eval` ✓ (docs-only change)