### PR TITLE
feat: Flake decomposition Phase 0 + Phase 1 — foundation and microvm migration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -155,7 +155,7 @@
     _mkMicrovmV2 = name: roleEnables:
       nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
-        specialArgs = inputs // {inherit inputs roleEnables;};
+        specialArgs = inputs // {inherit roleEnables;};
         modules = [
           microvm.nixosModules.microvm
           home-manager.nixosModules.home-manager

--- a/flake.nix
+++ b/flake.nix
@@ -171,12 +171,6 @@
           ./targets/microvms/defaults.nix
           ./targets/microvms/${name}.nix
           {home-manager.sharedModules = [opnix.homeManagerModules.default];}
-          # Resolve pre-existing shell conflict: users.nix sets useDefaultShell
-          # via myConfig.users, and dev-vm.nix also sets shell. Give priority
-          # to the target file's explicit shell.
-          ({lib, ...}: {
-            users.users.dev.useDefaultShell = lib.mkForce false;
-          })
         ];
       };
   in {
@@ -412,11 +406,13 @@
       };
 
       # Phase 1: MicroVM v2 configs using new library mkNixosSystem
-      # Runs in parallel with microvm.nixosConfigurations until verified
-      "dev-vm-v2" = _mkMicrovmV2 "dev-vm" {
-        roles.opencode.enable = true;
-      };
-      "openclaw-v2" = _mkMicrovmV2 "openclaw" {};
+      # Runs in parallel with microvm.nixosConfigurations until verified.
+      # NOTE: dev-vm-v2 and openclaw-v2 deferred — pre-existing shell/
+      # agent-user conflicts surface when built via nixosConfigurations.
+      # "dev-vm-v2" = _mkMicrovmV2 "dev-vm" {
+      #   roles.opencode.enable = true;
+      # };
+      # "openclaw-v2" = _mkMicrovmV2 "openclaw" {};
       "matrix-v2" = _mkMicrovmV2 "matrix" {};
       "media-center-v2" = _mkMicrovmV2 "media-center" {};
     };

--- a/flake.nix
+++ b/flake.nix
@@ -155,7 +155,7 @@
     _mkMicrovmV2 = name: roleEnables:
       nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
-        specialArgs = inputs // {inherit roleEnables;};
+        specialArgs = inputs // {inherit inputs roleEnables;};
         modules = [
           microvm.nixosModules.microvm
           home-manager.nixosModules.home-manager

--- a/flake.nix
+++ b/flake.nix
@@ -151,6 +151,28 @@
           {home-manager.sharedModules = [opnix.homeManagerModules.default];}
         ];
       };
+    # Phase 1: MicroVM v2 helper using new library mkNixosSystem
+    _mkMicrovmV2 = name: roleEnables:
+      nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        specialArgs = inputs // {inherit roleEnables;};
+        modules = [
+          microvm.nixosModules.microvm
+          home-manager.nixosModules.home-manager
+          opnix.nixosModules.default
+          configuration
+          ./modules
+          ./modules/nixos/base.nix
+          ./modules/services/ollama/nixos.nix
+          ./modules/services/openclaw
+          inputs.nix-openclaw.nixosModules.openclaw-gateway
+          ./os/microvm.nix
+          ./modules/microvm
+          ./targets/microvms/defaults.nix
+          ./targets/microvms/${name}.nix
+          {home-manager.sharedModules = [opnix.homeManagerModules.default];}
+        ];
+      };
   in {
     packages = forAllSystems (
       system: let
@@ -382,6 +404,15 @@
           ./machine-types/server-arm.nix
         ];
       };
+
+      # Phase 1: MicroVM v2 configs using new library mkNixosSystem
+      # Runs in parallel with microvm.nixosConfigurations until verified
+      "dev-vm-v2" = _mkMicrovmV2 "dev-vm" {
+        roles.opencode.enable = true;
+      };
+      "openclaw-v2" = _mkMicrovmV2 "openclaw" {};
+      "matrix-v2" = _mkMicrovmV2 "matrix" {};
+      "media-center-v2" = _mkMicrovmV2 "media-center" {};
     };
 
     microvm.nixosConfigurations = {

--- a/flake.nix
+++ b/flake.nix
@@ -171,6 +171,12 @@
           ./targets/microvms/defaults.nix
           ./targets/microvms/${name}.nix
           {home-manager.sharedModules = [opnix.homeManagerModules.default];}
+          # Resolve pre-existing shell conflict: users.nix sets useDefaultShell
+          # via myConfig.users, and dev-vm.nix also sets shell. Give priority
+          # to the target file's explicit shell.
+          ({lib, ...}: {
+            users.users.dev.useDefaultShell = lib.mkForce false;
+          })
         ];
       };
   in {

--- a/library/archetypes/desktop-nixos.nix
+++ b/library/archetypes/desktop-nixos.nix
@@ -1,0 +1,60 @@
+{
+  inputs,
+  lib,
+  ...
+}: {
+  imports = [];
+
+  myConfig = {
+    skills.superpowersPath = inputs.superpowers or null;
+  };
+
+  nixpkgs.config.allowUnfree = true;
+
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+  nix.settings.experimental-features = ["nix-command" "flakes"];
+
+  networking.networkmanager.enable = true;
+  networking.firewall.enable = lib.mkDefault true;
+
+  services = {
+    xserver = {
+      enable = true;
+    };
+    pulseaudio.enable = false;
+    pipewire = {
+      enable = true;
+      alsa.enable = true;
+      alsa.support32Bit = true;
+      pulse.enable = true;
+      jack.enable = true;
+    };
+  };
+
+  security.rtkit.enable = true;
+
+  programs.steam.enable = true;
+  programs.steam.remotePlay.openFirewall = true;
+  hardware.graphics = {
+    enable = true;
+    enable32Bit = true;
+  };
+
+  services.openssh = {
+    enable = true;
+    settings = {
+      PermitRootLogin = "prohibit-password";
+      PasswordAuthentication = false;
+      AllowAgentForwarding = true;
+    };
+  };
+
+  users.users.root.openssh.authorizedKeys.keys = [];
+
+  time.timeZone = "America/New_York";
+  i18n.defaultLocale = "en_US.UTF-8";
+
+  system.stateVersion = "25.05";
+}

--- a/library/archetypes/developer-laptop-darwin.nix
+++ b/library/archetypes/developer-laptop-darwin.nix
@@ -1,0 +1,26 @@
+{inputs, ...}: {
+  myConfig = {
+    skills.superpowersPath = inputs.superpowers or null;
+
+    roles = {
+      homebrew.enable = true;
+      desktop.enable = true;
+      entertainment.enable = true;
+    };
+  };
+
+  nixpkgs.config.allowUnfree = true;
+
+  users.users.root.openssh.authorizedKeys.keys = [];
+
+  services.openssh = {
+    enable = true;
+    settings = {
+      PermitRootLogin = "prohibit-password";
+      PasswordAuthentication = false;
+      AllowAgentForwarding = true;
+    };
+  };
+
+  time.timeZone = "America/New_York";
+}

--- a/library/archetypes/headless-server-darwin.nix
+++ b/library/archetypes/headless-server-darwin.nix
@@ -1,0 +1,18 @@
+{inputs, ...}: {
+  myConfig = {
+    skills.superpowersPath = inputs.superpowers or null;
+  };
+
+  users.users.root.openssh.authorizedKeys.keys = [];
+
+  services.openssh = {
+    enable = true;
+    settings = {
+      PermitRootLogin = "no";
+      PasswordAuthentication = false;
+      AllowAgentForwarding = true;
+    };
+  };
+
+  time.timeZone = "America/New_York";
+}

--- a/library/archetypes/headless-server-nixos.nix
+++ b/library/archetypes/headless-server-nixos.nix
@@ -1,0 +1,72 @@
+{
+  pkgs,
+  lib,
+  inputs,
+  ...
+}: {
+  imports = [
+    inputs.disko.nixosModules.disko
+  ];
+
+  myConfig = {
+    skills.superpowersPath = inputs.superpowers or null;
+    onepassword.tokenFile = "/etc/opnix/token";
+    roles.tailscale = {
+      enable = true;
+      authKeyOpnixItem = "op://Homelab/Tailscale Auth Key/credential";
+    };
+  };
+
+  hardware.facter.reportPath = "/etc/nixos/facter.json";
+
+  users.users.root.openssh.authorizedKeys.keys = [];
+  users.users.admin = {
+    isNormalUser = true;
+    extraGroups = ["wheel"];
+    useDefaultShell = true;
+    openssh.authorizedKeys.keys = [];
+  };
+
+  security.sudo.wheelNeedsPassword = false;
+
+  boot = {
+    loader.systemd-boot.enable = lib.mkDefault true;
+    loader.efi.canTouchEfiVariables = lib.mkDefault true;
+    kernelModules = ["kvm-intel" "kvm-amd"];
+  };
+
+  nix.settings.experimental-features = ["nix-command" "flakes"];
+
+  networking = {
+    useDHCP = lib.mkDefault true;
+    dhcpcd.extraConfig = ''
+      option host_name
+      send host-name = ""
+    '';
+    firewall = {
+      enable = true;
+      allowedTCPPorts = [22];
+    };
+  };
+
+  services.xserver.enable = false;
+
+  services.openssh = {
+    enable = true;
+    settings = {
+      PermitRootLogin = "no";
+      PubkeyAuthentication = true;
+      PasswordAuthentication = false;
+      AllowAgentForwarding = true;
+    };
+  };
+
+  environment.systemPackages = with pkgs; [
+    qemu
+    virtiofsd
+  ];
+
+  time.timeZone = "America/New_York";
+
+  system.stateVersion = "25.05";
+}

--- a/library/archetypes/microvm-guest.nix
+++ b/library/archetypes/microvm-guest.nix
@@ -1,0 +1,34 @@
+{
+  inputs,
+  lib,
+  ...
+}: {
+  myConfig = {
+    skills = {
+      superpowersPath = inputs.superpowers or null;
+      externalInputs = lib.mkIf (inputs ? vercel-skills) {
+        inherit (inputs) vercel-skills;
+      };
+    };
+
+    onepassword.enable = lib.mkForce false;
+    autoUpgrade.flakeUrl = lib.mkForce "";
+  };
+
+  networking.firewall.enable = true;
+
+  users.users.root.openssh.authorizedKeys.keys = [];
+
+  services.openssh = {
+    enable = true;
+    settings = {
+      PermitRootLogin = "prohibit-password";
+      PasswordAuthentication = false;
+      AllowAgentForwarding = true;
+    };
+  };
+
+  time.timeZone = "America/New_York";
+
+  system.stateVersion = "25.05";
+}

--- a/library/flake-module.nix
+++ b/library/flake-module.nix
@@ -1,0 +1,7 @@
+_: {
+  flake.nixosModules.library = {
+    imports = [
+      (import ../modules)
+    ];
+  };
+}

--- a/library/flake.nix
+++ b/library/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Configuration library — reusable modules, archetypes, and system builders";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.05";
+    nix-darwin.url = "github:nix-darwin/nix-darwin/master";
+    nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+    nix-homebrew.url = "github:zhaofengli/nix-homebrew";
+    microvm.url = "github:astro/microvm.nix";
+    microvm.inputs.nixpkgs.follows = "nixpkgs";
+    superpowers.url = "github:obra/superpowers";
+    superpowers.flake = false;
+    opnix.url = "github:brizzbuzz/opnix";
+    opnix.inputs.nixpkgs.follows = "nixpkgs";
+    disko.url = "github:nix-community/disko";
+    disko.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = {nixpkgs, ...}: let
+    inherit (nixpkgs) lib;
+  in {
+    lib = {
+      inherit (import ./lib/mk-system.nix {inherit lib;}) mkDarwinSystem mkNixosSystem;
+    };
+
+    nixosModules.default = import ./flake-module.nix;
+
+    flakeModules.default = import ./flake-module.nix;
+  };
+}

--- a/library/lib/mk-system.nix
+++ b/library/lib/mk-system.nix
@@ -1,0 +1,85 @@
+{lib}: rec {
+  mkDarwinSystem = {
+    inputs,
+    hostname,
+    system ? "aarch64-darwin",
+    modules ? [],
+    overrides ? {},
+  }: let
+    inherit (inputs) nix-darwin;
+  in
+    nix-darwin.lib.darwinSystem {
+      inherit system;
+      specialArgs = {inherit inputs;};
+      modules =
+        [
+          {
+            networking.hostName = hostname;
+            system.configurationRevision = inputs.self.rev or inputs.self.dirtyRev or null;
+            nixpkgs = {
+              config = {
+                allowUnfree = true;
+                permittedInsecurePackages = [
+                  "google-chrome-144.0.7559.97"
+                  "olm-3.2.16"
+                ];
+              };
+              overlays = [(import ../../overlays)];
+            };
+          }
+          (import ../../modules)
+        ]
+        ++ modules
+        ++ lib.optional (overrides != {}) {
+          myConfig = lib.mkMerge [
+            overrides
+            (lib.mkForce {})
+          ];
+        };
+    };
+
+  mkNixosSystem = {
+    inputs,
+    hostname,
+    system ? "x86_64-linux",
+    modules ? [],
+    overrides ? {},
+  }: let
+    inherit (inputs) nixpkgs;
+  in
+    nixpkgs.lib.nixosSystem {
+      inherit system;
+      specialArgs = inputs // {inherit inputs;};
+      modules =
+        [
+          {
+            networking.hostName = hostname;
+            system.configurationRevision = inputs.self.rev or inputs.self.dirtyRev or null;
+            nixpkgs = {
+              config = {
+                allowUnfree = true;
+                permittedInsecurePackages = [
+                  "google-chrome-144.0.7559.97"
+                  "olm-3.2.16"
+                ];
+              };
+              hostPlatform = system;
+              overlays = [(import ../../overlays)];
+            };
+          }
+          (import ../../modules)
+          inputs.home-manager.nixosModules.home-manager
+          {
+            home-manager.sharedModules = [
+              inputs.opnix.homeManagerModules.default
+            ];
+          }
+        ]
+        ++ modules
+        ++ lib.optional (overrides != {}) {
+          myConfig = lib.mkMerge [
+            (lib.mkOverride 50 overrides)
+          ];
+        };
+    };
+}

--- a/modules/common/agent-user.nix
+++ b/modules/common/agent-user.nix
@@ -48,9 +48,7 @@
         group = cfg.name;
         uid = lib.mkIf (cfg.uid != null) cfg.uid;
         description = "Service automation agent account (no sudo access)";
+        extraGroups = lib.mkForce [];
       };
-
-      # Ensure agent is NOT in wheel/sudo groups
-      users.users.${cfg.name}.extraGroups = lib.mkForce [];
     };
 }

--- a/profiles/monkey/flake.nix
+++ b/profiles/monkey/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Will Weaver personal profile";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    schema.url = "github:funkymonkeymonk/nix?dir=schema";
+  };
+
+  outputs = {schema, ...}: {
+    myProfile = schema.lib.mkProfile (import ./profile.nix);
+  };
+}

--- a/profiles/monkey/profile.nix
+++ b/profiles/monkey/profile.nix
@@ -1,0 +1,42 @@
+{
+  user = {
+    name = "monkey";
+    email = "me@willweaver.dev";
+    fullName = "Will Weaver";
+  };
+
+  roles = {
+    developer.enable = true;
+    desktop.enable = true;
+    workstation.enable = true;
+    entertainment.enable = true;
+    llm-host.enable = true;
+    opencode.enable = true;
+    pi.enable = true;
+    homebrew.enable = true;
+  };
+
+  opencode = {
+    model = "ollama/qwen3.5";
+    enableBrowserAgents = false;
+  };
+
+  providers = {
+    ollama = {
+      name = "Ollama Local";
+      baseURL = "http://localhost:11434/v1";
+      models = {
+        "qwen3.5:2b".name = "Qwen 3.5 2B (Fast)";
+        "qwen3.5".name = "Qwen 3.5 9B (Balanced)";
+        "qwen3.5:122b".name = "Qwen 3.5 122B (Quality)";
+      };
+    };
+    opencode-go = {
+      name = "OpenCode Go";
+      baseURL = "https://opencode.ai/zen/go/v1";
+      onePasswordItem = "op://Opnix/OpenCode Go API/credential";
+    };
+  };
+
+  claudeCode = {};
+}

--- a/profiles/wweaver/flake.nix
+++ b/profiles/wweaver/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Will Weaver work profile";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    schema.url = "github:funkymonkeymonk/nix?dir=schema";
+  };
+
+  outputs = {schema, ...}: {
+    myProfile = schema.lib.mkProfile (import ./profile.nix);
+  };
+}

--- a/profiles/wweaver/profile.nix
+++ b/profiles/wweaver/profile.nix
@@ -1,0 +1,43 @@
+{
+  user = {
+    name = "wweaver";
+    email = "wweaver@justworks.com";
+    fullName = "Will Weaver";
+  };
+
+  roles = {
+    developer.enable = true;
+    desktop.enable = true;
+    workstation.enable = true;
+    entertainment.enable = true;
+    llm-host.enable = true;
+    opencode.enable = true;
+    pi.enable = true;
+    homebrew.enable = true;
+  };
+
+  opencode = {
+    model = "just-llms/claude-sonnet-4-6";
+    disabledProviders = ["opencode"];
+    enableBrowserAgents = false;
+  };
+
+  providers = {
+    just-llms = {
+      name = "Just LLMs";
+      baseURLOpnixItem = "op://Justworks/LiteLLM/baseURL";
+      onePasswordItem = "op://Justworks/Justworks LiteLLM/wweaver-poweruser-key";
+      dynamicModels = true;
+    };
+    ollama = {
+      name = "Ollama (local)";
+      baseURL = "http://localhost:11434/v1";
+      models = {
+        "qwen3.5:latest".name = "Qwen 3.5 (7B)";
+        "qwen3.5:2b".name = "Qwen 3.5 (2B)";
+      };
+    };
+  };
+
+  claudeCode = {};
+}

--- a/schema/flake-module.nix
+++ b/schema/flake-module.nix
@@ -1,0 +1,3 @@
+_: {
+  flake.nixosModules.profile = import ./modules/profile.nix;
+}

--- a/schema/flake.nix
+++ b/schema/flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "Profile schema — shared contract between library and profile flakes";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = {nixpkgs}: let
+    inherit (nixpkgs) lib;
+  in {
+    lib = {
+      inherit (import ./modules/validator.nix {inherit lib;}) mkProfile;
+    };
+
+    nixosModules.profile = import ./modules/profile.nix;
+
+    flakeModules.default = import ./flake-module.nix;
+  };
+}

--- a/schema/modules/profile.nix
+++ b/schema/modules/profile.nix
@@ -1,0 +1,168 @@
+{lib, ...}: let
+  inherit (lib) mkOption types;
+in {
+  options.myProfile = {
+    user = {
+      name = mkOption {
+        type = types.str;
+        description = "Username for the primary user account";
+      };
+      email = mkOption {
+        type = types.str;
+        description = "Email address for the primary user";
+      };
+      fullName = mkOption {
+        type = types.str;
+        description = "Full name of the primary user";
+      };
+    };
+
+    roles = mkOption {
+      type = types.attrsOf (types.submodule {
+        options = {
+          enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Enable this role";
+          };
+        };
+      });
+      default = {};
+      description = "Role toggles — each key corresponds to a role in the library";
+    };
+
+    opencode = mkOption {
+      type = types.submodule {
+        options = {
+          model = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description = "Default LLM model for opencode";
+          };
+          theme = mkOption {
+            type = types.str;
+            default = "system";
+            description = "UI theme for opencode";
+          };
+          autoupdate = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Enable automatic updates for opencode";
+          };
+          enableBrowserAgents = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Enable browser automation agents";
+          };
+          disabledProviders = mkOption {
+            type = types.listOf types.str;
+            default = [];
+            description = "List of built-in provider names to disable";
+          };
+        };
+      };
+      default = {};
+      description = "OpenCode AI assistant preferences";
+    };
+
+    providers = mkOption {
+      type = types.attrsOf (types.submodule {
+        options = {
+          npm = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description = "NPM package for the provider";
+          };
+          name = mkOption {
+            type = types.str;
+            description = "Display name of the provider";
+          };
+          baseURL = mkOption {
+            type = types.str;
+            default = "";
+            description = "Base URL for the provider API";
+          };
+          models = mkOption {
+            type = types.attrsOf (types.submodule {
+              options = {
+                name = mkOption {
+                  type = types.str;
+                  description = "Display name of the model";
+                };
+              };
+            });
+            default = {};
+            description = "Available models for this provider";
+          };
+          dynamicModels = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Fetch available models from the provider's /v1/models endpoint at runtime";
+          };
+          onePasswordItem = mkOption {
+            type = types.str;
+            default = "";
+            description = "1Password item reference to retrieve API key";
+          };
+          baseURLOpnixItem = mkOption {
+            type = types.str;
+            default = "";
+            description = "1Password item reference to retrieve the base URL";
+          };
+        };
+      });
+      default = {};
+      description = "LLM provider configurations";
+    };
+
+    skills = mkOption {
+      type = types.submodule {
+        options = {
+          enabledRoles = mkOption {
+            type = types.listOf types.str;
+            default = [];
+            description = "List of enabled roles for skills filtering";
+          };
+          skillsPath = mkOption {
+            type = types.str;
+            default = ".config/opencode/skills";
+            description = "Path relative to home directory where skills are installed";
+          };
+        };
+      };
+      default = {};
+      description = "Agent skills preferences";
+    };
+
+    llmEndpoints = mkOption {
+      type = types.attrsOf (types.submodule {
+        options = {
+          host = mkOption {
+            type = types.str;
+            description = "Host address for the LLM endpoint";
+          };
+          port = mkOption {
+            type = types.str;
+            description = "Port for the LLM endpoint";
+          };
+        };
+      });
+      default = {};
+      description = "Additional LLM endpoint configurations";
+    };
+
+    claudeCode = mkOption {
+      type = types.submodule {
+        options = {
+          includeCoAuthoredBy = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Include Co-Authored-By trailers in commits";
+          };
+        };
+      };
+      default = {};
+      description = "Claude Code preferences";
+    };
+  };
+}

--- a/schema/modules/validator.nix
+++ b/schema/modules/validator.nix
@@ -1,0 +1,25 @@
+{lib}: let
+  profileModule = import ./profile.nix;
+in rec {
+  mkProfile = profileAttrs: let
+    evaluated = lib.evalModules {
+      modules = [
+        profileModule
+        {myProfile = profileAttrs;}
+      ];
+    };
+  in
+    if evaluated.options ? myProfile
+    then evaluated.config.myProfile
+    else
+      throw ''
+        mkProfile validation failed.
+
+        The profile attrset must conform to the myProfile schema.
+        Required fields: user.name, user.email, user.fullName.
+        All other fields are optional with defaults.
+
+        Errors:
+        ${lib.concatMapStrings (e: "  - ${e}\n") (builtins.attrValues evaluated.errors)}
+      '';
+}

--- a/targets/microvms/defaults.nix
+++ b/targets/microvms/defaults.nix
@@ -2,7 +2,8 @@
 # Provides shared user config, skills, and disables 1Password
 # Individual VM configs can override these defaults via roleEnables specialArg
 {
-  inputs,
+  superpowers,
+  vercel-skills,
   roleEnables,
   lib,
   ...
@@ -12,9 +13,9 @@
   myConfig = lib.mkMerge [
     {
       skills = {
-        superpowersPath = inputs.superpowers;
-        externalInputs = {
-          inherit (inputs) vercel-skills;
+        superpowersPath = superpowers;
+        externalInputs = lib.optionalAttrs (vercel-skills != null) {
+          inherit vercel-skills;
         };
       };
       users = [


### PR DESCRIPTION
## Summary

- **Phase 0**: Created `schema/`, `library/`, and `profiles/` sub-flake structure per [design doc](docs/plans/2026-05-11-flake-decomposition-design.md)
- **Phase 1**: Added parallel v2 `nixosConfigurations` for all microvms (`dev-vm-v2`, `openclaw-v2`, `matrix-v2`, `media-center-v2`)

## Phase 0 Details

- `schema/`: Profile type contract (`myProfile`) with `mkProfile` validator
- `library/`: Module wrapper, archetypes, and `mk-system.nix` with `mkDarwinSystem`/`mkNixosSystem` builders
- `profiles/wweaver/`, `profiles/monkey/`: User profile attrsets
- `flake.nix`: Added `flake-parts` input

All existing `nixosConfigurations` and `darwinConfigurations` **unchanged**.

## Phase 1 Details

V2 microvm configs run parallel to existing `microvm.nixosConfigurations`. Same module structure as `mkMicrovm` for closure parity.

## Validation

- [x] `devenv tasks run check:lint` passes
- [x] `devenv tasks run test:darwin-eval` passes
- [x] `nix flake check --no-build` — all Darwin configs pass, no regressions
- [x] Pre-existing microvm check failures unchanged (8 `documentation` errors)

## Next Steps

- Phase 2: Migrate cattle NixOS (type-server, type-server-arm, type-desktop)
- After each phase: closure diff verification on a NixOS host