### PR TITLE
ci: add ARM64 runner + fix old type-server-arm microcode on aarch64

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
   workflow_dispatch:
+env:
+  NIX_ACCESS_TOKENS: github.com=${{ github.token }} api.github.com=${{ github.token }} codeload.github.com=${{ github.token }}
 permissions:
   contents: read
 concurrency:
@@ -27,7 +29,7 @@ jobs:
           extra-conf: |
             experimental-features = nix-command flakes
             sandbox = false
-            access-tokens = github.com=${{ github.token }} api.github.com=${{ github.token }}
+            access-tokens = ${{ env.NIX_ACCESS_TOKENS }}
       - name: Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v13
       - name: Setup Cachix
@@ -75,7 +77,7 @@ jobs:
           extra-conf: |
             experimental-features = nix-command flakes
             sandbox = false
-            access-tokens = github.com=${{ github.token }} api.github.com=${{ github.token }}
+            access-tokens = ${{ env.NIX_ACCESS_TOKENS }}
       - name: Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v13
       - name: Setup Cachix
@@ -154,7 +156,7 @@ jobs:
           extra-conf: |
             experimental-features = nix-command flakes
             sandbox = false
-            access-tokens = github.com=${{ github.token }} api.github.com=${{ github.token }}
+            access-tokens = ${{ env.NIX_ACCESS_TOKENS }}
       - name: Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v13
       - name: Setup Cachix

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
+env:
+  NIX_ACCESS_TOKENS: github.com=${{ github.token }} api.github.com=${{ github.token }} codeload.github.com=${{ github.token }}
 permissions:
   contents: read
   pull-requests: read
@@ -25,7 +27,7 @@ jobs:
           extra-conf: |
             experimental-features = nix-command flakes
             sandbox = false
-            access-tokens = github.com=${{ github.token }} api.github.com=${{ github.token }}
+            access-tokens = ${{ env.NIX_ACCESS_TOKENS }}
       - name: Cachix (read-only)
         uses: cachix/cachix-action@v15
         with:
@@ -88,7 +90,7 @@ jobs:
           extra-conf: |
             experimental-features = nix-command flakes
             sandbox = false
-            access-tokens = github.com=${{ github.token }} api.github.com=${{ github.token }}
+            access-tokens = ${{ env.NIX_ACCESS_TOKENS }}
       - name: Cachix (read-only)
         uses: cachix/cachix-action@v15
         with:
@@ -260,7 +262,7 @@ jobs:
           extra-conf: |
             experimental-features = nix-command flakes
             sandbox = false
-            access-tokens = github.com=${{ github.token }} api.github.com=${{ github.token }}
+            access-tokens = ${{ env.NIX_ACCESS_TOKENS }}
       - name: Cachix (read-only)
         uses: cachix/cachix-action@v15
         with:
@@ -298,7 +300,7 @@ jobs:
           extra-conf: |
             experimental-features = nix-command flakes
             sandbox = false
-            access-tokens = github.com=${{ github.token }} api.github.com=${{ github.token }}
+            access-tokens = ${{ env.NIX_ACCESS_TOKENS }}
       - name: Cachix (read-only)
         uses: cachix/cachix-action@v15
         with:
@@ -339,7 +341,7 @@ jobs:
           extra-conf: |
             experimental-features = nix-command flakes
             sandbox = false
-            access-tokens = github.com=${{ github.token }} api.github.com=${{ github.token }}
+            access-tokens = ${{ env.NIX_ACCESS_TOKENS }}
       - name: Cachix (read-only)
         uses: cachix/cachix-action@v15
         with:
@@ -533,7 +535,7 @@ jobs:
           extra-conf: |
             experimental-features = nix-command flakes
             sandbox = false
-            access-tokens = github.com=${{ github.token }} api.github.com=${{ github.token }}
+            access-tokens = ${{ env.NIX_ACCESS_TOKENS }}
       - name: Cachix (read-only)
         uses: cachix/cachix-action@v15
         with:
@@ -569,7 +571,7 @@ jobs:
           extra-conf: |
             experimental-features = nix-command flakes
             sandbox = false
-            access-tokens = github.com=${{ github.token }} api.github.com=${{ github.token }}
+            access-tokens = ${{ env.NIX_ACCESS_TOKENS }}
       - name: Cachix (read-only)
         uses: cachix/cachix-action@v15
         with:


### PR DESCRIPTION
## Summary
Add native ARM64 Linux builds to CI using `ubuntu-24.04-arm` runner. Fixes the old `type-server-arm` config that previously could not build on ARM.

## Changes
- **New job `build-nixos-arm`** in `pr-validation.yml` — builds ARM configs on `ubuntu-24.04-arm`
- **New job `build-linux-arm`** in `main-build.yml` — ARM cache population
- **ARM filter**: Changed from `-arm$` to `-arm(-|$)` to catch both `type-server-arm` and `type-server-arm-v2`
- **Fixed old `type-server-arm`**: Disable `hardware.cpu.intel/amd.updateMicrocode` to prevent evaluation error on aarch64
- **Build report** tracks ARM separately

## Motivation
ARM configs like `type-server-arm-v2` previously failed on x86_64 runners due to cross-compile limitations. Now they build natively on ARM hardware.