### PR TITLE
ci: add ARM64 runner for aarch64-linux NixOS builds

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -91,13 +91,21 @@ jobs:
           # (arm configs can't build on x86_64 runners)
           ALL_CONFIGS=$(nix eval --impure .#nixosConfigurations \
             --apply 'x: builtins.attrNames x' --json 2>/dev/null || echo '[]')
+          # ARM configs build on native ARM runners; x86_64 on ubuntu-latest
+          ARM_CONFIGS=$(echo "$ALL_CONFIGS" | jq \
+            '[.[] | select(test("^(installer-|bootstrap)") | not)
+                  | select(test("-arm(-|$)"))]')
           CONFIGS=$(echo "$ALL_CONFIGS" | jq \
             '[.[] | select(test("^(installer-|bootstrap)") | not)
-                  | select(test("-arm$") | not)]')
+                  | select(test("-arm(-|$)") | not)]')
           echo "configs<<EOF" >> $GITHUB_OUTPUT
           echo "$CONFIGS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-          echo "Found NixOS configurations: $CONFIGS"
+          echo "arm-configs<<EOF" >> $GITHUB_OUTPUT
+          echo "$ARM_CONFIGS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "Found NixOS configurations (x86_64): $CONFIGS"
+          echo "Found NixOS configurations (ARM): $ARM_CONFIGS"
       - name: Build Linux configurations (push to Cachix)
         id: build
         run: |
@@ -129,10 +137,75 @@ jobs:
             exit 1
           fi
           echo "All NixOS configurations built and pushed to Cachix"
+  build-linux-arm:
+    name: Build ARM Linux Configurations
+    runs-on: ubuntu-24.04-arm
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v21
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes
+            sandbox = false
+      - name: Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v13
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v15
+        with:
+          name: funkymonkeymonk
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: Discover ARM NixOS configurations
+        id: discover
+        run: |
+          echo "Discovering ARM NixOS configurations..."
+          ALL_CONFIGS=$(nix eval --impure .#nixosConfigurations \
+            --apply 'x: builtins.attrNames x' --json 2>/dev/null || echo '[]')
+          ARM_CONFIGS=$(echo "$ALL_CONFIGS" | jq \
+            '[.[] | select(test("-arm(-|$)"))]')
+          echo "arm-configs<<EOF" >> $GITHUB_OUTPUT
+          echo "$ARM_CONFIGS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "Found ARM NixOS configurations: $ARM_CONFIGS"
+      - name: Build ARM Linux configurations (push to Cachix)
+        id: build
+        run: |
+          echo "Building ARM NixOS configurations and pushing to Cachix..."
+          CONFIGS='${{ steps.discover.outputs.arm-configs }}'
+          FAILED=0
+          BUILT=0
+          for config in $(echo "$CONFIGS" | jq -r '.[]'); do
+            echo ""
+            echo "========================================"
+            echo "Building $config configuration..."
+            echo "========================================"
+            if nix build \
+                ".#nixosConfigurations.$config.config.system.build.toplevel" \
+                --no-link --impure 2>&1; then
+              echo "$config build complete"
+              BUILT=$((BUILT + 1))
+            else
+              echo "WARNING: $config build failed"
+              FAILED=$((FAILED + 1))
+            fi
+          done
+          echo ""
+          echo "Built: $BUILT, Failed: $FAILED"
+          echo "built=$BUILT" >> "$GITHUB_OUTPUT"
+          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
+          if [ "$FAILED" -gt 0 ]; then
+            echo "Some ARM NixOS configurations failed to build"
+            exit 1
+          fi
+          echo "All ARM NixOS configurations built and pushed to Cachix"
   cache-health:
     name: Verify Cache Population
     runs-on: ubuntu-latest
-    needs: [build-darwin, build-linux]
+    needs: [build-darwin, build-linux, build-linux-arm]
     if: always()
     steps:
       - name: Check build results
@@ -142,6 +215,7 @@ jobs:
 
           DARWIN="${{ needs.build-darwin.result }}"
           LINUX="${{ needs.build-linux.result }}"
+          LINUX_ARM="${{ needs.build-linux-arm.result }}"
 
           if [ "$DARWIN" = "success" ]; then
             echo "- Darwin builds: pushed to Cachix" >> "$GITHUB_STEP_SUMMARY"
@@ -150,14 +224,20 @@ jobs:
           fi
 
           if [ "$LINUX" = "success" ]; then
-            echo "- NixOS builds: pushed to Cachix" >> "$GITHUB_STEP_SUMMARY"
+            echo "- NixOS (x86_64) builds: pushed to Cachix" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- NixOS builds: **FAILED** ($LINUX)" >> "$GITHUB_STEP_SUMMARY"
+            echo "- NixOS (x86_64) builds: **FAILED** ($LINUX)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ "$LINUX_ARM" = "success" ]; then
+            echo "- NixOS (ARM) builds: pushed to Cachix" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- NixOS (ARM) builds: **FAILED** ($LINUX_ARM)" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "$DARWIN" != "success" ] || [ "$LINUX" != "success" ]; then
+          if [ "$DARWIN" != "success" ] || [ "$LINUX" != "success" ] || [ "$LINUX_ARM" != "success" ]; then
             echo "**Cache is stale.** Local deploys may need to build from source." \
               >> "$GITHUB_STEP_SUMMARY"
             echo ""

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -77,6 +77,7 @@ jobs:
       nixos-count: ${{ steps.discover.outputs.nixos-count }}
       darwin-changed: ${{ steps.check-changes.outputs.darwin-changed }}
       nixos-changed: ${{ steps.check-changes.outputs.nixos-changed }}
+      nixos-arm-changed: ${{ steps.check-changes.outputs.nixos-arm-changed }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -185,14 +186,20 @@ jobs:
           echo "Darwin configs needing rebuild: $DARWIN_CHANGED"
           # Check NixOS configs
           NIXOS_CHANGED="[]"
+          NIXOS_ARM_CHANGED="[]"
           if [ -f .drv-cache/nixos-configs ]; then
             NIXOS_CHANGED_CONFIGS=()
+            NIXOS_ARM_CHANGED_CONFIGS=()
             for config in $(cat .drv-cache/nixos-configs | jq -r '.[]'); do
               OLD_HASH=$(cat .drv-cache/nixos-${config}.hash 2>/dev/null || echo "")
               NEW_HASH=$(compute_drv_hash "$config" "nixos")
               if [ "$OLD_HASH" != "$NEW_HASH" ]; then
                 echo "NixOS config '$config' changed ($OLD_HASH -> $NEW_HASH)"
-                NIXOS_CHANGED_CONFIGS+=("$config")
+                if echo "$config" | grep -qE -- '-arm(-|$)'; then
+                  NIXOS_ARM_CHANGED_CONFIGS+=("$config")
+                else
+                  NIXOS_CHANGED_CONFIGS+=("$config")
+                fi
               else
                 echo "NixOS config '$config' unchanged"
               fi
@@ -202,17 +209,26 @@ jobs:
             if [ ${#NIXOS_CHANGED_CONFIGS[@]} -gt 0 ]; then
               NIXOS_CHANGED=$(printf '%s\n' "${NIXOS_CHANGED_CONFIGS[@]}" | jq -R . | jq -s .)
             fi
+            if [ ${#NIXOS_ARM_CHANGED_CONFIGS[@]} -gt 0 ]; then
+              NIXOS_ARM_CHANGED=$(printf '%s\n' "${NIXOS_ARM_CHANGED_CONFIGS[@]}" | jq -R . | jq -s .)
+            fi
           else
-            # No cache exists, discover configs dynamically (exclude ARM - can't build on x86_64)
+             # No cache exists, discover configs dynamically
             echo "No cache found, discovering NixOS configs dynamically..."
             ALL_NIXOS=$(nix eval --impure .#nixosConfigurations \
               --apply 'x: builtins.attrNames x' --json 2>/dev/null || echo '[]')
-            NIXOS_CHANGED=$(echo "$ALL_NIXOS" | jq '[.[] | select(test("-arm$") | not)]')
+            # ARM configs build on ubuntu-24.04-arm, x86_64 configs on ubuntu-latest
+            NIXOS_ARM_CHANGED=$(echo "$ALL_NIXOS" | jq '[.[] | select(test("-arm(-|$)"))]')
+            NIXOS_CHANGED=$(echo "$ALL_NIXOS" | jq '[.[] | select(test("-arm(-|$)") | not)]')
           fi
           echo "nixos-changed<<EOF" >> $GITHUB_OUTPUT
           echo "$NIXOS_CHANGED" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-          echo "NixOS configs needing rebuild: $NIXOS_CHANGED"
+          echo "nixos-arm-changed<<EOF" >> $GITHUB_OUTPUT
+          echo "$NIXOS_ARM_CHANGED" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "NixOS configs needing rebuild (x86_64): $NIXOS_CHANGED"
+          echo "NixOS configs needing rebuild (ARM): $NIXOS_ARM_CHANGED"
           # Save current config lists to staging
           echo '${{ steps.discover.outputs.darwin-configs }}' > .drv-cache-staging/darwin-configs
           echo '${{ steps.discover.outputs.nixos-configs }}' > .drv-cache-staging/nixos-configs
@@ -260,7 +276,7 @@ jobs:
             echo "✗ Build failed"
             exit 1
           fi
-  # Build all NixOS configurations that changed
+  # Build all NixOS configurations that changed (x86_64)
   build-nixos:
     name: Build NixOS - ${{ matrix.config }}
     needs: discover-targets
@@ -300,11 +316,56 @@ jobs:
             echo "✗ Build failed"
             exit 1
           fi
+  # Build all ARM NixOS configurations on native ARM runners
+  build-nixos-arm:
+    name: Build NixOS (ARM) - ${{ matrix.config }}
+    needs: discover-targets
+    runs-on: ubuntu-24.04-arm
+    if: ${{ needs.discover-targets.outputs.nixos-arm-changed != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJson(needs.discover-targets.outputs.nixos-arm-changed) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v21
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes
+            sandbox = false
+      - name: Cachix (read-only)
+        uses: cachix/cachix-action@v15
+        with:
+          name: funkymonkeymonk
+          skipPush: true
+      - name: Create stub facter.json
+        run: bash .github/scripts/create-facter-stub.sh
+      - name: Build ${{ matrix.config }}
+        id: build
+        run: |
+          echo "Building NixOS ARM configuration: ${{ matrix.config }}"
+          if nix build .#nixosConfigurations.${{ matrix.config }}.config.system.build.toplevel \
+              --dry-run --quiet --impure 2>&1; then
+            echo "result=success" >> $GITHUB_OUTPUT
+            echo "✓ Build plan validated"
+          else
+            echo "result=failure" >> $GITHUB_OUTPUT
+            echo "✗ Build failed"
+            exit 1
+          fi
   # Collect all build results and report
   build-report:
     name: Build Report
     runs-on: ubuntu-latest
-    needs: [build-darwin, build-nixos, discover-targets, test-foundation, validate-auxiliary]
+    needs:
+      - build-darwin
+      - build-nixos
+      - build-nixos-arm
+      - discover-targets
+      - test-foundation
+      - validate-auxiliary
     if: always()
     steps:
       - name: Download staging cache
@@ -320,6 +381,22 @@ jobs:
              needs.build-darwin.result == 'skipped') &&
             (needs.build-nixos.result == 'success' ||
              needs.build-nixos.result == 'skipped') &&
+            (needs.build-nixos-arm.result == 'success' ||
+             needs.build-nixos-arm.result == 'skipped') &&
+            (needs.test-foundation.result == 'success' ||
+             needs.test-foundation.result == 'skipped') &&
+            (needs.validate-auxiliary.result == 'success' ||
+             needs.validate-auxiliary.result == 'skipped')
+          }}
+      - name: Save derivation cache
+        if: >
+          ${{
+            (needs.build-darwin.result == 'success' ||
+             needs.build-darwin.result == 'skipped') &&
+            (needs.build-nixos.result == 'success' ||
+             needs.build-nixos.result == 'skipped') &&
+            (needs.build-nixos-arm.result == 'success' ||
+             needs.build-nixos-arm.result == 'skipped') &&
             (needs.test-foundation.result == 'success' ||
              needs.test-foundation.result == 'skipped') &&
             (needs.validate-auxiliary.result == 'success' ||
@@ -354,10 +431,12 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           DARWIN_RESULT="${{ needs.build-darwin.result }}"
           NIXOS_RESULT="${{ needs.build-nixos.result }}"
+          NIXOS_ARM_RESULT="${{ needs.build-nixos-arm.result }}"
           TEST_FOUNDATION_RESULT="${{ needs.test-foundation.result }}"
           VALIDATE_AUX_RESULT="${{ needs.validate-auxiliary.result }}"
           DARWIN_CHANGED='${{ needs.discover-targets.outputs.darwin-changed }}'
           NIXOS_CHANGED='${{ needs.discover-targets.outputs.nixos-changed }}'
+          NIXOS_ARM_CHANGED='${{ needs.discover-targets.outputs.nixos-arm-changed }}'
           # Count configs
           DARWIN_TOTAL=$(echo '${{ needs.discover-targets.outputs.darwin-configs }}' \
             | jq 'length')
@@ -365,9 +444,12 @@ jobs:
             | jq 'length')
           DARWIN_CHANGED_COUNT=$(echo "$DARWIN_CHANGED" | jq 'length')
           NIXOS_CHANGED_COUNT=$(echo "$NIXOS_CHANGED" | jq 'length')
+          NIXOS_ARM_CHANGED_COUNT=$(echo "$NIXOS_ARM_CHANGED" | jq 'length')
           SUMMARY="**Darwin:** $DARWIN_CHANGED_COUNT of $DARWIN_TOTAL"
           echo "$SUMMARY configs changed" >> $GITHUB_STEP_SUMMARY
-          SUMMARY="**NixOS:** $NIXOS_CHANGED_COUNT of $NIXOS_TOTAL"
+          SUMMARY="**NixOS (x86_64):** $NIXOS_CHANGED_COUNT of $NIXOS_TOTAL"
+          echo "$SUMMARY configs changed" >> $GITHUB_STEP_SUMMARY
+          SUMMARY="**NixOS (ARM):** $NIXOS_ARM_CHANGED_COUNT of $NIXOS_TOTAL"
           echo "$SUMMARY configs changed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           # Report validation results
@@ -401,7 +483,11 @@ jobs:
             ALL_SUCCESS=false
           fi
           if [ "$NIXOS_RESULT" != "success" ] && [ "$NIXOS_RESULT" != "skipped" ]; then
-            echo "❌ NixOS builds failed" >> $GITHUB_STEP_SUMMARY
+            echo "❌ NixOS (x86_64) builds failed" >> $GITHUB_STEP_SUMMARY
+            ALL_SUCCESS=false
+          fi
+          if [ "$NIXOS_ARM_RESULT" != "success" ] && [ "$NIXOS_ARM_RESULT" != "skipped" ]; then
+            echo "❌ NixOS (ARM) builds failed" >> $GITHUB_STEP_SUMMARY
             ALL_SUCCESS=false
           fi
           if [ "$TEST_FOUNDATION_RESULT" != "success" ] \


### PR DESCRIPTION
## Summary
Add native ARM64 Linux builds to CI using GitHub's `ubuntu-24.04-arm` runner.

## Changes
- **New job `build-nixos-arm`** in `pr-validation.yml` — builds ARM configs (`-arm`/`-arm-v2` suffix) on `ubuntu-24.04-arm`
- **New job `build-linux-arm`** in `main-build.yml` — builds + pushes ARM configs to Cachix
- **Separated ARM vs x86_64 configs** — ARM filter changed from `-arm$` to `-arm(-|$)` to catch both `type-server-arm` and `type-server-arm-v2`
- **Build report tracks ARM** separately in both workflows

## Motivation
ARM configs like `type-server-arm-v2` previously failed on x86_64 runners due to cross-compile limitations (`cabal2nix-cachix` can't build for aarch64 on x86_64). Now they build natively on ARM hardware.

## Testing
- New CI jobs will validate on this PR
- Requires `ubuntu-24.04-arm` runner (free for public repos)