### PR TITLE
fix: library overlay completeness and archetype platform guards

### DIFF
--- a/library/archetypes/headless-server-nixos.nix
+++ b/library/archetypes/headless-server-nixos.nix
@@ -32,7 +32,7 @@
   boot = {
     loader.systemd-boot.enable = lib.mkDefault true;
     loader.efi.canTouchEfiVariables = lib.mkDefault true;
-    kernelModules = ["kvm-intel" "kvm-amd"];
+    kernelModules = lib.optionals pkgs.stdenv.hostPlatform.isx86_64 ["kvm-intel" "kvm-amd"];
   };
 
   nix.settings.experimental-features = ["nix-command" "flakes"];

--- a/library/lib/mk-system.nix
+++ b/library/lib/mk-system.nix
@@ -24,7 +24,20 @@
                   "olm-3.2.16"
                 ];
               };
-              overlays = [(import ../../overlays)];
+              overlays = [
+                (final: _prev: {
+                  stable = import inputs.nixpkgs-stable {
+                    inherit (final) system config;
+                  };
+                })
+                (final: _prev: {
+                  inherit (inputs.devenv.packages.${final.stdenv.hostPlatform.system}) devenv;
+                })
+                (final: _prev: {
+                  zellij-pane-tracker = inputs.zellij-pane-tracker.packages.${final.stdenv.hostPlatform.system}.default;
+                })
+                (import ../../overlays)
+              ];
             };
           }
           (import ../../modules)
@@ -64,7 +77,20 @@
                 ];
               };
               hostPlatform = system;
-              overlays = [(import ../../overlays)];
+              overlays = [
+                (final: _prev: {
+                  stable = import inputs.nixpkgs-stable {
+                    inherit (final) system config;
+                  };
+                })
+                (final: _prev: {
+                  inherit (inputs.devenv.packages.${final.stdenv.hostPlatform.system}) devenv;
+                })
+                (final: _prev: {
+                  zellij-pane-tracker = inputs.zellij-pane-tracker.packages.${final.stdenv.hostPlatform.system}.default;
+                })
+                (import ../../overlays)
+              ];
             };
           }
           (import ../../modules)


### PR DESCRIPTION
## Summary
Fixes CI failures across Phase 2-5 PRs:

1. **headless-server-nixos archetype**: Make kvm-intel/kvm-amd kernelModules conditional on x86_64. Fixes type-server-arm-v2 evaluation on aarch64-linux (intel-microcode not available on ARM).

2. **mkDarwinSystem + mkNixosSystem**: Add all missing overlays (stable nixpkgs, devenv, zellij-pane-tracker) that were previously only available in `configuration` block in flake.nix. Fixes darwin-server-v2 `zellij-pane-tracker missing` error.

## Testing
- lint: pass
- darwin-eval: pass