### PR TITLE
fix: add fileSystems to type-desktop-v2 [Phase 2]

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -491,6 +491,12 @@
               "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIIxGvpCUmx1UV3K22/+sWLdRknZmlTmQgckoAUCApF8 monkey@MegamanX"
             ];
           }
+          {
+            fileSystems."/" = {
+              device = "/dev/null";
+              fsType = "ext4";
+            };
+          }
         ];
         overrides = {
           autoUpgrade.flakeUrl = "github:funkymonkeymonk/nix#type-desktop-v2";


### PR DESCRIPTION
## Summary
Add minimal fileSystems definition to type-desktop-v2 to fix CI build
failure: 'The fileSystems option does not specify your root file system.'

This is a template config with no real machine - uses /dev/null placeholder
matching the bootstrap pattern.