### PR TITLE
fix: hardcode just-llms baseURL instead of fetching from 1Password

### DIFF
--- a/modules/roles/foundation.nix
+++ b/modules/roles/foundation.nix
@@ -29,6 +29,7 @@ in {
 
           # Navigation and search
           entr
+          ncdu
           tree
           zoxide
           fzf

--- a/profiles/wweaver/profile.nix
+++ b/profiles/wweaver/profile.nix
@@ -25,7 +25,7 @@
   providers = {
     just-llms = {
       name = "Just LLMs";
-      baseURLOpnixItem = "op://Justworks/LiteLLM/baseURL";
+      baseURL = "https://litellm.justworksai.net";
       onePasswordItem = "op://Justworks/Justworks LiteLLM/wweaver-poweruser-key";
       dynamicModels = true;
     };

--- a/targets/wweaver/default.nix
+++ b/targets/wweaver/default.nix
@@ -44,8 +44,8 @@
         autoStart = true;
         # Local Ollama for fast local models
         ollamaUrl = "http://host.docker.internal:11434";
-        # LiteLLM base URL via 1Password (not hardcoded)
-        openaiBaseUrlOpnixItem = "op://Justworks/LiteLLM/baseURL";
+        # LiteLLM base URL (hardcoded - not sensitive)
+        openaiBaseUrl = "https://litellm.justworksai.net";
         # Embedded SearxNG for web search
         embeddedSearxng = true;
         # Chat model (balanced speed/quality)
@@ -122,8 +122,7 @@
           just-llms = {
             npm = "@ai-sdk/openai-compatible";
             name = "Just LLMs";
-            baseURL = "";
-            baseURLOpnixItem = "op://Justworks/LiteLLM/baseURL";
+            baseURL = "https://litellm.justworksai.net";
             onePasswordItem = "op://Justworks/Justworks LiteLLM/wweaver-poweruser-key";
             dynamicModels = true;
             models = {


### PR DESCRIPTION
## Summary

- Hardcode `https://litellm.justworksai.net` as the just-llms baseURL in all relevant configs
- Remove `openaiBaseUrlOpnixItem` (1Password lookup) from `targets/wweaver/default.nix` in favor of `openaiBaseUrl`
- Update `profiles/wweaver/profile.nix` to use hardcoded `baseURL` instead of `baseURLOpnixItem`
- Update `modules/roles/foundation.nix` to add `ncdu` package

The LiteLLM base URL is not sensitive information and doesn't need to be stored in 1Password, simplifying configuration.