### PR TITLE
test: add missing option tests for claude-code, pi, bifrost, caddy, searxng, lume

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -19,6 +19,12 @@
   testLlmClient = import ./test-llm-client.nix {inherit pkgs;};
 
   testVllmMlx = import ./test-vllm-mlx.nix {inherit pkgs;};
+  testClaudeCode = import ./test-claude-code.nix {inherit pkgs;};
+  testPi = import ./test-pi.nix {inherit pkgs;};
+  testBifrost = import ./test-bifrost.nix {inherit pkgs;};
+  testCaddy = import ./test-caddy.nix {inherit pkgs;};
+  testSearxng = import ./test-searxng.nix {inherit pkgs;};
+  testLume = import ./test-lume.nix {inherit pkgs;};
   testNixosModules = import ./test-nixos-modules.nix {inherit pkgs;};
   testStackIntegration = import ./test-stack-integration.nix {inherit pkgs;};
   testZero = import ./test-zero.nix {inherit pkgs;};
@@ -158,6 +164,30 @@ in
     # vllm-mlx module tests
     vllm-mlx-options = testVllmMlx.vllmMlxOptionsTest;
     megamanx-vllm = testVllmMlx.megamanxVllmMlxTest;
+
+    # Claude Code module tests
+    claude-code-options = testClaudeCode.claudeCodeOptionsTest;
+    claude-code-custom-options = testClaudeCode.claudeCodeCustomOptionsTest;
+
+    # Pi coding agent module tests
+    pi-options = testPi.piOptionsTest;
+    pi-custom-options = testPi.piCustomOptionsTest;
+
+    # Bifrost AI gateway module tests
+    bifrost-options = testBifrost.bifrostOptionsTest;
+    bifrost-custom-options = testBifrost.bifrostCustomOptionsTest;
+
+    # Caddy reverse proxy module tests
+    caddy-options = testCaddy.caddyOptionsTest;
+    caddy-custom-options = testCaddy.caddyCustomOptionsTest;
+
+    # SearXNG module tests
+    searxng-options = testSearxng.searxngOptionsTest;
+    searxng-custom-options = testSearxng.searxngCustomOptionsTest;
+
+    # Lume module tests
+    lume-options = testLume.lumeOptionsTest;
+    lume-custom-options = testLume.lumeCustomOptionsTest;
 
     # LLM stack integration test
     stack-integration = testStackIntegration.stackIntegrationTest;

--- a/tests/test-bifrost.nix
+++ b/tests/test-bifrost.nix
@@ -1,0 +1,154 @@
+# Bifrost AI gateway option tests
+# Validates option defaults and custom values
+{pkgs, ...}: let
+  inherit (pkgs) lib;
+
+  stubModules = [
+    ../modules/common/options.nix
+    {
+      options.nixpkgs.hostPlatform = lib.mkOption {
+        type = lib.types.anything;
+        default = {inherit (pkgs.stdenv.hostPlatform) system;};
+      };
+    }
+    {
+      config._module.args = {inherit pkgs;};
+    }
+  ];
+
+  bifrostDefaults =
+    (lib.evalModules {
+      modules = stubModules;
+    }).config.myConfig.bifrost;
+
+  bifrostCustom =
+    (lib.evalModules {
+      modules =
+        stubModules
+        ++ [
+          {
+            config.myConfig.bifrost = {
+              enable = true;
+              port = 9090;
+              host = "127.0.0.1";
+              logLevel = "debug";
+              appDir = "/var/lib/bifrost";
+              upstreams = {
+                "vllm-mlx-local" = {
+                  url = "http://localhost:8300/v1";
+                  type = "vllm";
+                  apiKey = "dummy";
+                  allowPrivateNetwork = true;
+                  requestTimeout = 60;
+                  models = ["qwen3.5"];
+                };
+              };
+            };
+          }
+        ];
+    }).config.myConfig.bifrost;
+in {
+  bifrostOptionsTest = pkgs.runCommand "test-bifrost-options" {} ''
+    echo "=== Testing Bifrost Option Defaults ==="
+
+    ${
+      if !bifrostDefaults.enable
+      then ''echo "  enable default = false: OK"''
+      else ''echo "  enable should default to false!"; exit 1''
+    }
+
+    ${
+      if bifrostDefaults.port == 8081
+      then ''echo "  port default = 8081: OK"''
+      else ''echo "  port should default to 8081!"; exit 1''
+    }
+
+    ${
+      if bifrostDefaults.host == "0.0.0.0"
+      then ''echo "  host default = 0.0.0.0: OK"''
+      else ''echo "  host should default to 0.0.0.0!"; exit 1''
+    }
+
+    ${
+      if bifrostDefaults.logLevel == "info"
+      then ''echo "  logLevel default = info: OK"''
+      else ''echo "  logLevel should default to info!"; exit 1''
+    }
+
+    ${
+      if bifrostDefaults.appDir == "$HOME/.config/bifrost"
+      then ''echo "  appDir default = \$HOME/.config/bifrost: OK"''
+      else ''echo "  appDir should default to \$HOME/.config/bifrost!"; exit 1''
+    }
+
+    ${
+      if bifrostDefaults.upstreams == {}
+      then ''echo "  upstreams default = {}: OK"''
+      else ''echo "  upstreams should default to {}!"; exit 1''
+    }
+
+    echo "All Bifrost option defaults verified"
+    touch $out
+  '';
+
+  bifrostCustomOptionsTest = pkgs.runCommand "test-bifrost-custom-options" {} ''
+    echo "=== Testing Bifrost Custom Options ==="
+
+    ${
+      if bifrostCustom.enable
+      then ''echo "  enable = true: OK"''
+      else ''echo "  enable should be true!"; exit 1''
+    }
+
+    ${
+      if bifrostCustom.port == 9090
+      then ''echo "  port = 9090: OK"''
+      else ''echo "  port should be 9090!"; exit 1''
+    }
+
+    ${
+      if bifrostCustom.host == "127.0.0.1"
+      then ''echo "  host = 127.0.0.1: OK"''
+      else ''echo "  host should be 127.0.0.1!"; exit 1''
+    }
+
+    ${
+      if bifrostCustom.logLevel == "debug"
+      then ''echo "  logLevel = debug: OK"''
+      else ''echo "  logLevel should be debug!"; exit 1''
+    }
+
+    ${
+      if bifrostCustom.appDir == "/var/lib/bifrost"
+      then ''echo "  appDir = /var/lib/bifrost: OK"''
+      else ''echo "  appDir should be /var/lib/bifrost!"; exit 1''
+    }
+
+    ${
+      if bifrostCustom.upstreams ? "vllm-mlx-local"
+      then ''echo "  upstreams.vllm-mlx-local defined: OK"''
+      else ''echo "  upstreams.vllm-mlx-local should be defined!"; exit 1''
+    }
+
+    ${
+      if bifrostCustom.upstreams."vllm-mlx-local".url == "http://localhost:8300/v1"
+      then ''echo "  upstream URL correct: OK"''
+      else ''echo "  upstream URL should be http://localhost:8300/v1!"; exit 1''
+    }
+
+    ${
+      if bifrostCustom.upstreams."vllm-mlx-local".type == "vllm"
+      then ''echo "  upstream type = vllm: OK"''
+      else ''echo "  upstream type should be vllm!"; exit 1''
+    }
+
+    ${
+      if builtins.elem "qwen3.5" bifrostCustom.upstreams."vllm-mlx-local".models
+      then ''echo "  upstream models contains qwen3.5: OK"''
+      else ''echo "  upstream models should contain qwen3.5!"; exit 1''
+    }
+
+    echo "All Bifrost custom options verified"
+    touch $out
+  '';
+}

--- a/tests/test-caddy.nix
+++ b/tests/test-caddy.nix
@@ -1,0 +1,116 @@
+# Caddy reverse proxy option tests
+# Validates option defaults and custom values
+{pkgs, ...}: let
+  inherit (pkgs) lib;
+
+  stubModules = [
+    ../modules/common/options.nix
+    {
+      options.nixpkgs.hostPlatform = lib.mkOption {
+        type = lib.types.anything;
+        default = {inherit (pkgs.stdenv.hostPlatform) system;};
+      };
+    }
+    {
+      config._module.args = {inherit pkgs;};
+    }
+  ];
+
+  caddyDefaults =
+    (lib.evalModules {
+      modules = stubModules;
+    }).config.myConfig.caddy;
+
+  caddyCustom =
+    (lib.evalModules {
+      modules =
+        stubModules
+        ++ [
+          {
+            config.myConfig.caddy = {
+              enable = true;
+              port = 8080;
+              dataDir = "/var/lib/caddy";
+              hosts = {
+                "app.internal" = "localhost:9000";
+                "api.internal" = "localhost:9001";
+              };
+            };
+          }
+        ];
+    }).config.myConfig.caddy;
+in {
+  caddyOptionsTest = pkgs.runCommand "test-caddy-options" {} ''
+    echo "=== Testing Caddy Option Defaults ==="
+
+    ${
+      if !caddyDefaults.enable
+      then ''echo "  enable default = false: OK"''
+      else ''echo "  enable should default to false!"; exit 1''
+    }
+
+    ${
+      if caddyDefaults.port == 80
+      then ''echo "  port default = 80: OK"''
+      else ''echo "  port should default to 80!"; exit 1''
+    }
+
+    ${
+      if caddyDefaults.dataDir == "$HOME/.local/share/caddy"
+      then ''echo "  dataDir default = \$HOME/.local/share/caddy: OK"''
+      else ''echo "  dataDir should default to \$HOME/.local/share/caddy!"; exit 1''
+    }
+
+    ${
+      if caddyDefaults.hosts == {}
+      then ''echo "  hosts default = {}: OK"''
+      else ''echo "  hosts should default to {}!"; exit 1''
+    }
+
+    echo "All Caddy option defaults verified"
+    touch $out
+  '';
+
+  caddyCustomOptionsTest = pkgs.runCommand "test-caddy-custom-options" {} ''
+    echo "=== Testing Caddy Custom Options ==="
+
+    ${
+      if caddyCustom.enable
+      then ''echo "  enable = true: OK"''
+      else ''echo "  enable should be true!"; exit 1''
+    }
+
+    ${
+      if caddyCustom.port == 8080
+      then ''echo "  port = 8080: OK"''
+      else ''echo "  port should be 8080!"; exit 1''
+    }
+
+    ${
+      if caddyCustom.dataDir == "/var/lib/caddy"
+      then ''echo "  dataDir = /var/lib/caddy: OK"''
+      else ''echo "  dataDir should be /var/lib/caddy!"; exit 1''
+    }
+
+    ${
+      if caddyCustom.hosts ? "app.internal"
+      then ''echo "  hosts.app.internal defined: OK"''
+      else ''echo "  hosts.app.internal should be defined!"; exit 1''
+    }
+
+    ${
+      if caddyCustom.hosts."app.internal" == "localhost:9000"
+      then ''echo "  hosts.app.internal = localhost:9000: OK"''
+      else ''echo "  hosts.app.internal should be localhost:9000!"; exit 1''
+    }
+
+    ${
+      if caddyCustom.hosts ? "api.internal"
+      then ''echo "  hosts.api.internal defined: OK"''
+      else ''echo "  hosts.api.internal should be defined!"; exit 1''
+    }
+
+    echo "All Caddy custom options verified"
+    touch $out
+  '';
+}

--- a/tests/test-claude-code.nix
+++ b/tests/test-claude-code.nix
@@ -1,0 +1,145 @@
+# Claude Code option tests
+# Validates option defaults and custom values
+{pkgs, ...}: let
+  inherit (pkgs) lib;
+
+  stubModules = [
+    ../modules/common/options.nix
+    {
+      options.nixpkgs.hostPlatform = lib.mkOption {
+        type = lib.types.anything;
+        default = {inherit (pkgs.stdenv.hostPlatform) system;};
+      };
+    }
+    {
+      config._module.args = {inherit pkgs;};
+    }
+  ];
+
+  claudeDefaults =
+    (lib.evalModules {
+      modules = stubModules;
+    }).config.myConfig.claude-code;
+
+  claudeCustom =
+    (lib.evalModules {
+      modules =
+        stubModules
+        ++ [
+          {
+            config.myConfig.claude-code = {
+              enable = true;
+              includeCoAuthoredBy = true;
+              mcpServers = {
+                test-server = {
+                  type = "local";
+                  command = ["node" "server.js"];
+                  enabled = true;
+                };
+              };
+              agents = {
+                "reviewer" = "Code review agent";
+              };
+              commands = {
+                "explain" = "Explain this code";
+              };
+              hooks = {
+                "pre-commit" = "Run tests";
+              };
+            };
+          }
+        ];
+    }).config.myConfig.claude-code;
+in {
+  claudeCodeOptionsTest = pkgs.runCommand "test-claude-code-options" {} ''
+    echo "=== Testing Claude Code Option Defaults ==="
+
+    ${
+      if !claudeDefaults.enable
+      then ''echo "  enable default = false: OK"''
+      else ''echo "  enable should default to false!"; exit 1''
+    }
+
+    ${
+      if !claudeDefaults.includeCoAuthoredBy
+      then ''echo "  includeCoAuthoredBy default = false: OK"''
+      else ''echo "  includeCoAuthoredBy should default to false!"; exit 1''
+    }
+
+    ${
+      if claudeDefaults.extraSettings == {}
+      then ''echo "  extraSettings default = {}: OK"''
+      else ''echo "  extraSettings should default to {}!"; exit 1''
+    }
+
+    ${
+      if claudeDefaults.mcpServers == {}
+      then ''echo "  mcpServers default = {}: OK"''
+      else ''echo "  mcpServers should default to {}!"; exit 1''
+    }
+
+    ${
+      if claudeDefaults.agents == {}
+      then ''echo "  agents default = {}: OK"''
+      else ''echo "  agents should default to {}!"; exit 1''
+    }
+
+    ${
+      if claudeDefaults.commands == {}
+      then ''echo "  commands default = {}: OK"''
+      else ''echo "  commands should default to {}!"; exit 1''
+    }
+
+    ${
+      if claudeDefaults.hooks == {}
+      then ''echo "  hooks default = {}: OK"''
+      else ''echo "  hooks should default to {}!"; exit 1''
+    }
+
+    echo "All Claude Code option defaults verified"
+    touch $out
+  '';
+
+  claudeCodeCustomOptionsTest = pkgs.runCommand "test-claude-code-custom-options" {} ''
+    echo "=== Testing Claude Code Custom Options ==="
+
+    ${
+      if claudeCustom.enable
+      then ''echo "  enable = true: OK"''
+      else ''echo "  enable should be true!"; exit 1''
+    }
+
+    ${
+      if claudeCustom.includeCoAuthoredBy
+      then ''echo "  includeCoAuthoredBy = true: OK"''
+      else ''echo "  includeCoAuthoredBy should be true!"; exit 1''
+    }
+
+    ${
+      if claudeCustom.mcpServers ? test-server
+      then ''echo "  mcpServers.test-server defined: OK"''
+      else ''echo "  mcpServers.test-server should be defined!"; exit 1''
+    }
+
+    ${
+      if claudeCustom.agents ? reviewer
+      then ''echo "  agents.reviewer defined: OK"''
+      else ''echo "  agents.reviewer should be defined!"; exit 1''
+    }
+
+    ${
+      if claudeCustom.commands ? explain
+      then ''echo "  commands.explain defined: OK"''
+      else ''echo "  commands.explain should be defined!"; exit 1''
+    }
+
+    ${
+      if claudeCustom.hooks ? pre-commit
+      then ''echo "  hooks.pre-commit defined: OK"''
+      else ''echo "  hooks.pre-commit should be defined!"; exit 1''
+    }
+
+    echo "All Claude Code custom options verified"
+    touch $out
+  '';
+}

--- a/tests/test-lume.nix
+++ b/tests/test-lume.nix
@@ -1,0 +1,134 @@
+# Lume option tests
+# Validates option defaults and custom values from modules/services/lume/darwin.nix
+{pkgs, ...}: let
+  inherit (pkgs) lib;
+
+  lumeStubs = [
+    ../modules/services/lume/darwin.nix
+    {
+      options.nixpkgs.hostPlatform = lib.mkOption {
+        type = lib.types.anything;
+        default = {inherit (pkgs.stdenv.hostPlatform) system;};
+      };
+      options.myConfig.users = lib.mkOption {
+        type = lib.types.listOf lib.types.anything;
+        default = [];
+      };
+      options.myConfig.isDarwin = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+      };
+      options.environment.systemPackages = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        default = [];
+      };
+      options.launchd.daemons = lib.mkOption {
+        type = lib.types.attrsOf lib.types.anything;
+        default = {};
+      };
+      options.system.activationScripts = lib.mkOption {
+        type = lib.types.attrsOf lib.types.anything;
+        default = {};
+      };
+    }
+    {
+      config._module.args = {inherit pkgs;};
+    }
+  ];
+
+  lumeDefaults =
+    (lib.evalModules {
+      modules = lumeStubs;
+    }).config.myConfig.lume;
+
+  lumeCustom =
+    (lib.evalModules {
+      modules =
+        lumeStubs
+        ++ [
+          {
+            config.myConfig.lume = {
+              enable = true;
+              port = 8888;
+              enableBackgroundService = false;
+              enableAutoUpdater = false;
+              prePullImages = ["macos-tahoe-vanilla:latest"];
+            };
+          }
+        ];
+    }).config.myConfig.lume;
+in {
+  lumeOptionsTest = pkgs.runCommand "test-lume-options" {} ''
+    echo "=== Testing Lume Option Defaults ==="
+
+    ${
+      if !lumeDefaults.enable
+      then ''echo "  enable default = false: OK"''
+      else ''echo "  enable should default to false!"; exit 1''
+    }
+
+    ${
+      if lumeDefaults.port == 7777
+      then ''echo "  port default = 7777: OK"''
+      else ''echo "  port should default to 7777!"; exit 1''
+    }
+
+    ${
+      if lumeDefaults.enableBackgroundService
+      then ''echo "  enableBackgroundService default = true: OK"''
+      else ''echo "  enableBackgroundService should default to true!"; exit 1''
+    }
+
+    ${
+      if lumeDefaults.enableAutoUpdater
+      then ''echo "  enableAutoUpdater default = true: OK"''
+      else ''echo "  enableAutoUpdater should default to true!"; exit 1''
+    }
+
+    ${
+      if lumeDefaults.prePullImages == []
+      then ''echo "  prePullImages default = []: OK"''
+      else ''echo "  prePullImages should default to []!"; exit 1''
+    }
+
+    echo "All Lume option defaults verified"
+    touch $out
+  '';
+
+  lumeCustomOptionsTest = pkgs.runCommand "test-lume-custom-options" {} ''
+    echo "=== Testing Lume Custom Options ==="
+
+    ${
+      if lumeCustom.enable
+      then ''echo "  enable = true: OK"''
+      else ''echo "  enable should be true!"; exit 1''
+    }
+
+    ${
+      if lumeCustom.port == 8888
+      then ''echo "  port = 8888: OK"''
+      else ''echo "  port should be 8888!"; exit 1''
+    }
+
+    ${
+      if !lumeCustom.enableBackgroundService
+      then ''echo "  enableBackgroundService = false: OK"''
+      else ''echo "  enableBackgroundService should be false!"; exit 1''
+    }
+
+    ${
+      if !lumeCustom.enableAutoUpdater
+      then ''echo "  enableAutoUpdater = false: OK"''
+      else ''echo "  enableAutoUpdater should be false!"; exit 1''
+    }
+
+    ${
+      if builtins.elem "macos-tahoe-vanilla:latest" lumeCustom.prePullImages
+      then ''echo "  prePullImages contains macos-tahoe-vanilla:latest: OK"''
+      else ''echo "  prePullImages should contain macos-tahoe-vanilla:latest!"; exit 1''
+    }
+
+    echo "All Lume custom options verified"
+    touch $out
+  '';
+}

--- a/tests/test-pi.nix
+++ b/tests/test-pi.nix
@@ -1,0 +1,222 @@
+# Pi coding agent option tests
+# Validates option defaults and custom values
+{pkgs, ...}: let
+  inherit (pkgs) lib;
+
+  stubModules = [
+    ../modules/common/options.nix
+    {
+      options.nixpkgs.hostPlatform = lib.mkOption {
+        type = lib.types.anything;
+        default = {inherit (pkgs.stdenv.hostPlatform) system;};
+      };
+    }
+    {
+      config._module.args = {inherit pkgs;};
+    }
+  ];
+
+  piDefaults =
+    (lib.evalModules {
+      modules = stubModules;
+    }).config.myConfig.pi;
+
+  piCustom =
+    (lib.evalModules {
+      modules =
+        stubModules
+        ++ [
+          {
+            config.myConfig.pi = {
+              enable = true;
+              settings = {
+                theme = "dark";
+                editor = "helix";
+              };
+              agentsMd = "# Global agent instructions";
+              systemMd = "Custom system prompt";
+              keybindings = {
+                "acceptSuggestion" = "Tab";
+              };
+              models = {
+                "custom-model" = {
+                  name = "Custom";
+                  provider = "ollama";
+                  modelId = "qwen3.5";
+                };
+              };
+              prompts = {
+                "explain" = "Explain this";
+              };
+              skills = {
+                "nix" = "Nix skill content";
+              };
+              extensions = {
+                "my-ext" = "console.log('hello')";
+              };
+              npmPackages = {
+                "pi-web-access" = "^0.10.7";
+              };
+              themes = {
+                "custom" = {
+                  background = "#000000";
+                  foreground = "#ffffff";
+                };
+              };
+            };
+          }
+        ];
+    }).config.myConfig.pi;
+in {
+  piOptionsTest = pkgs.runCommand "test-pi-options" {} ''
+    echo "=== Testing Pi Option Defaults ==="
+
+    ${
+      if !piDefaults.enable
+      then ''echo "  enable default = false: OK"''
+      else ''echo "  enable should default to false!"; exit 1''
+    }
+
+    ${
+      if piDefaults.settings == {}
+      then ''echo "  settings default = {}: OK"''
+      else ''echo "  settings should default to {}!"; exit 1''
+    }
+
+    ${
+      if piDefaults.agentsMd == ""
+      then ''echo "  agentsMd default = empty: OK"''
+      else ''echo "  agentsMd should default to empty!"; exit 1''
+    }
+
+    ${
+      if piDefaults.systemMd == ""
+      then ''echo "  systemMd default = empty: OK"''
+      else ''echo "  systemMd should default to empty!"; exit 1''
+    }
+
+    ${
+      if piDefaults.keybindings == {}
+      then ''echo "  keybindings default = {}: OK"''
+      else ''echo "  keybindings should default to {}!"; exit 1''
+    }
+
+    ${
+      if piDefaults.models == {}
+      then ''echo "  models default = {}: OK"''
+      else ''echo "  models should default to {}!"; exit 1''
+    }
+
+    ${
+      if piDefaults.prompts == {}
+      then ''echo "  prompts default = {}: OK"''
+      else ''echo "  prompts should default to {}!"; exit 1''
+    }
+
+    ${
+      if piDefaults.skills == {}
+      then ''echo "  skills default = {}: OK"''
+      else ''echo "  skills should default to {}!"; exit 1''
+    }
+
+    ${
+      if piDefaults.extensions == {}
+      then ''echo "  extensions default = {}: OK"''
+      else ''echo "  extensions should default to {}!"; exit 1''
+    }
+
+    ${
+      if piDefaults.npmPackages == {}
+      then ''echo "  npmPackages default = {}: OK"''
+      else ''echo "  npmPackages should default to {}!"; exit 1''
+    }
+
+    ${
+      if piDefaults.themes == {}
+      then ''echo "  themes default = {}: OK"''
+      else ''echo "  themes should default to {}!"; exit 1''
+    }
+
+    echo "All Pi option defaults verified"
+    touch $out
+  '';
+
+  piCustomOptionsTest = pkgs.runCommand "test-pi-custom-options" {} ''
+    echo "=== Testing Pi Custom Options ==="
+
+    ${
+      if piCustom.enable
+      then ''echo "  enable = true: OK"''
+      else ''echo "  enable should be true!"; exit 1''
+    }
+
+    ${
+      if piCustom.settings.theme == "dark"
+      then ''echo "  settings.theme = dark: OK"''
+      else ''echo "  settings.theme should be dark!"; exit 1''
+    }
+
+    ${
+      if piCustom.settings.editor == "helix"
+      then ''echo "  settings.editor = helix: OK"''
+      else ''echo "  settings.editor should be helix!"; exit 1''
+    }
+
+    ${
+      if piCustom.agentsMd == "# Global agent instructions"
+      then ''echo "  agentsMd custom value: OK"''
+      else ''echo "  agentsMd should be '# Global agent instructions'!"; exit 1''
+    }
+
+    ${
+      if piCustom.systemMd == "Custom system prompt"
+      then ''echo "  systemMd custom value: OK"''
+      else ''echo "  systemMd should be 'Custom system prompt'!"; exit 1''
+    }
+
+    ${
+      if piCustom.keybindings.acceptSuggestion == "Tab"
+      then ''echo "  keybindings.acceptSuggestion = Tab: OK"''
+      else ''echo "  keybindings.acceptSuggestion should be Tab!"; exit 1''
+    }
+
+    ${
+      if piCustom.models ? custom-model
+      then ''echo "  models.custom-model defined: OK"''
+      else ''echo "  models.custom-model should be defined!"; exit 1''
+    }
+
+    ${
+      if piCustom.prompts ? explain
+      then ''echo "  prompts.explain defined: OK"''
+      else ''echo "  prompts.explain should be defined!"; exit 1''
+    }
+
+    ${
+      if piCustom.skills ? nix
+      then ''echo "  skills.nix defined: OK"''
+      else ''echo "  skills.nix should be defined!"; exit 1''
+    }
+
+    ${
+      if piCustom.extensions ? my-ext
+      then ''echo "  extensions.my-ext defined: OK"''
+      else ''echo "  extensions.my-ext should be defined!"; exit 1''
+    }
+
+    ${
+      if piCustom.npmPackages ? pi-web-access
+      then ''echo "  npmPackages.pi-web-access defined: OK"''
+      else ''echo "  npmPackages.pi-web-access should be defined!"; exit 1''
+    }
+
+    ${
+      if piCustom.themes ? custom
+      then ''echo "  themes.custom defined: OK"''
+      else ''echo "  themes.custom should be defined!"; exit 1''
+    }
+
+    echo "All Pi custom options verified"
+    touch $out
+  '';
+}

--- a/tests/test-searxng.nix
+++ b/tests/test-searxng.nix
@@ -1,0 +1,88 @@
+# SearXNG option tests
+# Validates option defaults and custom values
+{pkgs, ...}: let
+  inherit (pkgs) lib;
+
+  stubModules = [
+    ../modules/common/options.nix
+    {
+      options.nixpkgs.hostPlatform = lib.mkOption {
+        type = lib.types.anything;
+        default = {inherit (pkgs.stdenv.hostPlatform) system;};
+      };
+    }
+    {
+      config._module.args = {inherit pkgs;};
+    }
+  ];
+
+  searxngDefaults =
+    (lib.evalModules {
+      modules = stubModules;
+    }).config.myConfig.searxng;
+
+  searxngCustom =
+    (lib.evalModules {
+      modules =
+        stubModules
+        ++ [
+          {
+            config.myConfig.searxng = {
+              enable = true;
+              port = 9090;
+              secretKey = "my-secret-key";
+            };
+          }
+        ];
+    }).config.myConfig.searxng;
+in {
+  searxngOptionsTest = pkgs.runCommand "test-searxng-options" {} ''
+    echo "=== Testing SearXNG Option Defaults ==="
+
+    ${
+      if !searxngDefaults.enable
+      then ''echo "  enable default = false: OK"''
+      else ''echo "  enable should default to false!"; exit 1''
+    }
+
+    ${
+      if searxngDefaults.port == 8080
+      then ''echo "  port default = 8080: OK"''
+      else ''echo "  port should default to 8080!"; exit 1''
+    }
+
+    ${
+      if searxngDefaults.secretKey == ""
+      then ''echo "  secretKey default = empty: OK"''
+      else ''echo "  secretKey should default to empty!"; exit 1''
+    }
+
+    echo "All SearXNG option defaults verified"
+    touch $out
+  '';
+
+  searxngCustomOptionsTest = pkgs.runCommand "test-searxng-custom-options" {} ''
+    echo "=== Testing SearXNG Custom Options ==="
+
+    ${
+      if searxngCustom.enable
+      then ''echo "  enable = true: OK"''
+      else ''echo "  enable should be true!"; exit 1''
+    }
+
+    ${
+      if searxngCustom.port == 9090
+      then ''echo "  port = 9090: OK"''
+      else ''echo "  port should be 9090!"; exit 1''
+    }
+
+    ${
+      if searxngCustom.secretKey == "my-secret-key"
+      then ''echo "  secretKey = my-secret-key: OK"''
+      else ''echo "  secretKey should be my-secret-key!"; exit 1''
+    }
+
+    echo "All SearXNG custom options verified"
+    touch $out
+  '';
+}


### PR DESCRIPTION
Add option-level tests for modules that currently had no test coverage, preventing regressions in option defaults and structure.

## New tests
- `tests/test-claude-code.nix` — claude-code defaults (enable, includeCoAuthoredBy, mcpServers, agents, commands, hooks)
- `tests/test-pi.nix` — pi defaults (enable, settings, agentsMd, models, prompts, skills, extensions, npmPackages, themes)
- `tests/test-bifrost.nix` — bifrost defaults (enable, port, host, logLevel, appDir, upstreams)
- `tests/test-caddy.nix` — caddy defaults (enable, port, dataDir, hosts)
- `tests/test-searxng.nix` — searxng defaults (enable, port, secretKey)
- `tests/test-lume.nix` — lume defaults (enable, port, enableBackgroundService, enableAutoUpdater, prePullImages)

All wired into `tests/default.nix`.