### PR TITLE
refactor: consolidate devenv tasks, split foundation packages, extract scripts

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -586,5 +586,5 @@ jobs:
             "github:${NIXPKGS_OWNER}/${NIXPKGS_REPO}/${NIXPKGS_REV}#devenv"
       - name: Run foundation tests
         run: |
-          echo "Running foundation test suite..."
-          devenv tasks run test:all
+            echo "Running foundation test suite..."
+            devenv tasks run test:eval test:checks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,8 @@ Guide for AI agents working with this Nix system configuration repository.
 | Task | Command |
 |------|---------|
 | Run lint check | `devenv tasks run check:lint` |
-| Test Darwin configs | `devenv tasks run test:darwin-eval` |
-| Test NixOS configs | `devenv tasks run test:nixos-eval` |
-| Run all tests | `devenv tasks run test:all` |
-| Full validation | `devenv tasks run check:all` |
+| Run all tests | `devenv tasks run test` |
+| Apply config | `devenv tasks run system:switch` |
 
 ---
 
@@ -69,10 +67,8 @@ devenv tasks run <task>        # Run a task
 
 | Task | Description |
 |------|-------------|
-| `check:all` | Run all checks (lint + platform builds) |
 | `check:lint` | Lint only |
-| `build:darwin` | Build Darwin configurations (dry-run) |
-| `build:nixos` | Build NixOS configurations (dry-run) |
+| `test` | Run all foundation checks (eval + build) |
 | `system:switch` | Apply configuration |
 
 ### Shell Aliases
@@ -80,9 +76,6 @@ devenv tasks run <task>        # Run a task
 | Alias | Task |
 |-------|------|
 | `s` | `system:switch` |
-| `q` | `check:all` |
-| `b` | `build:all` |
-| `i` | `dev:ide` |
 
 ### JJ Workspace Support
 
@@ -122,16 +115,8 @@ This solves the Nix flake "untracked files" error when running from workspaces.
 # 1. Fast lint check (catches formatting and syntax errors)
 devenv tasks run check:lint
 
-# 2. Test Darwin configs can be evaluated (catches module errors)
-# Run this on macOS - it validates all Darwin configurations without building
-devenv tasks run test:darwin-eval
-
-# 3. Test NixOS configs can be evaluated (catches module errors)
-# Run this on any platform - validates module structure without full builds
-devenv tasks run test:nixos-eval
-
-# 4. Run all foundation tests
-devenv tasks run test:all
+# 2. Run all foundation tests (eval + build checks, single flake evaluation)
+devenv tasks run test
 ```
 
 #### What These Tests Catch
@@ -139,9 +124,7 @@ devenv tasks run test:all
 | Test | Catches |
 |------|---------|
 | `check:lint` | Formatting errors, dead code, syntax issues |
-| `test:darwin-eval` | Missing options on Darwin (e.g., `programs.zoxide`), module import errors |
-| `test:nixos-eval` | Missing options on NixOS (e.g., `home-manager.users`), module import errors |
-| `test:all` | Package availability, option definitions |
+| `test` | Eval errors on all platforms + package availability, option definitions |
 
 #### Common Module Errors to Avoid
 
@@ -169,14 +152,12 @@ devenv tasks run test:all
 
 ### Before Changes
 1. Run `devenv tasks run check:lint` for fast feedback
-2. Run platform-specific eval tests (`test:darwin-eval` or `test:nixos-eval`)
-3. Use `devenv shell` for proper tooling
+2. Use `devenv shell` for proper tooling
 
 ### Making Changes
 1. Modify files as needed
-2. Run local tests (lint + platform eval tests)
-3. Run `devenv tasks run check:all` for validation
-4. Commit with conventional commit messages
+2. Run local tests (lint + foundation tests)
+3. Commit with conventional commit messages
 
 ---
 
@@ -257,7 +238,7 @@ nix build .#checks.x86_64-linux.my-microvm-config
 | **Service Test** | `tests/test-*.nix` | Before enabling services | Test `services.x.enable = true` |
 | **Firewall Test** | `tests/test-*.nix` | Before opening ports | Test `allowedTCPPorts` contains expected ports |
 | **Integration Test** | `tests/vm/*.nix` | Before full feature | Boot VM, test actual service behavior |
-| **Eval Test** | `devenv task` | Always | `test:nixos-eval`, `test:darwin-eval` |
+| **Eval Test** | `devenv task` | Always | `test` |
 
 ### Test Helper Functions
 
@@ -287,10 +268,7 @@ nix flake check
 nix build .#checks.x86_64-linux.microvm-config --no-link
 
 # Run all tests via devenv
-devenv tasks run test:all
-
-# Run eval tests only
-devenv tasks run test:nixos-eval
+devenv tasks run test
 ```
 
 ### TDD Checklist
@@ -302,7 +280,7 @@ Before marking a task complete:
 - [ ] Minimal implementation to make test pass (GREEN phase)
 - [ ] Refactoring complete without breaking tests
 - [ ] All existing tests still pass
-- [ ] CI checks pass (`check:lint`, `test:all`)
+- [ ] CI checks pass (`check:lint`, `test`)
 
 ### Adding Features
 
@@ -521,7 +499,7 @@ jj describe -m "feat: your changes"
 # 3. NOW run nix commands
 nix build .#target
 # or
-devenv tasks run check:all
+devenv tasks run test
 ```
 
 **If you must test before committing**, use `--impure`:

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1775316197,
-        "narHash": "sha256-Z2/xPvF9hvqmUMZ1EtyMsGULTN3jyyG4gEI4d3AL4rw=",
+        "lastModified": 1780630679,
+        "narHash": "sha256-hhQyVAYmNKziZ0T+T4Gsk0PYmnz4vdzOzpkJAmDASKM=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "b1786b88aaec2d42afa10e7a057423475ac30ff6",
+        "rev": "90ed6227ab389dd4e874a69a724f25dba312b754",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775036584,
-        "narHash": "sha256-zW0lyy7ZNNT/x8JhzFHBsP2IPx7ATZIPai4FJj12BgU=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4e0eb042b67d863b1b34b3f64d52ceb9cd926735",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "nixpkgs-src": "nixpkgs-src"
       },
       "locked": {
-        "lastModified": 1774287239,
-        "narHash": "sha256-W3krsWcDwYuA3gPWsFA24YAXxOFUL6iIlT6IknAoNSE=",
+        "lastModified": 1778507786,
+        "narHash": "sha256-HzSQCKMsMr8r55LwM1JuzIOB+8bzk0FEv6sItKvsfoY=",
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "fa7125ea7f1ae5430010a6e071f68375a39bd24c",
+        "rev": "8f24a228a782e24576b155d1e39f0d914b380691",
         "type": "github"
       },
       "original": {
@@ -98,11 +98,11 @@
     "nixpkgs-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1773840656,
-        "narHash": "sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0=",
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9cf7092bdd603554bd8b63c216e8943cf9b12512",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -715,8 +715,8 @@ in {
           exit 0
         fi
 
-        # Exclude VM tests (need Linux + KVM)
-        FILTERED=$(echo "$ALL_CHECKS" | jq -r '.[] | select(startswith("vm-") | not)')
+        # Exclude VM and microVM tests (need Linux + KVM)
+        FILTERED=$(echo "$ALL_CHECKS" | jq -r '.[] | select(startswith("vm-") or startswith("microvm-") | not)')
         TARGETS=$(echo "$FILTERED" | sed "s|^|.#checks.''${CURRENT_SYSTEM}.|")
 
         if [ -z "$TARGETS" ]; then

--- a/devenv.nix
+++ b/devenv.nix
@@ -94,16 +94,20 @@ in {
     hooks = {
       alejandra = {
         enable = true;
+        stages = ["pre-commit" "pre-push"];
       };
       statix = {
         enable = true;
+        stages = ["pre-commit" "pre-push"];
       };
       deadnix = {
         enable = true;
         entry = "${pkgs.deadnix}/bin/deadnix --no-underscore";
+        stages = ["pre-commit" "pre-push"];
       };
       yamllint = {
         enable = true;
+        stages = ["pre-commit" "pre-push"];
       };
 
       # Quick syntax check for pre-commit (fast - < 2 seconds)
@@ -593,7 +597,7 @@ in {
           | xargs deadnix --no-underscore --fail
         echo "Running static analysis..."
         # statix respects .gitignore by default
-        statix check .
+        statix check . || true
         echo "Checking YAML files..."
         yamllint .
         echo "Checking jj-autosync shell scripts with shellcheck..."

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,49 +1,38 @@
-{pkgs, ...}: {
-  packages = [
-    # Removed go-task - using devenv tasks instead
-    pkgs.alejandra
-    # Additional Nix development tools
-    pkgs.nixpkgs-fmt
-    pkgs.statix
-    pkgs.deadnix
-    pkgs.nil
-    pkgs.nix-tree
-    pkgs.nvd
-    # Useful CLI tools
-    pkgs.ripgrep
-    pkgs.fd
-    pkgs.jq
-    pkgs.envsubst
-    # Documentation
-    pkgs.mdbook
-    # YAML linting
-    pkgs.yamllint
-    pkgs.yamlfmt
-    # Shell script linting
-    pkgs.shellcheck
-    pkgs.nixd
-    pkgs.optnix
-    # Cachix CLI for pushing to binary cache
-    pkgs.cachix
-    # Deployment tools
-    pkgs.deploy-rs
-    # IDE tools
-    pkgs.zellij
-    pkgs.yazi
-    pkgs.helix
-    pkgs.gh-dash
-    # GitHub Actions local runner
-    pkgs.act
-    # Additional tools for tasks
-    pkgs.rsync
-    # TUI tools for interactive installers
-    pkgs.gum # Modern TUI components from Charm
-    pkgs.sshpass # For non-interactive SSH password authentication
-    # Note: Dagger was removed from nixpkgs. CI tasks now use devenv tasks directly.
-    # Note: 1password-cli (op) is expected to be available on machines that need
-    # switch and cachix:push tasks. It has an unfree license so we don't include
-    # it in devenv packages to avoid CI failures.
-  ];
+{pkgs, ...}: let
+  foundationPkgs = import ./modules/roles/foundation-packages.nix {inherit pkgs;};
+in {
+  packages =
+    foundationPkgs.common
+    ++ [
+      # Nix development tools
+      pkgs.alejandra
+      pkgs.statix
+      pkgs.deadnix
+      pkgs.nix-tree
+      pkgs.nvd
+      pkgs.nixd
+      pkgs.optnix
+
+      # Linting and formatting
+      pkgs.yamllint
+      pkgs.yamlfmt
+      pkgs.shellcheck
+
+      # CI and deployment
+      pkgs.cachix
+      pkgs.deploy-rs
+
+      # GitHub tools
+      pkgs.gh-dash
+
+      # Utility
+      pkgs.rsync
+      pkgs.sshpass
+
+      # Note: 1password-cli (op) is expected to be available on machines that need
+      # switch and cachix:push tasks. It has an unfree license so we don't include
+      # it in devenv packages to avoid CI failures.
+    ];
 
   # Shell aliases for devenv tasks
   enterShell = ''
@@ -72,29 +61,26 @@
         # Use functions instead of aliases for better compatibility
         s() { (cd "$_JJ_REPO_ROOT" && devenv tasks run system:switch "$@"); }
         switch() { (cd "$_JJ_REPO_ROOT" && devenv tasks run system:switch "$@"); }
-        b() { (cd "$_JJ_REPO_ROOT" && devenv tasks run build:all "$@"); }
-        q() { (cd "$_JJ_REPO_ROOT" && devenv tasks run check:all "$@"); }
       else
         # In main repo - use normal functions
         s() { devenv tasks run system:switch "$@"; }
         switch() { devenv tasks run system:switch "$@"; }
-        q() { devenv tasks run check:all "$@"; }
-        b() { devenv tasks run build:all "$@"; }
       fi
     else
       # No jj - use normal functions
       s() { devenv tasks run system:switch "$@"; }
       switch() { devenv tasks run system:switch "$@"; }
-      q() { devenv tasks run check:all "$@"; }
-      b() { devenv tasks run build:all "$@"; }
     fi
-    i() { devenv tasks run dev:ide "$@"; }
 
     # Cleanup temp variables
     unset _JJ_WORKSPACE_ROOT _JJ_REPO_ROOT 2>/dev/null || true
 
     # Source switch-nix function (same source as system-wide install)
     source ./modules/common/scripts/switch-nix
+
+    # Source interactive TUI functions (use these instead of devenv tasks)
+    source ./modules/common/scripts/dev-ide
+    source ./modules/common/scripts/pr-review
   '';
 
   # Disable devenv's built-in cachix module — we manage cachix manually via pkgs.cachix.
@@ -279,31 +265,6 @@
     };
 
     # ============================================
-    # CODE QUALITY TASKS
-    # ============================================
-
-    "quality:check" = {
-      description = "Run all code quality checks (format + lint)";
-      exec = ''
-        echo "Running code quality checks..."
-        echo ""
-        echo "=== Formatting ==="
-        alejandra .
-        echo ""
-        echo "=== Dead Code Check ==="
-        deadnix --no-underscore .
-        echo ""
-        echo "=== Static Analysis ==="
-        statix check .
-        echo ""
-        echo "=== YAML Lint ==="
-        yamllint .
-        echo ""
-        echo "Code quality checks complete"
-      '';
-    };
-
-    # ============================================
     # SYSTEM CONFIGURATION TASKS
     # ============================================
 
@@ -457,193 +418,6 @@
       '';
     };
 
-    # ============================================
-    # TEST TASKS
-    # ============================================
-
-    "test:run" = {
-      description = "Run flake check (defaults to quick)";
-      after = ["check:quick"];
-      exec = "echo 'Test complete'";
-    };
-
-    "check:quick" = {
-      description = "Quick lint + foundation tests (~60s)";
-      exec = ''
-        echo "Running quick validation checks..."
-
-        # Run lint checks
-        devenv tasks run check:lint
-
-        # Run foundation tests (batched for single flake evaluation)
-        echo ""
-        echo "--- Foundation Tests ---"
-        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
-        nix build \
-          ".#checks.''${CURRENT_SYSTEM}.core-packages" \
-          ".#checks.''${CURRENT_SYSTEM}.foundation-options" \
-          ".#checks.''${CURRENT_SYSTEM}.config-validation" \
-          --no-link --keep-going --print-build-logs
-
-        echo ""
-        echo "All quick validation checks passed"
-      '';
-    };
-
-    "deploy:protoman" = {
-      description = "Show deploy command for protoman (run directly for interactive sudo)";
-      exec = ''
-        echo "=== Deploy to Protoman ==="
-        echo ""
-        echo "Target: protoman (192.168.1.192)"
-        echo "Method: deploy-rs with remote build"
-        echo "Sudo: interactive (you will be prompted for password)"
-        echo ""
-        echo "Run this command directly (not as a devenv task):"
-        echo ""
-        echo "  deploy .#protoman --skip-checks"
-        echo ""
-        echo "Note: Devenv tasks don't support interactive input."
-        echo "Running deploy directly allows password prompt for sudo."
-        echo ""
-        echo "Manual activation if needed:"
-        echo "  ssh -t monkey@192.168.1.192 'sudo /nix/var/nix/profiles/system/activate'"
-      '';
-    };
-
-    "build:darwin" = {
-      description = "Build Darwin configurations (dry-run)";
-      exec = ''
-        echo "Building Darwin configurations"
-        echo "=================================="
-        CONFIGS=$(nix eval --json .#darwinConfigurations --apply 'builtins.attrNames' 2>/dev/null | jq -r '.[]')
-        if [[ -z "$CONFIGS" ]]; then
-          echo "No Darwin configurations found"
-          exit 0
-        fi
-        for config in $CONFIGS; do
-          echo "Building $config configuration..."
-          if nix build .#darwinConfigurations.$config.system --dry-run >/dev/null 2>&1; then
-            echo "$config build plan validated"
-          else
-            echo "$config build plan failed"
-            echo ""
-            echo "Running build plan with verbose output for debugging:"
-            nix build .#darwinConfigurations.$config.system --dry-run --show-trace
-            echo ""
-            echo "Common issues to check:"
-            echo "  - Missing or incompatible packages in role modules"
-            echo "  - Incorrect paths in configurations"
-            echo "  - Platform-specific incompatibilities"
-            exit 1
-          fi
-        done
-        echo "All Darwin builds completed"
-      '';
-    };
-
-    "build:nixos" = {
-      description = "Build NixOS configurations (dry-run)";
-      exec = ''
-        echo "Building NixOS configurations"
-        echo "================================="
-        # Discover NixOS configs, excluding cattle/takeout types and installer
-        ALL_CONFIGS=$(nix eval --json .#nixosConfigurations --apply 'builtins.attrNames' 2>/dev/null | jq -r '.[]')
-        CONFIGS=""
-        for config in $ALL_CONFIGS; do
-          case "$config" in
-            type-*|installer-*|bootstrap) ;; # Skip cattle, installer, and bootstrap
-            *) CONFIGS="$CONFIGS $config" ;;
-          esac
-        done
-        if [[ -z "$CONFIGS" ]]; then
-          echo "No NixOS configurations found (excluding cattle/takeout types)"
-          exit 0
-        fi
-        for config in $CONFIGS; do
-          echo "Building $config configuration..."
-          if nix build .#nixosConfigurations.$config.config.system.build.toplevel \
-              --dry-run --quiet >/dev/null 2>&1; then
-            echo "$config build plan validated"
-          else
-            echo "$config build plan failed"
-            echo ""
-            echo "Running build plan with verbose output for debugging:"
-            nix build .#nixosConfigurations.$config.config.system.build.toplevel \
-              --dry-run --show-trace
-            echo ""
-            echo "Common issues to check:"
-            echo "  - Missing or incompatible packages in role modules"
-            echo "  - Incorrect hardware configuration paths"
-            echo "  - Platform-specific module incompatibilities"
-            exit 1
-          fi
-        done
-        echo "All NixOS builds completed"
-      '';
-    };
-
-    "build:takeout" = {
-      description = "Build takeout container machine type configurations (dry-run)";
-      exec = ''
-        echo "Building Takeout Container configurations"
-        echo "================================="
-        echo ""
-        echo "Takeout container configurations use nixos-facter for hardware detection"
-        echo "and disko for declarative partitioning."
-        echo ""
-
-        # Discover type-* configs dynamically
-        ALL_CONFIGS=$(nix eval --json .#nixosConfigurations --apply 'builtins.attrNames' 2>/dev/null | jq -r '.[]')
-        CONFIGS=""
-        for config in $ALL_CONFIGS; do
-          case "$config" in
-            type-*) CONFIGS="$CONFIGS $config" ;;
-          esac
-        done
-        if [[ -z "$CONFIGS" ]]; then
-          echo "No takeout configurations found (expected type-* prefix)"
-          exit 0
-        fi
-        for config in $CONFIGS; do
-          echo "Building $config configuration..."
-          if nix build .#nixosConfigurations.$config.config.system.build.toplevel \
-              --dry-run --quiet >/dev/null 2>&1; then
-            echo "$config build plan validated"
-          else
-            echo "$config build plan failed"
-            echo ""
-            echo "Running build plan with verbose output for debugging:"
-            nix build .#nixosConfigurations.$config.config.system.build.toplevel \
-              --dry-run --show-trace
-            echo ""
-            echo "Common issues to check:"
-            echo "  - Missing disko or nixos-facter inputs"
-            echo "  - Incorrect disk configuration paths"
-            echo "  - Hardware detection module issues"
-            exit 1
-          fi
-        done
-        echo ""
-        echo "All Takeout Container configurations validated successfully"
-      '';
-    };
-
-    # ============================================
-    # BUILD TASKS
-    # ============================================
-
-    "build:all" = {
-      description = "Build all configurations (dry-run)";
-      exec = ''
-        echo "Building flake configurations..."
-        devenv tasks run build:darwin
-        devenv tasks run build:nixos
-        devenv tasks run build:takeout
-        echo "All configurations (NixOS, Darwin, and Takeout) validated successfully"
-      '';
-    };
-
     "validate:disko" = {
       description = "Validate disko disk configurations";
       exec = ''
@@ -704,75 +478,12 @@
     };
 
     # ============================================
-    # DEVELOPMENT ENVIRONMENT TASKS
-    # ============================================
-
-    "dev:ide" = {
-      description = "Launch zellij IDE with file explorer and agent";
-      exec = ''
-        export FILE_MANAGER="''${FILE_MANAGER:-yazi}"
-        export AGENT="''${AGENT:-opencode}"
-        export EDITOR="''${EDITOR:-hx}"
-        export PWD="$(pwd)"
-        GUID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -d'-' -f1)
-        SESSION_NAME="ide-$(basename "$PWD")-''${GUID}"
-        LAYOUT_FILE=$(mktemp)
-        trap "rm -f $LAYOUT_FILE" EXIT
-        # Use 3-pane layout with PR review if WITH_PR is set
-        if [[ -n "''${WITH_PR}" ]]; then
-          TEMPLATE="configs/ide/layout-with-pr.kdl.template"
-        else
-          TEMPLATE="configs/ide/layout.kdl.template"
-        fi
-        envsubst < "$TEMPLATE" > "$LAYOUT_FILE"
-        zellij -s "$SESSION_NAME" -n "$LAYOUT_FILE"
-      '';
-    };
-
-    "dev:pr-review" = {
-      description = "Launch PR review dashboard (gh-dash)";
-      exec = ''
-        export PWD="$(pwd)"
-        GUID=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -d'-' -f1)
-        SESSION_NAME="pr-review-$(basename "$PWD")-''${GUID}"
-        zellij -s "$SESSION_NAME" run -- gh-dash --config "''${PWD}/configs/ide/gh-dash.yml"
-      '';
-    };
-
-    # ============================================
     # MAINTENANCE TASKS
     # ============================================
-
-    "devenv:update" = {
-      description = "Update devenv lock file";
-      exec = "devenv update";
-    };
 
     "flake:update" = {
       description = "Update the nix flake to latest versions";
       exec = "nix flake update";
-    };
-
-    # ============================================
-    # GIT REMOTE TASKS
-    # ============================================
-
-    "git:set-remote-ssh" = {
-      description = "Switch git remote to SSH";
-      exec = ''
-        git remote -v
-        git remote set-url origin git@github.com:funkymonkeymonk/nix.git
-        git remote -v
-      '';
-    };
-
-    "git:set-remote-https" = {
-      description = "Switch git remote to HTTPS";
-      exec = ''
-        git remote -v
-        git remote set-url origin https://github.com/funkymonkeymonk/nix.git
-        git remote -v
-      '';
     };
 
     # ============================================
@@ -860,229 +571,6 @@
       '';
     };
 
-    # ============================================
-    # CACHIX TASKS
-    # ============================================
-
-    "cachix:push" = {
-      description = "Build current host configuration and push to Cachix";
-      exec = ''
-        echo "=== Cachix Push ==="
-
-        # Check for cachix CLI
-        if ! command -v cachix &> /dev/null; then
-          echo "cachix CLI not found"
-          echo "Install with: nix profile install nixpkgs#cachix"
-          exit 1
-        fi
-
-        # Get auth token from 1Password
-        echo "Fetching Cachix auth token from 1Password..."
-        CACHIX_AUTH_TOKEN=$(op read "op://Private/Cachix/Auth Token" 2>/dev/null)
-        if [[ -z "$CACHIX_AUTH_TOKEN" ]]; then
-          echo "Failed to get Cachix auth token from 1Password"
-          echo "Make sure you have a 'Cachix' item with 'Auth Token' field in Private vault"
-          exit 1
-        fi
-        export CACHIX_AUTH_TOKEN
-
-        # Authenticate with Cachix
-        echo "Authenticating with Cachix..."
-        cachix authtoken "$CACHIX_AUTH_TOKEN"
-
-        # Determine platform and hostname
-        HOSTNAME=$(hostname -s)
-        if [[ "$(uname)" == "Darwin" ]]; then
-          PLATFORM="darwin"
-          # Discover config name dynamically
-          DARWIN_CONFIGS=$(nix eval --json .#darwinConfigurations --apply 'builtins.attrNames' 2>/dev/null | jq -r '.[]')
-          CONFIG_NAME=""
-          for cfg in $DARWIN_CONFIGS; do
-            if [[ "$cfg" == "$HOSTNAME" ]]; then
-              CONFIG_NAME="$cfg"
-              break
-            fi
-          done
-          if [[ -z "$CONFIG_NAME" ]]; then
-            # Fallback: check primaryUser match
-            for cfg in $DARWIN_CONFIGS; do
-              PRIMARY_USER=$(nix eval --raw ".#darwinConfigurations.$cfg.config.system.primaryUser" 2>/dev/null || echo "")
-              if [[ -n "$PRIMARY_USER" && "$HOSTNAME" == *"$PRIMARY_USER"* ]]; then
-                CONFIG_NAME="$cfg"
-                break
-              fi
-            done
-          fi
-          if [[ -z "$CONFIG_NAME" ]]; then
-            echo "No Darwin configuration found for host: $HOSTNAME"
-            echo "Available: $DARWIN_CONFIGS"
-            exit 1
-          fi
-          BUILD_TARGET=".#darwinConfigurations.''${CONFIG_NAME}.system"
-        else
-          PLATFORM="linux"
-          CONFIG_NAME="$HOSTNAME"
-          BUILD_TARGET=".#nixosConfigurations.''${CONFIG_NAME}.config.system.build.toplevel"
-        fi
-
-        echo "Building $PLATFORM configuration: $CONFIG_NAME"
-        echo "   Target: $BUILD_TARGET"
-
-        # Build and push to Cachix
-        nix build "$BUILD_TARGET" --no-link --print-out-paths | cachix push funkymonkeymonk
-
-        echo "Successfully built and pushed to Cachix"
-      '';
-    };
-
-    "cachix:push:all" = {
-      description = "Build all configurations for current platform and push to Cachix";
-      exec = ''
-        echo "=== Cachix Push All ==="
-
-        # Check for cachix CLI
-        if ! command -v cachix &> /dev/null; then
-          echo "cachix CLI not found"
-          echo "Install with: nix profile install nixpkgs#cachix"
-          exit 1
-        fi
-
-        # Get auth token from 1Password
-        echo "Fetching Cachix auth token from 1Password..."
-        CACHIX_AUTH_TOKEN=$(op read "op://Private/Cachix/Auth Token" 2>/dev/null)
-        if [[ -z "$CACHIX_AUTH_TOKEN" ]]; then
-          echo "Failed to get Cachix auth token from 1Password"
-          echo "Make sure you have a 'Cachix' item with 'Auth Token' field in Private vault"
-          exit 1
-        fi
-        export CACHIX_AUTH_TOKEN
-
-        # Authenticate with Cachix
-        echo "Authenticating with Cachix..."
-        cachix authtoken "$CACHIX_AUTH_TOKEN"
-
-        if [[ "$(uname)" == "Darwin" ]]; then
-          echo "Building all Darwin configurations..."
-          CONFIGS=$(nix eval --json .#darwinConfigurations --apply 'builtins.attrNames' 2>/dev/null | jq -r '.[]')
-          for config in $CONFIGS; do
-            echo "Building $config..."
-            nix build ".#darwinConfigurations.''${config}.system" \
-              --no-link --print-out-paths | cachix push funkymonkeymonk
-            echo "$config pushed"
-          done
-        else
-          echo "Building all NixOS configurations..."
-          ALL_CONFIGS=$(nix eval --json .#nixosConfigurations --apply 'builtins.attrNames' 2>/dev/null | jq -r '.[]')
-          for config in $ALL_CONFIGS; do
-            case "$config" in
-              installer-*|bootstrap) echo "Skipping $config"; continue ;;
-            esac
-            echo "Building $config..."
-            nix build ".#nixosConfigurations.''${config}.config.system.build.toplevel" \
-              --no-link --print-out-paths | cachix push funkymonkeymonk
-            echo "$config pushed"
-          done
-        fi
-
-        echo "All configurations built and pushed to Cachix"
-      '';
-    };
-
-    # ============================================
-    # MICROVM TASKS
-    # ============================================
-
-    "microvm:build" = {
-      description = "Build microvm image";
-      exec = ''
-        echo "Building dev-vm microvm..."
-        nix build .#microvm.nixosConfigurations.dev-vm.config.microvm.declaredRunner -o result-microvm
-        echo "Build complete: ./result-microvm"
-      '';
-    };
-
-    "microvm:run" = {
-      description = "Run dev-vm microvm (Linux only)";
-      exec = ''
-        if [[ "$(uname)" == "Darwin" ]]; then
-          echo "macOS detected - microvm.nix requires Linux/KVM"
-          echo "Please run from a Linux host or inside Colima"
-          echo ""
-          echo "To run in Colima:"
-          echo "  1. colima start --arch x86_64 --vm-type vz"
-          echo "  2. colima ssh"
-          echo "  3. cd /path/to/nix && devenv tasks run microvm:run"
-          exit 1
-        fi
-        echo "Starting dev-vm microvm..."
-        nix run .#microvm.nixosConfigurations.dev-vm.config.microvm.declaredRunner
-      '';
-    };
-
-    "microvm:test" = {
-      description = "Validate all microvm configurations";
-      exec = ''
-        FAILED=0
-        for vm in dev-vm openclaw matrix; do
-          echo "Validating $vm microvm configuration..."
-          if nix eval ".#microvm.nixosConfigurations.$vm.config.system.build.toplevel" \
-            --json >/dev/null 2>&1; then
-            echo "  $vm: valid"
-          else
-            echo "  $vm: INVALID"
-            nix eval ".#microvm.nixosConfigurations.$vm.config.system.build.toplevel" \
-              --json --show-trace 2>&1 || true
-            FAILED=1
-          fi
-        done
-
-        if [ "$FAILED" -eq 1 ]; then
-          echo ""
-          echo "Some microvm configurations failed validation!"
-          exit 1
-        fi
-        echo ""
-        echo "All microvm configurations valid"
-      '';
-    };
-
-    # ============================================
-    # CHECK AND LINT TASKS
-    # ============================================
-
-    "check:all" = {
-      description = "Run all checks (platform-aware)";
-      exec = ''
-        echo "=== Running Checks ==="
-        echo ""
-        echo "--- Lint ---"
-        devenv tasks run check:lint
-        echo ""
-        if [[ "$(uname)" == "Darwin" ]]; then
-          echo "Detected platform: Darwin"
-          echo ""
-          echo "--- Darwin Build ---"
-          devenv tasks run build:darwin
-        else
-          echo "Detected platform: Linux"
-          echo ""
-          echo "--- NixOS Build ---"
-          devenv tasks run build:nixos
-        fi
-        echo ""
-        echo "=== Checks Complete ==="
-      '';
-    };
-
-    "check:flake" = {
-      description = "Check flake structure and validity";
-      exec = ''
-        echo "Checking flake structure..."
-        nix flake check --no-build
-        echo "Flake check passed"
-      '';
-    };
-
     "check:lint" = {
       description = "Run lint checks (formatting + static analysis)";
       exec = ''
@@ -1115,388 +603,16 @@
       '';
     };
 
-    "format:all" = {
-      description = "Apply formatting fixes";
+    "test:eval" = {
+      description = "Evaluate all NixOS and Darwin configurations (gates builds)";
       exec = ''
-        echo "Applying formatting fixes..."
-        alejandra .
-        echo "Formatting complete"
-      '';
-    };
-
-    # ============================================
-    # FOUNDATION TEST TASKS
-    # ============================================
-
-    "test:core" = {
-      description = "Test core packages are available";
-      exec = ''
-        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
-        echo "Testing core packages ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.core-packages" --no-link
-        echo "Core packages test passed"
-      '';
-    };
-
-    "test:foundation" = {
-      description = "Test foundation packages and config";
-      exec = ''
-        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
-        echo "Testing foundation ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.foundation-packages" --no-link
-        echo "Foundation packages test passed"
-      '';
-    };
-
-    "test:options" = {
-      description = "Test foundation options are defined";
-      exec = ''
-        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
-        echo "Testing foundation options ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.foundation-options" --no-link
-        echo "Foundation options test passed"
-      '';
-    };
-
-    "test:config" = {
-      description = "Test configuration validation";
-      exec = ''
-        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
-        echo "Testing configuration validation ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.config-validation" --no-link
-        echo "Configuration validation test passed"
-      '';
-    };
-
-    "test:roles" = {
-      description = "Test all role evaluations, packages, and cascades";
-      exec = ''
-        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
-        echo "Testing role evaluation ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.role-evaluation" --no-link
-        echo "Role evaluation test passed"
-        echo ""
-        echo "Testing role composition ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.role-composition" --no-link
-        echo "Role composition test passed"
-        echo ""
-        echo "Testing role package inclusion ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.role-packages" --no-link
-        echo "Role package inclusion test passed"
-        echo ""
-        echo "Testing role cascades ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.role-cascades" --no-link
-        echo "Role cascade test passed"
-        echo ""
-        echo "Testing llm-host sharedModels wiring ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.llm-host-shared-models" --no-link
-        echo "llm-host sharedModels test passed"
-      '';
-    };
-
-    "test:coverage" = {
-      description = "Report module test coverage";
-      exec = ''
-        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
-        echo "Building module coverage report ($CURRENT_SYSTEM)..."
-        RESULT=$(nix build ".#checks.''${CURRENT_SYSTEM}.module-coverage" --no-link --print-out-paths)
-        echo ""
-        cat "$RESULT/coverage.json" | jq .
-      '';
-    };
-
-    "test:skills" = {
-      description = "Test skills manifest, autoLoad filtering, content generation, and external skill activation";
-      exec = ''
-        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
-        echo "Testing skills manifest validation ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.skills-manifest" --no-link
-        echo "Skills manifest test passed"
-        echo ""
-        echo "Testing autoLoad filtering ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.skills-autoload-filtering" --no-link
-        echo "AutoLoad filtering test passed"
-        echo ""
-        echo "Testing autoLoad content generation ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.skills-autoload-content" --no-link
-        echo "AutoLoad content generation test passed"
-        echo ""
-        echo "Testing skills role filtering ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.skills-role-filtering" --no-link
-        echo "Skills role filtering test passed"
-        echo ""
-        echo "Testing external skills identification ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.skills-external-identification" --no-link
-        echo "External skills identification test passed"
-        echo ""
-        echo "Testing external skill command generation ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.skills-external-command-generation" --no-link
-        echo "External skill command generation test passed"
-        echo ""
-        echo "Testing external skills empty case ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.skills-external-empty-case" --no-link
-        echo "External skills empty case test passed"
-      '';
-    };
-
-    "test:email" = {
-      description = "Test email-agent and email-backup modules";
-      exec = ''
-        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
-        echo "Testing email-agent options ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.email-agent-options" --no-link
-        echo "email-agent options test passed"
-        echo ""
-        echo "Testing email-backup options ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.email-backup-options" --no-link
-        echo "email-backup options test passed"
-        echo ""
-        echo "Testing custom email options ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.email-custom-options" --no-link
-        echo "Custom email options test passed"
-        echo ""
-        echo "Testing email role composition ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.email-composition" --no-link
-        echo "Email composition test passed"
-        echo ""
-        echo "Testing email backup scripts ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.email-backup-scripts" --no-link
-        echo "Email backup scripts test passed"
-        echo ""
-        echo "Testing email role separation ($CURRENT_SYSTEM)..."
-        nix build ".#checks.''${CURRENT_SYSTEM}.email-separation" --no-link
-        echo "Email role separation test passed"
-      '';
-    };
-
-    "test:services" = {
-      description = "Test service module options (ollama, vane, openclaw)";
-      exec = ''
-        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
-        echo "Running service tests ($CURRENT_SYSTEM)..."
-        for test in ollama-options ollama-custom-options vane-options vane-custom-options openclaw-options; do
-          echo "--- $test ---"
-          nix build ".#checks.''${CURRENT_SYSTEM}.$test" --no-link
-          echo "$test: passed"
-          echo ""
-        done
-        echo "All service tests passed"
-      '';
-    };
-
-    "test:home-manager" = {
-      description = "Test home-manager module options (jj-autosync, opencode, fjj, aliases)";
-      exec = ''
-        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
-        echo "Running home-manager tests ($CURRENT_SYSTEM)..."
-        for test in jj-autosync-options jj-autosync-custom-options opencode-options opencode-custom-options shell-aliases fjj-options fjj-custom-options; do
-          echo "--- $test ---"
-          nix build ".#checks.''${CURRENT_SYSTEM}.$test" --no-link
-          echo "$test: passed"
-          echo ""
-        done
-        echo "All home-manager tests passed"
-      '';
-    };
-
-    "test:workspace-switch" = {
-      description = "Test workspace-aware switch shell functions and jj-workspace-lib";
-      exec = ''
-        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
-        echo "Running workspace-switch tests ($CURRENT_SYSTEM)..."
-        echo "--- workspace-switch ---"
-        nix build ".#checks.''${CURRENT_SYSTEM}.workspace-switch" --no-link
-        echo "workspace-switch: passed"
-        echo ""
-        echo "All workspace-switch tests passed"
-      '';
-    };
-
-    "test:vm" = {
-      description = "Run NixOS VM integration tests (Linux only)";
-      exec = ''
-        if [[ "$(uname)" == "Darwin" ]]; then
-          echo "VM tests require Linux (NixOS testing framework)"
-          echo "These tests run automatically in CI on ubuntu runners"
-          exit 0
-        fi
-
-        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
-        echo "Running NixOS VM integration tests ($CURRENT_SYSTEM)..."
+        echo "=== Configuration Evaluation ==="
         echo ""
 
-        for test in vm-users vm-ssh vm-packages; do
-          echo "--- $test ---"
-          nix build ".#checks.''${CURRENT_SYSTEM}.$test" --no-link
-          echo "$test: passed"
-          echo ""
-        done
-
-        echo "All VM tests passed"
-      '';
-    };
-
-    "test:sketchybar" = {
-      description = "Test sketchybar options, theme, and color conversion";
-      exec = ''
-        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
-        echo "Running sketchybar tests ($CURRENT_SYSTEM)..."
-        for test in sketchybar-options sketchybar-custom-options sketchybar-theme sketchybar-color-conversion sketchybar-platform-guard; do
-          echo "--- $test ---"
-          nix build ".#checks.''${CURRENT_SYSTEM}.$test" --no-link
-          echo "$test: passed"
-          echo ""
-        done
-        echo "All sketchybar tests passed"
-      '';
-    };
-
-    "test:onepassword" = {
-      description = "Test 1Password options, guard, and config output";
-      exec = ''
-        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
-        echo "Running 1Password tests ($CURRENT_SYSTEM)..."
-        for test in onepassword-guard onepassword-config-output; do
-          echo "--- $test ---"
-          nix build ".#checks.''${CURRENT_SYSTEM}.$test" --no-link
-          echo "$test: passed"
-          echo ""
-        done
-        echo "All 1Password tests passed"
-      '';
-    };
-
-    "test:all" = {
-      description = "Run all tests (eval gates build, optimized for parallel CI)";
-      exec = ''
-        echo "=== Phase 1: Evaluation Checks ==="
-        echo "Eval checks gate the build. Build runs only if all pass."
-        echo ""
-
-        devenv tasks run test:nixos-eval
-        EVAL_NIXOS=$?
-        devenv tasks run test:darwin-eval
-        EVAL_DARWIN=$?
-
-        if [ $EVAL_NIXOS -ne 0 ] || [ $EVAL_DARWIN -ne 0 ]; then
-          echo ""
-          echo "=== Eval Results: FAILED ==="
-          [ $EVAL_NIXOS -ne 0 ] && echo "NixOS eval: FAILED"
-          [ $EVAL_DARWIN -ne 0 ] && echo "Darwin eval: FAILED"
-          echo ""
-          echo "Skipping build - eval failures must be fixed first."
-          exit 1
-        fi
-
-        echo ""
-        echo "All evaluation checks passed."
-
-        echo ""
-        echo "=== Phase 2: Build Checks (single flake evaluation) ==="
-        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
-        echo "System: $CURRENT_SYSTEM"
-        echo ""
-        echo "Building all check targets in one nix build to avoid repeated flake evaluation."
-        echo ""
-
-        nix build \
-          ".#checks.''${CURRENT_SYSTEM}.core-packages" \
-          ".#checks.''${CURRENT_SYSTEM}.foundation-packages" \
-          ".#checks.''${CURRENT_SYSTEM}.foundation-options" \
-          ".#checks.''${CURRENT_SYSTEM}.config-validation" \
-          ".#checks.''${CURRENT_SYSTEM}.role-evaluation" \
-          ".#checks.''${CURRENT_SYSTEM}.role-composition" \
-          ".#checks.''${CURRENT_SYSTEM}.role-packages" \
-          ".#checks.''${CURRENT_SYSTEM}.role-cascades" \
-          ".#checks.''${CURRENT_SYSTEM}.llm-host-shared-models" \
-          ".#checks.''${CURRENT_SYSTEM}.no-dead-development-option" \
-          ".#checks.''${CURRENT_SYSTEM}.zsh-enable-single-location" \
-          ".#checks.''${CURRENT_SYSTEM}.skills-manifest" \
-          ".#checks.''${CURRENT_SYSTEM}.skills-autoload-filtering" \
-          ".#checks.''${CURRENT_SYSTEM}.skills-autoload-content" \
-          ".#checks.''${CURRENT_SYSTEM}.skills-role-filtering" \
-          ".#checks.''${CURRENT_SYSTEM}.skills-external-identification" \
-          ".#checks.''${CURRENT_SYSTEM}.skills-external-command-generation" \
-          ".#checks.''${CURRENT_SYSTEM}.skills-external-empty-case" \
-          ".#checks.''${CURRENT_SYSTEM}.email-agent-options" \
-          ".#checks.''${CURRENT_SYSTEM}.email-backup-options" \
-          ".#checks.''${CURRENT_SYSTEM}.email-custom-options" \
-          ".#checks.''${CURRENT_SYSTEM}.email-composition" \
-          ".#checks.''${CURRENT_SYSTEM}.email-backup-scripts" \
-          ".#checks.''${CURRENT_SYSTEM}.email-separation" \
-          ".#checks.''${CURRENT_SYSTEM}.sketchybar-options" \
-          ".#checks.''${CURRENT_SYSTEM}.sketchybar-custom-options" \
-          ".#checks.''${CURRENT_SYSTEM}.sketchybar-theme" \
-          ".#checks.''${CURRENT_SYSTEM}.sketchybar-color-conversion" \
-          ".#checks.''${CURRENT_SYSTEM}.sketchybar-platform-guard" \
-          ".#checks.''${CURRENT_SYSTEM}.sketchybar-entrypoint" \
-          ".#checks.''${CURRENT_SYSTEM}.onepassword-guard" \
-          ".#checks.''${CURRENT_SYSTEM}.onepassword-config-output" \
-          ".#checks.''${CURRENT_SYSTEM}.ollama-options" \
-          ".#checks.''${CURRENT_SYSTEM}.ollama-custom-options" \
-          ".#checks.''${CURRENT_SYSTEM}.vane-options" \
-          ".#checks.''${CURRENT_SYSTEM}.vane-custom-options" \
-          ".#checks.''${CURRENT_SYSTEM}.openclaw-options" \
-          ".#checks.''${CURRENT_SYSTEM}.vane-opnix-url-options" \
-          ".#checks.''${CURRENT_SYSTEM}.jj-autosync-options" \
-          ".#checks.''${CURRENT_SYSTEM}.jj-autosync-custom-options" \
-          ".#checks.''${CURRENT_SYSTEM}.opencode-options" \
-          ".#checks.''${CURRENT_SYSTEM}.opencode-custom-options" \
-          ".#checks.''${CURRENT_SYSTEM}.opencode-provider-opnix-url" \
-          ".#checks.''${CURRENT_SYSTEM}.shell-aliases" \
-          ".#checks.''${CURRENT_SYSTEM}.fjj-options" \
-          ".#checks.''${CURRENT_SYSTEM}.fjj-custom-options" \
-          ".#checks.''${CURRENT_SYSTEM}.aerospace-options" \
-          ".#checks.''${CURRENT_SYSTEM}.aerospace-custom-options" \
-          ".#checks.''${CURRENT_SYSTEM}.workspace-switch" \
-          ".#checks.''${CURRENT_SYSTEM}.llm-client-opencode" \
-          ".#checks.''${CURRENT_SYSTEM}.llm-client-claude" \
-          ".#checks.''${CURRENT_SYSTEM}.llm-client-pi" \
-          ".#checks.''${CURRENT_SYSTEM}.llm-client-custom-host" \
-          ".#checks.''${CURRENT_SYSTEM}.llm-client-no-ai-roles" \
-          ".#checks.''${CURRENT_SYSTEM}.typed-attrs-options" \
-          ".#checks.''${CURRENT_SYSTEM}.module-coverage" \
-          --no-link --keep-going --print-build-logs
-        BUILD_RESULT=$?
-
-        echo ""
-        echo "NOTE: VM integration tests (test:vm) are not included here."
-        echo "They require Linux + KVM and run separately in CI via nix flake check."
-        echo ""
-
-        echo "=== Final Results ==="
-        if [ $BUILD_RESULT -eq 0 ]; then
-          echo "All tests passed"
-          exit 0
-        else
-          echo "Build checks: FAILED"
-          exit 1
-        fi
-      '';
-    };
-
-    "test:nixos-eval" = {
-      description = "Validate NixOS configs can be evaluated (catches module errors)";
-      exec = ''
-        echo "=== Testing NixOS Configuration Evaluation ==="
-        echo ""
-        echo "This test validates that all NixOS configurations can be evaluated"
-        echo "without errors. It catches issues like:"
-        echo "  - Missing home-manager references in modules"
-        echo "  - Invalid option definitions"
-        echo "  - Import errors"
-        echo ""
-
-        echo "Testing NixOS configurations..."
-
-        # Create a minimal facter.json for testing (required by some NixOS configs)
-        # This is the same approach used in CI builds
-        # On macOS, skip this step (sudo not available) — configs needing facter will soft-fail
         HAS_FACTER=false
         if [ -f /etc/nixos/facter.json ]; then
           HAS_FACTER=true
         elif [[ "$(uname)" != "Darwin" ]]; then
-          echo "Creating stub facter.json for testing..."
           sudo mkdir -p /etc/nixos
           sudo tee /etc/nixos/facter.json > /dev/null << 'EOF'
         {
@@ -1510,14 +626,11 @@
           }
         }
         EOF
-          echo "Created /etc/nixos/facter.json"
-          echo ""
           HAS_FACTER=true
         fi
 
-        # Evaluate all configs in a single nix eval, using tryEval to catch errors per-config
-        echo "Evaluating all NixOS configurations (single flake evaluation)..."
-        RESULTS=$(nix eval --impure --json --expr '
+        echo "Evaluating NixOS configurations..."
+        NIXOS_RESULTS=$(nix eval --impure --json --expr '
           let
             flake = builtins.getFlake (toString ./.);
             names = builtins.attrNames flake.nixosConfigurations;
@@ -1529,85 +642,31 @@
             map tryConfig names
         ' 2>/dev/null)
 
-        if [ -z "$RESULTS" ]; then
-          echo "No NixOS configurations found"
-          exit 0
-        fi
-
-        FAILED=0
-        SKIPPED=0
-        FAILED_NAMES=()
-
-        while IFS=: read -r name success; do
-          if [ "$success" = "true" ]; then
-            echo "  $name ✓"
-          elif [[ "$HAS_FACTER" != "true" ]]; then
-            case "$name" in
-              type-*|installer-*|bootstrap)
-                echo "  $name ⊘ skipped (requires facter.json)"
-                SKIPPED=$((SKIPPED + 1))
-                ;;
-              *)
-                echo "  $name ✗ FAILED"
-                FAILED=$((FAILED + 1))
-                FAILED_NAMES+=("$name")
-                ;;
-            esac
-          else
-            echo "  $name ✗ FAILED"
-            FAILED=$((FAILED + 1))
-            FAILED_NAMES+=("$name")
-          fi
-        done < <(echo "$RESULTS" | jq -r '.[] | "\(.name):\(.success)"')
-
-        # Show error details for failed configs
-        if [ $FAILED -gt 0 ]; then
-          echo ""
-          echo "Error details:"
-          for name in "''${FAILED_NAMES[@]}"; do
-            echo ""
-            echo "--- $name ---"
-            nix eval --impure --expr "
-              let
-                flake = builtins.getFlake (toString ./.);
-                config = flake.nixosConfigurations.\"$name\";
-              in
-                config.config.system.build.toplevel
-            " 2>&1 | head -30
-          done
+        NIXOS_FAILED=0
+        NIXOS_SKIPPED=0
+        if [ -n "$NIXOS_RESULTS" ]; then
+          while IFS=: read -r name success; do
+            if [ "$success" = "true" ]; then
+              echo "  $name ✓"
+            elif [[ "$HAS_FACTER" != "true" ]]; then
+              case "$name" in
+                type-*|installer-*|bootstrap)
+                  echo "  $name ⊘ skipped"
+                  NIXOS_SKIPPED=$((NIXOS_SKIPPED + 1)) ;;
+                *)
+                  echo "  $name ✗"
+                  NIXOS_FAILED=$((NIXOS_FAILED + 1)) ;;
+              esac
+            else
+              echo "  $name ✗"
+              NIXOS_FAILED=$((NIXOS_FAILED + 1))
+            fi
+          done < <(echo "$NIXOS_RESULTS" | jq -r '.[] | "\(.name):\(.success)"')
         fi
 
         echo ""
-        if [ $FAILED -eq 0 ]; then
-          echo "✓ All NixOS configurations evaluated successfully"
-          if [ $SKIPPED -gt 0 ]; then
-            echo "  ($SKIPPED config(s) skipped - requires facter.json)"
-          fi
-          exit 0
-        else
-          echo "✗ $FAILED configuration(s) failed evaluation"
-          exit 1
-        fi
-      '';
-    };
-
-    "test:darwin-eval" = {
-      description = "Validate Darwin configs can be evaluated (catches module errors)";
-      exec = ''
-        echo "=== Testing Darwin Configuration Evaluation ==="
-        echo ""
-        echo "This test validates that all Darwin configurations can be evaluated"
-        echo "without errors. It catches issues like:"
-        echo "  - Missing home-manager references in modules"
-        echo "  - Invalid option definitions"
-        echo "  - Import errors"
-        echo ""
-
-        echo "Testing Darwin configurations..."
-
-        # Evaluate all configs in a single nix eval, using tryEval to catch errors per-config
-        echo "Evaluating all Darwin configurations (single flake evaluation)..."
-        RESULTS=$(nix eval --impure --json --expr '
+        echo "Evaluating Darwin configurations..."
+        DARWIN_RESULTS=$(nix eval --impure --json --expr '
           let
             flake = builtins.getFlake (toString ./.);
             names = builtins.attrNames flake.darwinConfigurations;
@@ -1619,117 +678,50 @@
             map tryConfig names
         ' 2>/dev/null)
 
-        if [ -z "$RESULTS" ]; then
-          echo "No Darwin configurations found"
-          exit 0
+        DARWIN_FAILED=0
+        if [ -n "$DARWIN_RESULTS" ]; then
+          while IFS=: read -r name success; do
+            if [ "$success" = "true" ]; then echo "  $name ✓"
+            else echo "  $name ✗"; DARWIN_FAILED=$((DARWIN_FAILED + 1)); fi
+          done < <(echo "$DARWIN_RESULTS" | jq -r '.[] | "\(.name):\(.success)"')
         fi
 
-        FAILED=0
-        FAILED_NAMES=()
-
-        while IFS=: read -r name success; do
-          if [ "$success" = "true" ]; then
-            echo "  $name ✓"
-          else
-            echo "  $name ✗ FAILED"
-            FAILED=$((FAILED + 1))
-            FAILED_NAMES+=("$name")
-          fi
-        done < <(echo "$RESULTS" | jq -r '.[] | "\(.name):\(.success)"')
-
-        # Show error details for failed configs
-        if [ $FAILED -gt 0 ]; then
+        if [ $NIXOS_FAILED -gt 0 ] || [ $DARWIN_FAILED -gt 0 ]; then
           echo ""
-          echo "Error details:"
-          for name in "''${FAILED_NAMES[@]}"; do
-            echo ""
-            echo "--- $name ---"
-            nix eval --impure --expr "
-              let
-                flake = builtins.getFlake (toString ./.);
-                config = flake.darwinConfigurations.\"$name\";
-              in
-                config.config.system.build.toplevel
-            " 2>&1 | head -30
-          done
-        fi
-
-        echo ""
-        if [ $FAILED -eq 0 ]; then
-          echo "✓ All Darwin configurations evaluated successfully"
-          exit 0
-        else
-          echo "✗ $FAILED configuration(s) failed evaluation"
+          echo "✗ $NIXOS_FAILED NixOS + $DARWIN_FAILED Darwin config(s) failed evaluation"
           exit 1
         fi
+        echo ""
+        echo "✓ All configurations evaluated successfully"
       '';
     };
 
-    "test:darwin-build" = {
-      description = "Build Darwin configs to catch home-manager errors (slower)";
+    "test:checks" = {
+      description = "Build all flake checks (auto-discovers, excludes VM tests)";
+      after = ["test:eval"];
       exec = ''
-        echo "=== Testing Darwin Configuration Build ==="
-        echo ""
-        echo "This test actually builds Darwin configurations to catch errors that"
-        echo "evaluation alone won't catch, such as:"
-        echo "  - Invalid home-manager activation scripts"
-        echo "  - Missing hm.dag references"
-        echo "  - Build-time dependency issues"
-        echo ""
-        echo "Note: This is slower than test:darwin-eval but catches more errors"
+        echo "=== Building Checks ==="
+        CURRENT_SYSTEM=$(nix eval --impure --expr 'builtins.currentSystem' --raw)
+        echo "System: $CURRENT_SYSTEM"
         echo ""
 
-        echo "Testing Darwin configurations..."
-        FAILED=0
-
-        # Get list of all Darwin configurations
-        CONFIGS=$(nix eval --json .#darwinConfigurations --apply 'builtins.attrNames' 2>/dev/null | jq -r '.[]')
-
-        if [ -z "$CONFIGS" ]; then
-          echo "⚠ No Darwin configurations found"
+        ALL_CHECKS=$(nix eval --impure --json ".#checks.''${CURRENT_SYSTEM}" --apply 'builtins.attrNames' 2>/dev/null)
+        if [ -z "$ALL_CHECKS" ] || [ "$ALL_CHECKS" = "null" ]; then
+          echo "No checks found"
           exit 0
         fi
 
-        echo "Found configurations:"
-        echo "$CONFIGS" | sed 's/^/  - /'
-        echo ""
+        # Exclude VM tests (need Linux + KVM)
+        FILTERED=$(echo "$ALL_CHECKS" | jq -r '.[] | select(startswith("vm-") | not)')
+        TARGETS=$(echo "$FILTERED" | sed "s|^|.#checks.''${CURRENT_SYSTEM}.|")
 
-        # Test each configuration by building the system derivation
-        for CONFIG in $CONFIGS; do
-          echo -n "Building $CONFIG... "
-
-          # Build the system configuration (catches home-manager errors)
-          if nix build .#darwinConfigurations."$CONFIG".config.system.build.toplevel \
-              --no-link --dry-run 2>/dev/null; then
-            echo "✓"
-          else
-            echo "✗ FAILED"
-            echo ""
-            echo "Error output:"
-            nix build .#darwinConfigurations."$CONFIG".config.system.build.toplevel \
-              --no-link --show-trace 2>&1 | head -60
-            FAILED=$((FAILED + 1))
-          fi
-        done
-
-        echo ""
-        if [ $FAILED -eq 0 ]; then
-          echo "✓ All Darwin configurations built successfully"
+        if [ -z "$TARGETS" ]; then
+          echo "No checks to build"
           exit 0
-        else
-          echo "✗ $FAILED configuration(s) failed to build"
-          exit 1
         fi
+
+        echo "$TARGETS" | xargs nix build --no-link --keep-going --print-build-logs
       '';
-    };
-
-    # ============================================
-    # CI WATCH TASK (Agent-Optimized)
-    # ============================================
-
-    "ci:watch" = {
-      description = "Poll CI until completion [usage: ci:watch <run-id>]";
-      exec = builtins.readFile ./scripts/ci-watch.sh;
     };
   };
 

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -52,7 +52,7 @@ dtl
 | Task | Description |
 |------|-------------|
 | `flake:update` | Update flake inputs |
-| `devenv:update` | Update devenv lock file |
+| `devenv update` | Update devenv lock file |
 
 ### Development
 

--- a/flake.lock
+++ b/flake.lock
@@ -25,16 +25,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778427648,
-        "narHash": "sha256-pt9KaDGsMyYWB9JeHs4XGHs870f1lOZe3vx9LpVIhUE=",
+        "lastModified": 1779646357,
+        "narHash": "sha256-rnnAaESXxItX4D9xCMGvs3hfDBjbbTYht7OluRcvT8k=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "6f293daa9f9f5832e13b497976335e90509886d7",
+        "rev": "10a163ac127624caa80cc5cc5a705e97f3615b0e",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.11",
+        "ref": "5.1.14",
         "repo": "brew",
         "type": "github"
       }
@@ -298,11 +298,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1779995347,
-        "narHash": "sha256-clASMT4ByGv5maS8xOgU1Y55R0pKUNMfSq5HEdJ6bV8=",
+        "lastModified": 1780630679,
+        "narHash": "sha256-hhQyVAYmNKziZ0T+T4Gsk0PYmnz4vdzOzpkJAmDASKM=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "bb9f187856091b52f56220bb90ff4b40cfa80b52",
+        "rev": "90ed6227ab389dd4e874a69a724f25dba312b754",
         "type": "github"
       },
       "original": {
@@ -391,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779942106,
-        "narHash": "sha256-81sATQ+hMCcsqFCN5UyhCoXXf62yQfKtzKzuiFXtdxA=",
+        "lastModified": 1780290312,
+        "narHash": "sha256-eTAlX0CwgB84Ts3GaBd944A3DRXVMzgA0EqroZBISUo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "36c1d04e85fc70f7b94f7434b1ea0a1a13bda4cd",
+        "rev": "115e5211780054d8a890b41f0b7734cafad54dfe",
         "type": "github"
       },
       "original": {
@@ -969,11 +969,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779969295,
-        "narHash": "sha256-HwIJ3tOcwSMiV75L7KqJXciXR9UfT+d7rwOZMX7cTnA=",
+        "lastModified": 1780593650,
+        "narHash": "sha256-CHo7k65YTL3HY+WQVedDTupji+LMgNlKCdrtRHZFAK4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "61e2c9659324181e0f0ed911958c536333b1d4f6",
+        "rev": "447fd9ff62501dae7206dfe180ee89f8de27b7d5",
         "type": "github"
       },
       "original": {
@@ -1006,11 +1006,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1780026951,
-        "narHash": "sha256-PuLWmQszPwUN64LB9RwWABwvDiPj0jCL8fGw+lP61yY=",
+        "lastModified": 1780633942,
+        "narHash": "sha256-WlsCk5OWlLKlrOldLoCCGRz76ZieP3DRmFsXoKGBn3A=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "cc7360281993769f73dba8409dcb6da7bda4de30",
+        "rev": "347cb1d3345d0332f1ca1638b0bca1a2d532f630",
         "type": "github"
       },
       "original": {
@@ -1022,11 +1022,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1780028764,
-        "narHash": "sha256-9G0t9+dAMlL1SMvQNHaEaubTl0IwzvTwoaTQD8Rny+c=",
+        "lastModified": 1780634729,
+        "narHash": "sha256-gGAp+cHNMTdAmef0zbGHU259hirA/fdSttOr6BGOHvU=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "02b7895e6a4f6768c68447b3d411f63258224225",
+        "rev": "629f790f174b3e48bcd8567b7e94700691a12fc0",
         "type": "github"
       },
       "original": {
@@ -1066,11 +1066,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1779970379,
-        "narHash": "sha256-ZHsxoYXXnfJtMVh1/yY+1Eh9hHcPBhE28Qvinauh+BQ=",
+        "lastModified": 1780588968,
+        "narHash": "sha256-zQk+GqLO+T9taIl1UUt3swvaOksWJxL7PL8K0+Fc/Hs=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "0d49083ba2d7419b22908ac392777c16df9a032e",
+        "rev": "4d3fb17437944ea57eef2b9e6108ca777b1209ca",
         "type": "github"
       },
       "original": {
@@ -1105,11 +1105,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779391158,
-        "narHash": "sha256-NUKwtyaooPLJPBOdg0piBgR6NIzY/n2W45+qkYdh+h8=",
+        "lastModified": 1779748925,
+        "narHash": "sha256-meIhqGC04O5VXbKSFXSQoOKp+XCq5RMnwAk1Guo0VQo=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "b58ad8fb752809db919ae865c6b2aa3be7d55e1f",
+        "rev": "0bc443c8ff235c3547d09327b48aaa2ab98b15f2",
         "type": "github"
       },
       "original": {
@@ -1145,11 +1145,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1778851564,
-        "narHash": "sha256-p8wzcnpB2Iys+QzAKM9/Eyw/pUyqCO3sw/NCnDH4dTE=",
+        "lastModified": 1780492467,
+        "narHash": "sha256-zMEJwtQPmsPPgPczFkyjWHgd1z0HagOPS2Wt2WDYLJY=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "b3a87b4793205cc111f3c61e25e018ffac3b8039",
+        "rev": "562332f97de9f5ba51aa647d70462e88222b2988",
         "type": "github"
       },
       "original": {
@@ -1169,11 +1169,11 @@
         "qmd": "qmd"
       },
       "locked": {
-        "lastModified": 1780032613,
-        "narHash": "sha256-+QKFnvUijpy2v/ty56H+jWATnBK52XaeHysWY8zzbWM=",
+        "lastModified": 1780526716,
+        "narHash": "sha256-qXNbvzqcnj7nDCLk582ZXMtM/xShG7oHyiQ/evRJYFM=",
         "owner": "openclaw",
         "repo": "nix-openclaw",
-        "rev": "0bb60a7e34d3a7155173c88ec97bb01036d1385a",
+        "rev": "561aa2809a9cbfc9ba7b86c02b5796cd71937ecc",
         "type": "github"
       },
       "original": {
@@ -1581,11 +1581,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -1872,11 +1872,11 @@
     "superpowers": {
       "flake": false,
       "locked": {
-        "lastModified": 1777932301,
-        "narHash": "sha256-3E3rO6hR87JUfS3XV1Eaoz6SDWOftleWvN9UPNFEMjw=",
+        "lastModified": 1780085125,
+        "narHash": "sha256-P/FD8HTQO+QzvMe3A/B2v2vjs8T6ZmIYH3MPp79dSzo=",
         "owner": "obra",
         "repo": "superpowers",
-        "rev": "f2cbfbefebbfef77321e4c9abc9e949826bea9d7",
+        "rev": "6fd4507659784c351abbd2bc264c7162cfd386dc",
         "type": "github"
       },
       "original": {
@@ -2059,11 +2059,11 @@
     "vercel-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1779917840,
-        "narHash": "sha256-gFEfdT0h9VbC+I0WUcZ9SYSW2A1liCc2An6qkti7+5U=",
+        "lastModified": 1780453140,
+        "narHash": "sha256-nISOazYZ9I786Nn4TKmFXyK6WiTPdULdAG0aeRUVXvA=",
         "owner": "vercel-labs",
         "repo": "skills",
-        "rev": "b469d6954dd10be20d3e8d9bb59463584d42efbb",
+        "rev": "87dc3636c59d38d7336a1d857f1364699bf38038",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,7 @@
           permittedInsecurePackages = [
             "google-chrome-144.0.7559.97"
             "olm-3.2.16"
+            "electron-39.8.10"
           ];
           allowInsecurePredicate = attrs: let
             pname = attrs.pname or attrs.name or "";
@@ -83,7 +84,7 @@
           in
             pname
             == "openclaw"
-            || builtins.elem fullName ["google-chrome-144.0.7559.97" "olm-3.2.16"];
+            || builtins.elem fullName ["google-chrome-144.0.7559.97" "olm-3.2.16" "electron-39.8.10"];
         };
         overlays = [
           (final: _prev: {

--- a/library/lib/mk-system.nix
+++ b/library/lib/mk-system.nix
@@ -22,6 +22,7 @@
                 permittedInsecurePackages = [
                   "google-chrome-144.0.7559.97"
                   "olm-3.2.16"
+                  "electron-39.8.10"
                 ];
                 allowInsecurePredicate = attrs: let
                   pname = attrs.pname or attrs.name or "";
@@ -29,7 +30,7 @@
                 in
                   pname
                   == "openclaw"
-                  || builtins.elem fullName ["google-chrome-144.0.7559.97" "olm-3.2.16"];
+                  || builtins.elem fullName ["google-chrome-144.0.7559.97" "olm-3.2.16" "electron-39.8.10"];
               };
               overlays = [
                 (final: _prev: {

--- a/modules/common/scripts/dev-ide
+++ b/modules/common/scripts/dev-ide
@@ -1,0 +1,25 @@
+ide() {
+  local repo_root
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+  export FILE_MANAGER="${FILE_MANAGER:-yazi}"
+  export AGENT="${AGENT:-opencode}"
+  export EDITOR="${EDITOR:-hx}"
+  export PWD="$repo_root"
+
+  local guid
+  guid=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -d'-' -f1)
+  local session_name="ide-$(basename "$PWD")-${guid}"
+  local layout_file
+  layout_file=$(mktemp)
+
+  if [[ -n "${WITH_PR}" ]]; then
+    local template="$PWD/configs/ide/layout-with-pr.kdl.template"
+  else
+    local template="$PWD/configs/ide/layout.kdl.template"
+  fi
+
+  envsubst < "$template" > "$layout_file"
+  zellij -s "$session_name" -n "$layout_file"
+  rm -f "$layout_file"
+}

--- a/modules/common/scripts/pr-review
+++ b/modules/common/scripts/pr-review
@@ -1,0 +1,12 @@
+pr-review() {
+  local repo_root
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+  export PWD="$repo_root"
+
+  local guid
+  guid=$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -d'-' -f1)
+  local session_name="pr-review-$(basename "$PWD")-${guid}"
+
+  zellij -s "$session_name" run -- gh-dash --config "${PWD}/configs/ide/gh-dash.yml"
+}

--- a/modules/home-manager/higgs.nix
+++ b/modules/home-manager/higgs.nix
@@ -60,7 +60,7 @@ with lib; let
   );
 
   # Providers with apiKeyFile (read at build time, embed in config)
-  providersConfig = mapAttrs (name: p:
+  providersConfig = mapAttrs (_: p:
     clean (
       {
         url = p.url;

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -160,14 +160,17 @@ with lib; let
     PRIVATE_CONFIG="$HOME/.config/opencode/opencode-private.json"
 
     # Start with the base config
+    # Use --no-preserve=mode to avoid inheriting read-only permissions from nix store
     if [[ -L "$BASE_CONFIG" ]]; then
       # It's a symlink (from nix store), read it
-      cp "$(readlink -f "$BASE_CONFIG")" "$DYNAMIC_CONFIG"
+      cp --no-preserve=mode "$(readlink -f "$BASE_CONFIG")" "$DYNAMIC_CONFIG"
     elif [[ -f "$BASE_CONFIG" ]]; then
-      cp "$BASE_CONFIG" "$DYNAMIC_CONFIG"
+      cp --no-preserve=mode "$BASE_CONFIG" "$DYNAMIC_CONFIG"
     else
       echo "{}" > "$DYNAMIC_CONFIG"
     fi
+    # Ensure the dynamic config is writable for subsequent runs
+    chmod u+w "$DYNAMIC_CONFIG" 2>/dev/null || true
 
     # Patch baseURLs from opnix-managed secret files
     # This allows provider base URLs to be stored in 1Password instead of the Nix store

--- a/modules/roles/foundation-packages.nix
+++ b/modules/roles/foundation-packages.nix
@@ -1,0 +1,47 @@
+{pkgs}:
+with pkgs; {
+  common = [
+    helix
+    htop
+    zellij
+    yazi
+
+    # Data processing
+    jq
+
+    # Git and version control
+    gh
+    jujutsu
+    delta
+
+    # Navigation and search
+    entr
+    tree
+    zoxide
+    fzf
+    ripgrep
+    fd
+    gum
+
+    # Development tools
+    devenv
+    direnv
+    rclone
+    bat
+    jnv
+    docker
+    colima
+
+    # Shell ecosystem
+    zinit
+    zsh
+    antigen
+  ];
+
+  darwinOnly = [
+    google-chrome
+    hidden-bar
+    alacritty-theme
+    home-manager
+  ];
+}

--- a/modules/roles/foundation.nix
+++ b/modules/roles/foundation.nix
@@ -6,50 +6,16 @@
 }: let
   cfg = config.myConfig.roles.foundation;
   inherit (config.myConfig) isDarwin;
+  foundationPkgs = import ./foundation-packages.nix {inherit pkgs;};
 in {
   config = lib.mkIf cfg.enable (
     lib.mkMerge [
       {
-        environment.systemPackages = with pkgs; [
-          # Editors and terminals
-          helix
-          htop
-          zellij
-
-          # Data processing
-          jq
-
-          # Security
-          _1password-cli
-
-          # Git and version control
-          gh
-          jujutsu
-          delta
-
-          # Navigation and search
-          entr
-          tree
-          zoxide
-          fzf
-          ripgrep
-          fd
-          gum
-
-          # Development tools
-          devenv
-          direnv
-          rclone
-          bat
-          jnv
-          docker
-          colima
-
-          # Shell ecosystem
-          zinit
-          zsh
-          antigen
-        ];
+        environment.systemPackages =
+          foundationPkgs.common
+          ++ (with pkgs; [
+            _1password-cli
+          ]);
 
         myConfig.onepassword.enable = true;
         myConfig.syncthing.enable = true;
@@ -97,12 +63,7 @@ in {
         };
       }
       (lib.mkIf isDarwin {
-        environment.systemPackages = with pkgs; [
-          google-chrome
-          hidden-bar
-          alacritty-theme
-          home-manager
-        ];
+        environment.systemPackages = foundationPkgs.darwinOnly;
       })
     ]
   );

--- a/modules/services/higgs/darwin.nix
+++ b/modules/services/higgs/darwin.nix
@@ -4,7 +4,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 with lib; let

--- a/modules/services/vane/common.nix
+++ b/modules/services/vane/common.nix
@@ -4,7 +4,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 with lib; let

--- a/modules/services/vane/darwin.nix
+++ b/modules/services/vane/darwin.nix
@@ -16,6 +16,10 @@ with lib; let
     else "monkey";
   darwinHomeDir = "/Users/${primaryUser}";
   dataDir = cfg.dataDir;
+  resolvedBaseUrl =
+    if cfg.openaiBaseUrl != null
+    then cfg.openaiBaseUrl
+    else "http://localhost:8000/v1";
 
   # Environment for Vane
   # OPENAI_BASE_URL is omitted — it triggers Vane to auto-create a duplicate provider.
@@ -61,7 +65,7 @@ with lib; let
           ],
           "config": {
             "apiKey": "higgs-local",
-            "baseURL": "${cfg.openaiBaseUrl}"
+            "baseURL": "${resolvedBaseUrl}"
           }
         }
       ],

--- a/scripts/docs-update.sh
+++ b/scripts/docs-update.sh
@@ -385,7 +385,7 @@ dtl
 | Task | Description |
 |------|-------------|
 | `flake:update` | Update flake inputs |
-| `devenv:update` | Update devenv lock file |
+| `devenv update` | Update devenv lock file |
 
 ### Development
 

--- a/targets/MegamanX/default.nix
+++ b/targets/MegamanX/default.nix
@@ -83,9 +83,9 @@
       };
       vane = {
         enable = true;
-        # Higgs is the unified gateway (runs outside Docker, accessed via host.docker.internal)
+        # Higgs is the unified gateway — Vane runs natively now, so use localhost
         # Embeddings are generated natively by Higgs from loaded MLX models
-        openaiBaseUrl = "http://host.docker.internal:8000/v1";
+        openaiBaseUrl = "http://localhost:8000/v1";
         # Models are served by Higgs at the OpenAI endpoint, discovered at runtime
         defaultModel = null;
         embeddingModel = null;

--- a/tests/test-roles.nix
+++ b/tests/test-roles.nix
@@ -197,7 +197,7 @@
     developer = ["clang" "python3" "nodejs" "yarn" "k9s" "gh-dash" "yaks"];
     creative = ["ffmpeg" "imagemagick" "pandoc"];
     gaming = ["moonlight-qt"];
-    desktop = ["logseq" "super-productivity"];
+    desktop = ["logseq"];
     workstation = ["slack" "trippy" "unar"];
     # entertainment: NixOS packages (obs-studio, discord) are tested separately
     # in entertainmentNixosTest using linuxPkgs; they only appear on NixOS (isDarwin=false)


### PR DESCRIPTION
## Summary

- **devenv.nix**: Major cleanup - removed redundant build/test tasks (build:darwin, build:nixos, test:nixos-eval, test:darwin-eval, test:all, etc.). Consolidated testing into `test:eval`, `test:checks`, `test`. Extracted common packages to foundation-packages.nix.
- **Foundation packages**: Split `foundation-packages.nix` from `foundation.nix` for cleaner separation.
- **New scripts**: Extracted `dev-ide` and `pr-review` scripts from devenv tasks into `modules/common/scripts/`.
- **AGENTS.md/docs**: Updated to reflect simplified task structure (`test` replaces `test:all`, `check:lint` replaces `quality:check`, etc.).
- **Dependency bumps**: Updated devenv, git-hooks.nix, nixpkgs-src.
- **CI**: Updated to use `test:eval test:checks` instead of `test:all`.