### PR TITLE
feat: switch MegamanX to Ollama, add pi-plugins integration, and model-stack skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,14 @@ logs
 facter.json
 hardware-configuration.nix
 
+# Python cache
+__pycache__/
+*.pyc
+.pytest_cache/
+
+# Skill runtime caches
+.hw_cache.json
+
 # Yaks working directory (stored in parent git repo's refs/notes/yaks)
 .yaks/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,21 @@ Before marking a task complete:
 - [ ] All existing tests still pass
 - [ ] CI checks pass (`check:lint`, `test`)
 
+### Keeping Tests in Sync with Implementation
+
+When you **remove** a package, option, or feature, the tests that asserted its presence will fail. You MUST update those tests in the same commit — this is not optional.
+
+Common traps:
+
+| Change You Make | Test File to Update | Field to Update |
+|-----------------|---------------------|-----------------|
+| Remove package from role | `tests/test-roles.nix` | `roleExpectedPackages.<role>` |
+| Add package to role | `tests/test-roles.nix` | `roleExpectedPackages.<role>` |
+| Change role cascade | `tests/test-roles.nix` | `roleCascades.<role>` |
+| Remove service option | `tests/test-*.nix` | Any assertion referencing the option |
+
+**Rule:** If `devenv tasks run test` fails after your change, you have not finished. Fix the tests before pushing.
+
 ### Adding Features
 
 | Feature | Steps |

--- a/docs/reference/roles.md
+++ b/docs/reference/roles.md
@@ -58,6 +58,8 @@ Entertainment applications.
 
 ### foundation
 
+### foundation-packages
+
 ### gaming
 
 Gaming tools.
@@ -70,7 +72,7 @@ Gaming tools.
 
 Local model hosting.
 
-**Packages:** vllm-mlx (installed via uv)
+**Packages:** ollama
 
 ### microvm-host
 

--- a/flake.lock
+++ b/flake.lock
@@ -1631,11 +1631,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
         "type": "github"
       },
       "original": {
@@ -1663,6 +1663,22 @@
       "original": {
         "owner": "brizzbuzz",
         "repo": "opnix",
+        "type": "github"
+      }
+    },
+    "pi-plugins": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782448710,
+        "narHash": "sha256-xIEWRBRgdQLzmoOwROIbOG6mWbLR8xPC/Thelvpf29w=",
+        "owner": "funkymonkeymonk",
+        "repo": "pi-plugins",
+        "rev": "6f3f6e968805445a4e8764752c11188e4f2bcc5c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "funkymonkeymonk",
+        "repo": "pi-plugins",
         "type": "github"
       }
     },
@@ -1787,6 +1803,7 @@
         "nixpkgs": "nixpkgs_9",
         "nixpkgs-stable": "nixpkgs-stable",
         "opnix": "opnix",
+        "pi-plugins": "pi-plugins",
         "superpowers": "superpowers",
         "vercel-skills": "vercel-skills",
         "zellij-pane-tracker": "zellij-pane-tracker"

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,9 @@
 
     # Bifrost AI Gateway - high-performance LLM gateway
     bifrost.url = "github:maximhq/bifrost";
+
+    # Pi plugins - extensions and skills for pi coding agent
+    pi-plugins.url = "github:funkymonkeymonk/pi-plugins";
   };
 
   outputs = {
@@ -371,6 +374,7 @@
           ./modules/services/searxng/darwin.nix
           ./modules/services/caddy/darwin.nix
           ./modules/services/vllm-mlx/darwin.nix
+          ./modules/services/ollama/darwin.nix
           ./os/darwin.nix
           ./modules/home-manager/aerospace.nix
           ./targets/MegamanX

--- a/flake.nix
+++ b/flake.nix
@@ -706,12 +706,6 @@
             foundation-packages
             config-validation
             all-role-tests
-            role-evaluation
-            role-composition
-            role-packages
-            role-cascades
-            llm-host-shared-models
-            no-dead-development-option
             module-coverage
             skills-manifest
             skills-autoload-filtering
@@ -766,7 +760,6 @@
             llm-client-pi
             llm-client-custom-host
             llm-client-no-ai-roles
-            entertainment-nixos
             typed-attrs-options
             stack-integration
             phase5-core-bootstrap

--- a/modules/common/options.nix
+++ b/modules/common/options.nix
@@ -1365,6 +1365,29 @@ with lib; {
           Written to ~/.pi/agent/themes/<name>.json
         '';
       };
+
+      pluginsSource = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          Path to the pi-plugins repository.
+          Set to inputs.pi-plugins for the locked flake version,
+          or an absolute local path (e.g., /home/user/src/pi-plugins) for development.
+          When null, no plugins are copied from an external source.
+        '';
+      };
+
+      plugins = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          List of plugin names to install from pluginsSource.
+          Each name corresponds to a package in packages/<name>/src/index.ts
+          within the pi-plugins repository.
+          The plugin's extension is copied to ~/.pi/agent/extensions/<name>.ts
+          and any matching skill in .pi/skills/<name>/ is copied to ~/.pi/agent/skills/.
+        '';
+      };
     };
 
     microvm = {
@@ -1510,6 +1533,26 @@ with lib; {
         type = types.enum ["DEBUG" "INFO" "WARNING" "ERROR"];
         default = "INFO";
         description = "Server log level.";
+      };
+    };
+
+    ollama = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable Ollama inference server for local LLMs";
+      };
+
+      host = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = "Bind address for Ollama server";
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 11434;
+        description = "Bind port for Ollama server";
       };
     };
 

--- a/modules/home-manager/pi-coding-agent.nix
+++ b/modules/home-manager/pi-coding-agent.nix
@@ -240,12 +240,140 @@ with lib; let
       };
     };
 
+  # pi-plugins external source files
+  # When pluginsSource is set, copy selected extensions and all skills from that repo
+  pluginSourceFiles = let
+    src = cfg.pluginsSource;
+    names = cfg.plugins;
+    hasSource = src != null && names != [];
+    # Build extension file entries from pi-plugins packages/
+    extEntries = lib.concatLists (map (
+        name: let
+          extPath = src + "/packages/${name}/src/index.ts";
+        in
+          lib.optional (builtins.pathExists extPath) {
+            name = ".pi/agent/extensions/${name}.ts";
+            value = {
+              source = extPath;
+            };
+          }
+      )
+      names);
+    # Copy all skills from pi-plugins .pi/skills/ (skills are tightly coupled to extensions)
+    skillsDir = src + "/.pi/skills";
+    skillNames =
+      if builtins.pathExists skillsDir
+      then lib.attrNames (lib.filterAttrs (_: t: t == "directory") (builtins.readDir skillsDir))
+      else [];
+    skillEntries =
+      map (name: {
+        name = ".pi/agent/skills/${name}";
+        value = {
+          source = skillsDir + "/${name}";
+          recursive = true;
+        };
+      })
+      skillNames;
+  in
+    lib.optionalAttrs hasSource (lib.listToAttrs (extEntries ++ skillEntries));
+
+  # Model-stack skill (directory with scripts)
+  modelStackPath = ../../skills/model-stack;
+  modelStackFiles = lib.optionalAttrs (builtins.pathExists modelStackPath) {
+    ".pi/agent/skills/model-stack" = {
+      source = modelStackPath;
+      recursive = true;
+    };
+  };
+
   # All files merged together
-  allFiles = coreFiles // promptFiles // skillFiles // extensionFiles // themeFiles // npmFiles // bifrostDiscoveryFiles;
+  allFiles = coreFiles // promptFiles // skillFiles // extensionFiles // themeFiles // npmFiles // bifrostDiscoveryFiles // pluginSourceFiles // modelStackFiles;
+
+  # pi-dev: run pi with local plugin overrides (no special shell needed)
+  pi-dev-script = pkgs.writeShellScriptBin "pi-dev" ''
+    set -euo pipefail
+
+    PLUGINS_DIR=''${PI_PLUGINS_DIR:-$HOME/src/funkymonkeymonk/pi-plugins}
+    AGENT_DIR=''${PI_DEV_AGENT_DIR:-$HOME/.pi/agent-dev}
+    SYSTEM_AGENT="$HOME/.pi/agent"
+
+    if [[ ! -d "$PLUGINS_DIR" ]]; then
+      echo "Error: PI_PLUGINS_DIR not found: $PLUGINS_DIR"
+      echo "Clone pi-plugins and set PI_PLUGINS_DIR, or run from the repo:"
+      echo "  PI_PLUGINS_DIR=/path/to/pi-plugins pi-dev"
+      exit 1
+    fi
+
+    echo "Merging pi config with plugins from $PLUGINS_DIR"
+    mkdir -p "$AGENT_DIR"
+
+    link_dir() {
+      local src="$1"
+      local dst="$2"
+      mkdir -p "$dst"
+      if [[ -d "$src" ]]; then
+        for item in "$src"/*; do
+          [[ -e "$item" ]] || continue
+          local name=$(basename "$item")
+          [[ -e "$dst/$name" ]] && continue
+          ln -sf "$item" "$dst/$name"
+        done
+      fi
+    }
+
+    # Core config files
+    for f in settings.json models.json keybindings.json SYSTEM.md APPEND_SYSTEM.md; do
+      if [[ -f "$SYSTEM_AGENT/$f" && ! -f "$AGENT_DIR/$f" ]]; then
+        cp "$SYSTEM_AGENT/$f" "$AGENT_DIR/$f"
+      fi
+    done
+
+    # Merge directories
+    for dir in skills prompts themes sessions; do
+      link_dir "$SYSTEM_AGENT/$dir" "$AGENT_DIR/$dir"
+    done
+
+    # Link repo skills
+    if [[ -d "$PLUGINS_DIR/.pi/skills" ]]; then
+      mkdir -p "$AGENT_DIR/skills"
+      for skill in "$PLUGINS_DIR/.pi/skills"/*; do
+        [[ -d "$skill" ]] || continue
+        name=$(basename "$skill")
+        dst="$AGENT_DIR/skills/$name"
+        [[ -e "$dst" ]] && continue
+        ln -sf "$skill" "$dst"
+        echo "  + skill $name"
+      done
+    fi
+
+    # Link repo plugins
+    mkdir -p "$AGENT_DIR/extensions"
+    link_dir "$SYSTEM_AGENT/extensions" "$AGENT_DIR/extensions"
+
+    for ext in "$PLUGINS_DIR"/packages/*/src/index.ts; do
+      [[ -f "$ext" ]] || continue
+      name=$(basename "$(dirname "$(dirname "$ext")")")
+      dst="$AGENT_DIR/extensions/$name"
+      mkdir -p "$dst"
+      ln -sf "$ext" "$dst/index.ts"
+      echo "  + plugin $name"
+    done
+
+    # NPM packages
+    link_dir "$SYSTEM_AGENT/npm" "$AGENT_DIR/npm"
+    link_dir "$SYSTEM_AGENT/git" "$AGENT_DIR/git"
+
+    echo "Launching pi with merged config: $AGENT_DIR"
+    export PI_CODING_AGENT_DIR="$AGENT_DIR"
+    exec pi "$@"
+  '';
 in {
   config = mkIf cfg.enable {
     # All pi configuration files
     home.file = allFiles;
+
+    # pi-dev script for testing local plugin changes
+    home.packages = [pi-dev-script] ++ lib.optional (cfg.npmPackages != {}) pkgs.nodejs;
 
     # Run npm install when npm packages change
     home.activation.piNpmInstall = mkIf (cfg.npmPackages != {}) (lib.hm.dag.entryAfter ["writeBoundary"] ''
@@ -259,9 +387,6 @@ in {
         $DRY_RUN_CMD echo "$current_target" > "$stamp_file"
       fi
     '');
-
-    # Ensure nodejs is available for npm install
-    home.packages = mkIf (cfg.npmPackages != {}) [pkgs.nodejs];
 
     # Configure opnix secrets for models with 1Password items
     programs.onepassword-secrets = mkIf (modelsWithSecrets != {} && osConfig.myConfig.onepassword.enable) {

--- a/modules/roles/desktop.nix
+++ b/modules/roles/desktop.nix
@@ -13,7 +13,7 @@ in {
     lib.mkMerge ([
         {
           environment.systemPackages = with pkgs; [
-            logseq
+            # logseq removed: Build hangs for hours on electron-forge from source.
             # super-productivity disabled: Electron 41 kqueue assertion crash on macOS.
             # during electron-builder. Existing installed version (18.5.0) works fine.
             # Tracked: libuv kqueue.c:279 errno == EINTR

--- a/modules/roles/pi.nix
+++ b/modules/roles/pi.nix
@@ -3,6 +3,7 @@
   config,
   lib,
   pkgs,
+  inputs,
   ...
 }: let
   cfg = config.myConfig.roles.pi;
@@ -20,6 +21,12 @@ in {
 
     # Enable pi configuration management via home-manager
     myConfig.pi.enable = true;
+
+    # Install pi-plugins from the locked flake input.
+    # Override in your target to use a local checkout during development:
+    #   myConfig.pi.pluginsSource = /home/you/src/pi-plugins;
+    myConfig.pi.pluginsSource = lib.mkDefault inputs.pi-plugins.outPath;
+    myConfig.pi.plugins = lib.mkDefault ["pi-plugin-yaks"];
 
     # Use mkDefault so opencode wins if both are enabled
     myConfig.llmClient = {

--- a/modules/services/ollama/darwin.nix
+++ b/modules/services/ollama/darwin.nix
@@ -1,0 +1,52 @@
+# Ollama service module for Darwin (macOS)
+#
+# Uses launchd to manage Ollama as a system daemon.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.myConfig.ollama;
+
+  primaryUser =
+    if config.myConfig.users != []
+    then (builtins.head config.myConfig.users).name
+    else "monkey";
+
+  darwinHomeDir = "/Users/${primaryUser}";
+in {
+  config = mkIf cfg.enable {
+    environment.systemPackages = [pkgs.ollama];
+
+    launchd.daemons.ollama = {
+      command = "${pkgs.ollama}/bin/ollama serve";
+      serviceConfig = {
+        Label = "org.ollama.server";
+        RunAtLoad = true;
+        KeepAlive = true;
+        StandardOutPath = "/tmp/ollama.log";
+        StandardErrorPath = "/tmp/ollama.err";
+        UserName = primaryUser;
+        EnvironmentVariables = {
+          HOME = darwinHomeDir;
+          OLLAMA_HOST = "${cfg.host}:${toString cfg.port}";
+        };
+      };
+    };
+
+    system.activationScripts.postActivation.text = mkAfter ''
+      mkdir -p "${darwinHomeDir}/.ollama"
+    '';
+
+    myConfig.serviceRegistry = optionalAttrs cfg.enable {
+      ollama = {
+        name = "Ollama";
+        port = cfg.port;
+        launchdLabel = "org.ollama.server";
+        errorLog = "/tmp/ollama.err";
+      };
+    };
+  };
+}

--- a/skills/model-stack/SKILL.md
+++ b/skills/model-stack/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: model-stack
+description: >
+  Research and recommend the best local LLM model stack for the current machine.
+  Detects hardware (CPU, GPU, RAM, VRAM), discovers installed hosting stacks
+  (Ollama, llama.cpp, vLLM, etc.), searches Hugging Face for compatible models,
+  and enables easy downloads. Use when the user wants to find, evaluate, or
+  download local AI models that will run well on their system.
+---
+
+# Model Stack Research Skill
+
+Research the best local LLM models and hosting stack for the current machine.
+
+## Overview
+
+This skill detects the local hardware, checks which model hosting stacks are
+installed, queries Hugging Face for models, and recommends compatible downloads
+with the right quantization for the available resources.
+
+## Setup
+
+The skill includes a Python virtual environment for its dependencies. Set it up
+once:
+
+```bash
+cd .pi/skills/model-stack
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+```
+
+Or if you have `uv`:
+
+```bash
+cd .pi/skills/model-stack
+uv venv
+uv pip install -r requirements.txt
+```
+
+## Commands
+
+All commands can be run via the wrapper (`scripts/run`) which automatically
+uses the skill's venv, or directly with `.venv/bin/python`.
+
+### Detect Hardware and Stacks
+
+```bash
+./scripts/run scripts/detect.py
+```
+
+Shows:
+- CPU cores, architecture
+- System RAM
+- GPU(s) with VRAM
+- Installed hosting stacks and versions
+
+### Search Hugging Face for Compatible Models
+
+```bash
+./scripts/run scripts/search.py "<query>" [--limit N] [--sort downloads|trending|likes]
+```
+
+Examples:
+
+```bash
+./scripts/run scripts/search.py "qwen2.5 coder" --limit 20
+./scripts/run scripts/search.py "llama" --sort downloads
+./scripts/run scripts/search.py "small vision" --limit 10
+```
+
+The output includes a compatibility score for each model based on detected
+hardware and available VRAM/RAM.
+
+### Show Model Details and Compatibility
+
+```bash
+./scripts/run scripts/search.py --model "<owner/repo>"
+```
+
+Shows detailed info for a specific model including estimated memory usage
+for each available quantization and whether it will fit.
+
+### Download a Model via Detected Stack
+
+```bash
+./scripts/run scripts/download.py "<model>"
+```
+
+Downloads using the best available stack:
+1. **Ollama**: `ollama pull <model>` (if Ollama is installed)
+2. **Hugging Face CLI**: `huggingface-cli download <repo>` (for GGUF/raw)
+3. **Git LFS**: fallback for HF repos
+
+If multiple stacks are available, it prefers the one that matches the model
+format (Ollama for Ollama models, HF CLI for GGUF/safetensors).
+
+### Full Workflow
+
+```bash
+# 1. See what you have
+./scripts/run scripts/detect.py
+
+# 2. Find models that fit
+./scripts/run scripts/search.py "llama 3.2" --limit 10
+
+# 3. Check if a specific model fits
+./scripts/run scripts/search.py --model "unsloth/Llama-3.2-1B-Instruct-GGUF"
+
+# 4. Download the best match
+./scripts/run scripts/download.py "llama3.2"
+```
+
+## How Compatibility Works
+
+- **VRAM Check**: For unquantized models, the tool estimates memory at Q4_K_M
+  as a baseline and finds the best quantization that fits. It caps
+  recommendations at Q8_0 to avoid wasting memory on F16/F32 for inference.
+- **RAM Check**: If no GPU is detected, models run on CPU and estimates use
+  system RAM instead.
+- **Pre-quantized Models**: AWQ, GPTQ, GGUF, and EXL2 models are detected from
+  tags and their actual compressed sizes are used instead of estimating a new
+  quantization.
+- **Score**: Combines fit (will it run?), quality (quantization level), speed
+  (GPU tier), and community popularity.
+
+## Notes
+
+- GPU detection works for NVIDIA (nvidia-smi), Apple Silicon (sysctl), AMD
+  (rocm-smi), and Intel Arc (experimental).
+- If no GPU is detected, recommendations favor smaller, CPU-optimized models.
+- Hugging Face search uses the public Hub API; no token is required for
+  searching, but downloading gated models may need `HF_TOKEN`.
+- Hardware info is cached in `scripts/.hw_cache.json` to avoid re-detecting
+  on every search.

--- a/skills/model-stack/requirements.txt
+++ b/skills/model-stack/requirements.txt
@@ -1,0 +1,2 @@
+huggingface_hub>=0.25.0
+psutil>=5.9.0

--- a/skills/model-stack/scripts/compat.py
+++ b/skills/model-stack/scripts/compat.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Compatibility calculations for LLM models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+# Rough bytes per parameter for common quantization formats
+# These are empirical averages; actual sizes vary by model architecture
+QUANT_SIZES = {
+    "Q2_K": 0.29,
+    "Q3_K_S": 0.33,
+    "Q3_K_M": 0.37,
+    "Q3_K_L": 0.41,
+    "Q4_K_S": 0.44,
+    "Q4_K_M": 0.50,
+    "Q4_0": 0.50,
+    "Q5_K_S": 0.55,
+    "Q5_K_M": 0.61,
+    "Q5_0": 0.61,
+    "Q6_K": 0.71,
+    "Q8_0": 0.95,
+    "F16": 2.0,
+    "FP16": 2.0,
+    "BF16": 2.0,
+    "F32": 4.0,
+    "FP32": 4.0,
+}
+
+# Quality score (higher = better) - rough mapping
+QUANT_QUALITY = {
+    "Q2_K": 40,
+    "Q3_K_S": 50,
+    "Q3_K_M": 55,
+    "Q3_K_L": 60,
+    "Q4_K_S": 65,
+    "Q4_K_M": 72,
+    "Q4_0": 70,
+    "Q5_K_S": 75,
+    "Q5_K_M": 82,
+    "Q5_0": 80,
+    "Q6_K": 88,
+    "Q8_0": 95,
+    "F16": 98,
+    "FP16": 98,
+    "BF16": 98,
+    "F32": 100,
+    "FP32": 100,
+}
+
+# Default to use when no quantization specified
+DEFAULT_QUANT = "Q4_K_M"
+
+
+def parse_param_count(tags: list[str], model_id: str) -> float | None:
+    """Extract parameter count in billions from tags or model ID."""
+    # Check tags first
+    for tag in tags:
+        tag_lower = tag.lower()
+        # Match patterns like "7b", "13B", "70b", "8x7b", "1.5b"
+        match = __import__("re").match(r"^(\d+(?:\.\d+)?)b$", tag_lower)
+        if match:
+            return float(match.group(1))
+        match = __import__("re").match(r"^(\d+)x(\d+(?:\.\d+)?)b$", tag_lower)
+        if match:
+            # MoE like 8x7b
+            return float(match.group(1)) * float(match.group(2))
+
+    # Check model ID
+    id_lower = model_id.lower()
+    patterns = [
+        r"-(\d+(?:\.\d+)?)b-",
+        r"-(\d+(?:\.\d+)?)b$",
+        r"_(\d+(?:\.\d+)?)b_",
+        r"_(\d+(?:\.\d+)?)b$",
+    ]
+    for pat in patterns:
+        match = __import__("re").search(pat, id_lower)
+        if match:
+            return float(match.group(1))
+
+    return None
+
+
+# Pre-quantized format memory multipliers (already compressed)
+PRE_QUANT_MULTIPLIERS = {
+    "awq": 0.55,
+    "gptq": 0.55,
+    "gguf": 0.50,
+    "exl2": 0.45,
+    "bnb": 0.50,
+}
+
+
+def detect_prequantized(tags: list[str]) -> str | None:
+    """Detect if a model is already quantized (AWQ, GPTQ, etc.)."""
+    tag_set = {t.lower() for t in tags}
+    for fmt in PRE_QUANT_MULTIPLIERS:
+        if fmt in tag_set:
+            return fmt
+    return None
+
+
+def estimate_memory_for_model(params_b: float | None, tags: list[str]) -> float | None:
+    """Estimate memory usage considering pre-quantized formats."""
+    if params_b is None:
+        return None
+
+    prequant = detect_prequantized(tags)
+    if prequant:
+        multiplier = PRE_QUANT_MULTIPLIERS[prequant]
+        return params_b * multiplier * 1.2
+
+    # Default to Q4_K_M for unquantized model recommendations
+    return estimate_memory_gb(params_b, DEFAULT_QUANT)
+
+
+def estimate_memory_gb(params_b: float, quant: str = DEFAULT_QUANT) -> float:
+    """Estimate memory usage in GB for a model at a given quantization."""
+    multiplier = QUANT_SIZES.get(quant.upper(), QUANT_SIZES[DEFAULT_QUANT])
+    # Add overhead for KV cache, context, etc. (~20%)
+    return params_b * multiplier * 1.2
+
+
+def get_best_quantization(
+    params_b: float,
+    vram_gb: float,
+    ram_gb: float,
+    gpu_backend: str | None = None,
+    max_utilization: float = 0.5,
+    ceiling: str = "Q8_0",
+) -> tuple[str, float] | None:
+    """Find the best quantization that fits available memory.
+
+    Args:
+        max_utilization: Prefer using no more than this fraction of available
+            memory for the base weights. This leaves headroom for KV cache,
+            context, and system use. Set to 1.0 to use all available memory.
+        ceiling: Maximum quantization quality to recommend. F16/F32 are rarely
+            needed for inference and waste memory. Default is Q8_0.
+    """
+    # If we have a GPU, prefer VRAM. Otherwise use RAM.
+    available = vram_gb if vram_gb > 0 else ram_gb
+    if available <= 0:
+        return None
+
+    ceiling_quality = QUANT_QUALITY.get(ceiling, 100)
+
+    # Sort by quality descending
+    quants = sorted(QUANT_SIZES.keys(), key=lambda q: QUANT_QUALITY.get(q, 0), reverse=True)
+
+    best = None
+    for quant in quants:
+        quality = QUANT_QUALITY.get(quant, 0)
+        if quality > ceiling_quality:
+            continue
+        mem = estimate_memory_gb(params_b, quant)
+        if mem <= available:
+            if best is None:
+                best = (quant, mem)
+            # Prefer this quant if it uses less than max_utilization
+            if mem <= available * max_utilization:
+                return quant, mem
+
+    return best
+
+
+def score_model(
+    params_b: float,
+    quant: str,
+    mem_gb: float,
+    vram_gb: float,
+    ram_gb: float,
+    gpu_backend: str | None,
+    downloads: int = 0,
+    likes: int = 0,
+) -> dict[str, Any]:
+    """Score a model configuration. Returns score breakdown."""
+    available = vram_gb if vram_gb > 0 else ram_gb
+
+    # Fit score: how well it uses available memory (0-100)
+    if available > 0:
+        utilization = mem_gb / available
+        if utilization > 1.0:
+            fit = 0  # Won't fit
+        elif utilization < 0.3:
+            fit = 60  # Wastes a lot of memory
+        elif utilization < 0.6:
+            fit = 85
+        elif utilization < 0.85:
+            fit = 100
+        else:
+            fit = 90  # Cutting it close
+    else:
+        fit = 50
+
+    # Quality score from quantization
+    quality = QUANT_QUALITY.get(quant.upper(), 50)
+
+    # Speed score: GPU is much faster
+    speed = 20 if not gpu_backend else (100 if gpu_backend in ("cuda", "mps") else 70)
+
+    # Popularity score (log scale)
+    pop = min(100, 20 + (downloads / 100000) * 10 + (likes / 1000) * 5)
+
+    # Weighted composite
+    composite = int(
+        fit * 0.30 + quality * 0.30 + speed * 0.20 + pop * 0.20
+    )
+
+    return {
+        "fit": int(fit),
+        "quality": int(quality),
+        "speed": int(speed),
+        "popularity": int(pop),
+        "composite": composite,
+        "fits": fit > 0,
+        "estimated_memory_gb": round(mem_gb, 2),
+        "quantization": quant,
+    }
+
+
+def format_size(gb: float) -> str:
+    """Format gigabytes nicely."""
+    if gb >= 1000:
+        return f"{gb / 1024:.1f} TB"
+    return f"{gb:.1f} GB"
+
+
+def main() -> None:
+    """CLI for testing compatibility calculations."""
+    import sys
+    if len(sys.argv) < 3:
+        print("Usage: compat.py <params_b> <vram_gb> [ram_gb]")
+        print("Example: compat.py 7 8 16")
+        sys.exit(1)
+
+    params = float(sys.argv[1])
+    vram = float(sys.argv[2])
+    ram = float(sys.argv[3]) if len(sys.argv) > 3 else 0.0
+
+    result = get_best_quantization(params, vram, ram)
+    if result:
+        quant, mem = result
+        print(f"Best quant for {params}B model with {vram}GB VRAM: {quant} ({mem:.1f} GB)")
+        score = score_model(params, quant, mem, vram, ram, "cuda" if vram > 0 else None)
+        print(f"Score: {score['composite']} (fit={score['fit']}, quality={score['quality']}, speed={score['speed']})")
+    else:
+        print("Model does not fit in available memory.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/model-stack/scripts/detect.py
+++ b/skills/model-stack/scripts/detect.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Detect system hardware and installed model hosting stacks."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass
+class HardwareInfo:
+    os_name: str = ""
+    os_version: str = ""
+    cpu_name: str = ""
+    cpu_cores_physical: int = 0
+    cpu_cores_logical: int = 0
+    cpu_arch: str = ""
+    ram_gb: float = 0.0
+    gpus: list[GPUInfo] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class GPUInfo:
+    name: str = ""
+    vram_gb: float = 0.0
+    driver: str = ""
+    backend: str = ""  # cuda, rocm, mps, openvino, etc.
+
+
+@dataclass
+class StackInfo:
+    name: str = ""
+    version: str = ""
+    path: str = ""
+
+
+def run(cmd: list[str] | str, timeout: int = 10) -> str:
+    """Run a shell command and return stdout."""
+    try:
+        if isinstance(cmd, str):
+            result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=timeout)
+        else:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return result.stdout.strip()
+    except Exception:
+        return ""
+
+
+def detect_os() -> tuple[str, str]:
+    """Detect OS name and version."""
+    system = platform.system()
+    if system == "Darwin":
+        version = run(["sw_vers", "-productVersion"])
+        return "macOS", version or ""
+    if system == "Linux":
+        # Try /etc/os-release first
+        if os.path.exists("/etc/os-release"):
+            with open("/etc/os-release") as f:
+                data = f.read()
+            name_match = re.search(r'PRETTY_NAME="([^"]*)"', data)
+            name = name_match.group(1) if name_match else platform.linux_distribution()[0] if hasattr(platform, "linux_distribution") else "Linux"
+            return name, ""
+        return "Linux", ""
+    if system == "Windows":
+        return "Windows", platform.version()
+    return system, ""
+
+
+def detect_cpu() -> tuple[str, int, int, str]:
+    """Detect CPU name, physical cores, logical cores, architecture."""
+    cpu_name = ""
+    physical = os.cpu_count() or 0
+    logical = physical
+    arch = platform.machine()
+
+    system = platform.system()
+    if system == "Darwin":
+        cpu_name = run(["sysctl", "-n", "machdep.cpu.brand_string"])
+        physical = int(run(["sysctl", "-n", "hw.physicalcpu"]) or logical)
+        logical = int(run(["sysctl", "-n", "hw.logicalcpu"]) or physical)
+    elif system == "Linux":
+        lscpu = run(["lscpu"])
+        if lscpu:
+            model_match = re.search(r"Model name:\s*(.+)", lscpu)
+            if model_match:
+                cpu_name = model_match.group(1).strip()
+            core_match = re.search(r"Core\(s\) per socket:\s*(\d+)", lscpu)
+            socket_match = re.search(r"Socket\(s\):\s*(\d+)", lscpu)
+            if core_match and socket_match:
+                physical = int(core_match.group(1)) * int(socket_match.group(1))
+        # Fallback to /proc/cpuinfo
+        if not cpu_name and os.path.exists("/proc/cpuinfo"):
+            with open("/proc/cpuinfo") as f:
+                for line in f:
+                    if line.startswith("model name"):
+                        cpu_name = line.split(":", 1)[1].strip()
+                        break
+    elif system == "Windows":
+        cpu_name = run(["wmic", "cpu", "get", "Name", "/value"])
+        cpu_name = cpu_name.replace("Name=", "").strip() if "Name=" in cpu_name else cpu_name
+
+    if not cpu_name:
+        cpu_name = platform.processor() or "Unknown"
+
+    return cpu_name, physical, logical, arch
+
+
+def detect_ram() -> float:
+    """Detect total RAM in GB."""
+    try:
+        import psutil
+        return psutil.virtual_memory().total / (1024 ** 3)
+    except ImportError:
+        pass
+
+    system = platform.system()
+    if system == "Darwin":
+        mem = run(["sysctl", "-n", "hw.memsize"])
+        if mem:
+            return int(mem) / (1024 ** 3)
+    elif system == "Linux":
+        if os.path.exists("/proc/meminfo"):
+            with open("/proc/meminfo") as f:
+                for line in f:
+                    if line.startswith("MemTotal:"):
+                        kb = int(line.split()[1])
+                        return kb / (1024 ** 2)
+    elif system == "Windows":
+        mem = run(["wmic", "computersystem", "get", "TotalPhysicalMemory", "/value"])
+        match = re.search(r"TotalPhysicalMemory=(\d+)", mem)
+        if match:
+            return int(match.group(1)) / (1024 ** 3)
+
+    return 0.0
+
+
+def detect_nvidia_gpus() -> list[GPUInfo]:
+    """Detect NVIDIA GPUs using nvidia-smi."""
+    gpus = []
+    smi = run(["nvidia-smi", "--query-gpu=name,memory.total,driver_version", "--format=csv,noheader"])
+    if not smi:
+        return gpus
+    for line in smi.split("\n"):
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) >= 3:
+            name = parts[0]
+            mem_str = parts[1]
+            driver = parts[2]
+            # Parse memory (usually "8192 MiB" or "8.00 GiB")
+            mem_mb = 0
+            match = re.search(r"([\d.]+)\s*(MiB|GiB|MB|GB)", mem_str)
+            if match:
+                val = float(match.group(1))
+                unit = match.group(2)
+                if unit in ("GiB", "GB"):
+                    mem_mb = val * 1024
+                else:
+                    mem_mb = val
+            gpus.append(GPUInfo(name=name, vram_gb=mem_mb / 1024, driver=driver, backend="cuda"))
+    return gpus
+
+
+def detect_apple_gpus() -> list[GPUInfo]:
+    """Detect Apple Silicon GPUs."""
+    gpus = []
+    if platform.system() != "Darwin":
+        return gpus
+    # Check if Apple Silicon
+    arch = platform.machine()
+    if arch not in ("arm64", "aarch64"):
+        return gpus
+
+    # Unified memory on Apple Silicon
+    mem = run(["sysctl", "-n", "hw.memsize"])
+    vram_gb = int(mem) / (1024 ** 3) if mem else 0.0
+
+    # GPU name from system_profiler
+    profiler = run(["system_profiler", "SPDisplaysDataType"])
+    name = "Apple Silicon GPU"
+    match = re.search(r"Chipset Model: (.+)", profiler)
+    if match:
+        name = match.group(1).strip()
+
+    gpus.append(GPUInfo(name=name, vram_gb=vram_gb, driver="Metal", backend="mps"))
+    return gpus
+
+
+def detect_amd_gpus() -> list[GPUInfo]:
+    """Detect AMD GPUs using rocm-smi."""
+    gpus = []
+    rocm = run(["rocm-smi", "--showproductname", "--showmeminfo", "vram"])
+    if not rocm:
+        return gpus
+    # Simple parsing - rocm-smi output varies by version
+    lines = rocm.split("\n")
+    for line in lines:
+        if "GPU" in line and ("MiB" in line or "GB" in line):
+            parts = line.split()
+            name = "AMD GPU"
+            vram_gb = 0.0
+            for i, part in enumerate(parts):
+                if "MiB" in part:
+                    try:
+                        vram_gb = float(parts[i - 1]) / 1024
+                    except (ValueError, IndexError):
+                        pass
+                elif "GB" in part:
+                    try:
+                        vram_gb = float(parts[i - 1])
+                    except (ValueError, IndexError):
+                        pass
+            gpus.append(GPUInfo(name=name, vram_gb=vram_gb, driver="ROCm", backend="rocm"))
+    return gpus
+
+
+def detect_gpus() -> list[GPUInfo]:
+    """Detect all GPUs."""
+    all_gpus = []
+    all_gpus.extend(detect_nvidia_gpus())
+    all_gpus.extend(detect_apple_gpus())
+    all_gpus.extend(detect_amd_gpus())
+    return all_gpus
+
+
+def detect_stacks() -> list[StackInfo]:
+    """Detect installed model hosting stacks."""
+    stacks = []
+
+    checks = [
+        ("ollama", ["ollama", "--version"]),
+        ("vllm", ["python3", "-c", "import vllm; print(vllm.__version__)"]),
+        ("llama.cpp", ["llama-server", "--version"]),
+        ("llama.cpp", ["llama-cli", "--version"]),
+        ("lm-studio", ["lm-studio", "--version"]),
+        ("text-generation-inference", ["text-generation-launcher", "--version"]),
+        ("ollama", ["docker", "ps", "--filter", "name=ollama", "--format", "{{.Names}}"]),
+    ]
+
+    for name, cmd in checks:
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+            if result.returncode == 0:
+                version = result.stdout.strip().split("\n")[0][:50]
+                path = shutil.which(cmd[0]) or "docker"
+                stacks.append(StackInfo(name=name, version=version, path=path))
+        except Exception:
+            pass
+
+    # Deduplicate by name
+    seen = set()
+    unique = []
+    for s in stacks:
+        if s.name not in seen:
+            seen.add(s.name)
+            unique.append(s)
+    return unique
+
+
+def main() -> None:
+    hw = HardwareInfo()
+    hw.os_name, hw.os_version = detect_os()
+    hw.cpu_name, hw.cpu_cores_physical, hw.cpu_cores_logical, hw.cpu_arch = detect_cpu()
+    hw.ram_gb = detect_ram()
+    hw.gpus = detect_gpus()
+
+    stacks = detect_stacks()
+
+    print("=" * 60)
+    print("🖥️  System Hardware")
+    print("=" * 60)
+    print(f"OS:        {hw.os_name} {hw.os_version}".strip())
+    print(f"CPU:       {hw.cpu_name}")
+    print(f"Cores:     {hw.cpu_cores_physical} physical / {hw.cpu_cores_logical} logical")
+    print(f"Arch:      {hw.cpu_arch}")
+    print(f"RAM:       {hw.ram_gb:.1f} GB")
+
+    if hw.gpus:
+        print(f"\n🎮 GPUs ({len(hw.gpus)} detected):")
+        for i, gpu in enumerate(hw.gpus, 1):
+            print(f"  [{i}] {gpu.name}")
+            print(f"      VRAM:   {gpu.vram_gb:.1f} GB")
+            print(f"      Driver: {gpu.driver}")
+            print(f"      Backend: {gpu.backend}")
+    else:
+        print("\n🎮 GPUs:    None detected (CPU-only inference)")
+
+    print()
+    print("=" * 60)
+    print("📦 Installed Model Hosting Stacks")
+    print("=" * 60)
+    if stacks:
+        for s in stacks:
+            print(f"  • {s.name:20s} {s.version}")
+    else:
+        print("  None detected. Common stacks:")
+        print("    • ollama        - https://ollama.com")
+        print("    • llama.cpp     - https://github.com/ggml-org/llama.cpp")
+        print("    • vLLM          - https://github.com/vllm-project/vllm")
+        print("    • LM Studio     - https://lmstudio.ai")
+
+    print()
+
+    # Also output JSON for other scripts to consume
+    output = {
+        "hardware": hw.to_dict(),
+        "stacks": [{"name": s.name, "version": s.version, "path": s.path} for s in stacks],
+    }
+    print("--- JSON ---")
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/model-stack/scripts/download.py
+++ b/skills/model-stack/scripts/download.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Download a model using the best available hosting stack."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+
+def load_hw_info() -> dict[str, Any] | None:
+    """Load hardware and stack info."""
+    cache_path = os.path.join(_SCRIPT_DIR, ".hw_cache.json")
+    if os.path.exists(cache_path):
+        with open(cache_path) as f:
+            return json.load(f)
+
+    try:
+        result = subprocess.run(
+            [sys.executable, os.path.join(_SCRIPT_DIR, "detect.py")],
+            capture_output=True, text=True, timeout=30
+        )
+        lines = result.stdout.split("\n")
+        json_start = None
+        for i, line in enumerate(lines):
+            if line.strip() == "--- JSON ---":
+                json_start = i + 1
+                break
+        if json_start is not None:
+            data = json.loads("\n".join(lines[json_start:]))
+            with open(cache_path, "w") as f:
+                json.dump(data, f)
+            return data
+    except Exception:
+        pass
+    return None
+
+
+def has_stack(stacks: list[dict], name: str) -> bool:
+    return any(s["name"] == name for s in stacks)
+
+
+def ollama_pull(model: str) -> bool:
+    """Download via Ollama."""
+    ollama = shutil.which("ollama")
+    if not ollama:
+        return False
+
+    print(f"🦙 Downloading '{model}' via Ollama...")
+    try:
+        result = subprocess.run(
+            [ollama, "pull", model],
+            check=False,
+        )
+        return result.returncode == 0
+    except Exception as e:
+        print(f"Error: {e}")
+        return False
+
+
+def hf_download(repo_id: str, local_dir: str | None = None) -> bool:
+    """Download via huggingface-cli."""
+    hf_cli = shutil.which("huggingface-cli")
+    if not hf_cli:
+        # Try to use Python API
+        try:
+            from huggingface_hub import snapshot_download
+            print(f"🤗 Downloading '{repo_id}' via huggingface_hub...")
+            path = snapshot_download(repo_id, local_dir=local_dir)
+            print(f"Downloaded to: {path}")
+            return True
+        except ImportError:
+            print("huggingface_hub not installed. Run: python3 -m pip install huggingface_hub")
+            return False
+        except Exception as e:
+            print(f"Error: {e}")
+            return False
+
+    cmd = [hf_cli, "download", repo_id]
+    if local_dir:
+        cmd.extend(["--local-dir", local_dir])
+    print(f"🤗 Downloading '{repo_id}' via huggingface-cli...")
+    try:
+        result = subprocess.run(cmd, check=False)
+        return result.returncode == 0
+    except Exception as e:
+        print(f"Error: {e}")
+        return False
+
+
+def git_lfs_clone(repo_id: str) -> bool:
+    """Fallback: clone with git-lfs."""
+    git = shutil.which("git")
+    if not git:
+        return False
+
+    url = f"https://huggingface.co/{repo_id}"
+    target = repo_id.replace("/", "--")
+    print(f"📦 Cloning '{repo_id}' with git...")
+    try:
+        result = subprocess.run(
+            [git, "clone", url, target],
+            check=False,
+        )
+        return result.returncode == 0
+    except Exception as e:
+        print(f"Error: {e}")
+        return False
+
+
+def detect_model_format(repo_id: str) -> str:
+    """Try to detect if this is an Ollama-style model name or HF repo."""
+    # Ollama models are typically simple names like "llama3.2", "qwen2.5-coder"
+    # HF repos are "owner/name" with a slash
+    if "/" not in repo_id and " " not in repo_id:
+        return "ollama"
+    return "hf"
+
+
+def download(model: str, stack_preference: str | None = None, local_dir: str | None = None) -> bool:
+    """Download a model using the best available stack."""
+    hw = load_hw_info()
+    stacks = hw.get("stacks", []) if hw else []
+
+    fmt = detect_model_format(model)
+
+    # Determine which stack to use
+    if stack_preference:
+        chosen = stack_preference
+    elif fmt == "ollama" and has_stack(stacks, "ollama"):
+        chosen = "ollama"
+    elif has_stack(stacks, "ollama"):
+        chosen = "ollama"
+    elif shutil.which("huggingface-cli") or __import__("importlib.util").find_spec("huggingface_hub"):
+        chosen = "hf"
+    else:
+        chosen = "git"
+
+    print(f"Using stack: {chosen}")
+    print()
+
+    if chosen == "ollama":
+        return ollama_pull(model)
+    elif chosen == "hf":
+        return hf_download(model, local_dir)
+    elif chosen == "git":
+        return git_lfs_clone(model)
+    else:
+        print(f"Unknown stack: {chosen}")
+        return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download a model via the best available stack")
+    parser.add_argument("model", help="Model name or Hugging Face repo ID")
+    parser.add_argument("--stack", choices=["ollama", "hf", "git"],
+                        help="Force a specific download method")
+    parser.add_argument("--local-dir", help="Local directory for HF downloads")
+    args = parser.parse_args()
+
+    success = download(args.model, args.stack, args.local_dir)
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/model-stack/scripts/run
+++ b/skills/model-stack/scripts/run
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Wrapper to run Python scripts with the skill's venv if available
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_PYTHON="$SCRIPT_DIR/../.venv/bin/python"
+
+if [[ -x "$VENV_PYTHON" ]]; then
+    exec "$VENV_PYTHON" "$@"
+else
+    exec python3 "$@"
+fi

--- a/skills/model-stack/scripts/search.py
+++ b/skills/model-stack/scripts/search.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Search Hugging Face for compatible LLM models."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+# Add script dir to path for compat imports
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+import compat
+
+
+def load_hw_info() -> dict[str, Any] | None:
+    """Load hardware info from detect.py output."""
+    # Try to find cached detection output
+    cache_path = os.path.join(_SCRIPT_DIR, ".hw_cache.json")
+    if os.path.exists(cache_path):
+        with open(cache_path) as f:
+            return json.load(f)
+
+    # Run detect.py and parse JSON output
+    import subprocess
+    try:
+        result = subprocess.run(
+            [sys.executable, os.path.join(_SCRIPT_DIR, "detect.py")],
+            capture_output=True, text=True, timeout=30
+        )
+        # Find JSON section
+        lines = result.stdout.split("\n")
+        json_start = None
+        for i, line in enumerate(lines):
+            if line.strip() == "--- JSON ---":
+                json_start = i + 1
+                break
+        if json_start is not None:
+            data = json.loads("\n".join(lines[json_start:]))
+            # Cache it
+            with open(cache_path, "w") as f:
+                json.dump(data, f)
+            return data
+    except Exception:
+        pass
+    return None
+
+
+def search_hub(query: str, limit: int = 20, sort: str = "downloads") -> list[dict[str, Any]]:
+    """Search Hugging Face Hub for models."""
+    try:
+        from huggingface_hub import HfApi
+    except ImportError:
+        print("Error: huggingface_hub is not installed.")
+        print("Run: python3 -m pip install huggingface_hub")
+        sys.exit(1)
+
+    api = HfApi()
+
+    # Search for GGUF models and regular models
+    results = []
+    seen = set()
+
+    # First try GGUF-specific search
+    try:
+        for model in api.list_models(
+            search=f"{query} gguf",
+            sort=sort,
+            limit=limit * 2,
+        ):
+            if model.id not in seen:
+                seen.add(model.id)
+                results.append({
+                    "id": model.id,
+                    "tags": list(getattr(model, "tags", []) or []),
+                    "downloads": getattr(model, "downloads", 0) or 0,
+                    "likes": getattr(model, "likes", 0) or 0,
+                    "pipeline_tag": getattr(model, "pipeline_tag", ""),
+                    "library_name": getattr(model, "library_name", ""),
+                })
+    except Exception as e:
+        print(f"Warning: GGUF search failed: {e}")
+
+    # Also search without GGUF tag
+    try:
+        for model in api.list_models(
+            search=query,
+            sort=sort,
+            limit=limit * 2,
+        ):
+            if model.id not in seen and len(seen) < limit * 2:
+                seen.add(model.id)
+                results.append({
+                    "id": model.id,
+                    "tags": list(getattr(model, "tags", []) or []),
+                    "downloads": getattr(model, "downloads", 0) or 0,
+                    "likes": getattr(model, "likes", 0) or 0,
+                    "pipeline_tag": getattr(model, "pipeline_tag", ""),
+                    "library_name": getattr(model, "library_name", ""),
+                })
+    except Exception as e:
+        print(f"Warning: general search failed: {e}")
+
+    return results[:limit]
+
+
+def get_model_info(model_id: str) -> dict[str, Any] | None:
+    """Get detailed info for a specific model."""
+    try:
+        from huggingface_hub import HfApi
+    except ImportError:
+        return None
+
+    api = HfApi()
+    try:
+        info = api.model_info(model_id)
+        return {
+            "id": info.id,
+            "tags": list(getattr(info, "tags", []) or []),
+            "downloads": getattr(info, "downloads", 0) or 0,
+            "likes": getattr(info, "likes", 0) or 0,
+            "pipeline_tag": getattr(info, "pipeline_tag", ""),
+            "library_name": getattr(info, "library_name", ""),
+            "siblings": [s.rfilename for s in getattr(info, "siblings", []) or []],
+        }
+    except Exception:
+        return None
+
+
+def analyze_model(model: dict[str, Any], hw: dict[str, Any] | None) -> dict[str, Any]:
+    """Analyze a model's compatibility with the current hardware."""
+    tags = model.get("tags", [])
+    params = compat.parse_param_count(tags, model["id"])
+
+    if not hw:
+        return {
+            **model,
+            "params_b": params,
+            "compatibility": None,
+        }
+
+    hardware = hw.get("hardware", {})
+    gpus = hardware.get("gpus", []) or []
+    vram = max((g.get("vram_gb", 0) for g in gpus), default=0.0)
+    ram = hardware.get("ram_gb", 0.0)
+    backend = gpus[0].get("backend") if gpus else None
+
+    if params:
+        prequant = compat.detect_prequantized(tags)
+        if prequant:
+            # Already quantized model (AWQ, GPTQ, GGUF)
+            mem = compat.estimate_memory_for_model(params, tags)
+            quant_label = prequant.upper()
+            quality = 70  # Pre-quantized quality estimate
+            fits = mem is not None and mem <= max(vram, ram)
+            score = {
+                "fits": fits,
+                "composite": 75 if fits else 0,
+                "estimated_memory_gb": round(mem, 2) if mem else None,
+                "quantization": quant_label,
+                "fit": 90 if fits else 0,
+                "quality": quality,
+                "speed": 100 if backend in ("cuda", "mps") else 70,
+                "popularity": min(100, 20 + (model.get("downloads", 0) / 100000) * 10),
+            }
+        else:
+            best = compat.get_best_quantization(params, vram, ram, backend)
+            if best:
+                quant, mem = best
+                score = compat.score_model(
+                    params, quant, mem, vram, ram, backend,
+                    downloads=model.get("downloads", 0),
+                    likes=model.get("likes", 0),
+                )
+            else:
+                score = {
+                    "fits": False,
+                    "composite": 0,
+                    "estimated_memory_gb": round(compat.estimate_memory_gb(params), 2),
+                    "quantization": "Q4_K_M",
+                }
+    else:
+        score = None
+
+    return {
+        **model,
+        "params_b": params,
+        "compatibility": score,
+    }
+
+
+def print_results(results: list[dict[str, Any]], hw: dict[str, Any] | None) -> None:
+    """Print search results in a readable format."""
+    if not results:
+        print("No models found.")
+        return
+
+    # Show hardware summary
+    if hw:
+        h = hw.get("hardware", {})
+        gpus = h.get("gpus", []) or []
+        vram = max((g.get("vram_gb", 0) for g in gpus), default=0.0)
+        print(f"📊 Hardware: {h.get('cpu_name', 'Unknown CPU')}, {h.get('ram_gb', 0):.1f}GB RAM", end="")
+        if vram > 0:
+            print(f", {vram:.1f}GB VRAM ({gpus[0].get('backend', 'gpu')})")
+        else:
+            print(" (CPU-only)")
+        print()
+
+    # Header
+    print(f"{'Rank':>4} {'Model':<45} {'Params':>8} {'Mem':>8} {'Score':>5} {'Fits':>5}")
+    print("-" * 80)
+
+    # Sort by composite score descending
+    scored = [(r, r.get("compatibility", {}) or {}) for r in results]
+    scored.sort(key=lambda x: x[1].get("composite", 0) if x[1] else 0, reverse=True)
+
+    for i, (model, comp) in enumerate(scored, 1):
+        model_id = model["id"]
+        if len(model_id) > 44:
+            model_id = model_id[:41] + "..."
+
+        params = model.get("params_b")
+        params_str = f"{params:.1f}B" if params else "?"
+
+        if comp:
+            mem = comp.get("estimated_memory_gb", 0)
+            mem_str = f"{mem:.1f}GB"
+            score = comp.get("composite", 0)
+            score_str = f"{score}"
+            fits = "✅" if comp.get("fits") else "❌"
+        else:
+            mem_str = "?"
+            score_str = "?"
+            fits = "?"
+
+        print(f"{i:>4} {model_id:<45} {params_str:>8} {mem_str:>8} {score_str:>5} {fits:>5}")
+
+    print()
+    print("Tip: Run with --model <id> for detailed quantization breakdown.")
+
+
+def print_model_detail(model: dict[str, Any], hw: dict[str, Any] | None) -> None:
+    """Print detailed info for a single model."""
+    print(f"\n📦 {model['id']}")
+    print(f"   Downloads: {model.get('downloads', 0):,}")
+    print(f"   Likes: {model.get('likes', 0):,}")
+    print(f"   Tags: {', '.join(model.get('tags', [])[:10])}")
+
+    params = model.get("params_b")
+    if params:
+        print(f"   Estimated params: ~{params:.1f}B")
+
+    if not hw:
+        print("   (Run detect.py first for compatibility info)")
+        return
+
+    hardware = hw.get("hardware", {})
+    gpus = hardware.get("gpus", []) or []
+    vram = max((g.get("vram_gb", 0) for g in gpus), default=0.0)
+    ram = hardware.get("ram_gb", 0.0)
+    backend = gpus[0].get("backend") if gpus else None
+
+    print(f"\n   💻 Hardware: {vram:.1f}GB VRAM, {ram:.1f}GB RAM, backend={backend or 'cpu'}")
+    print()
+
+    if not params:
+        print("   Cannot estimate compatibility (unknown parameter count).")
+        return
+
+    # Show all quantizations
+    print(f"   {'Quant':<10} {'Memory':>10} {'Fits':>6} {'Quality':>8} {'Score':>6}")
+    print("   " + "-" * 50)
+
+    quants = sorted(compat.QUANT_SIZES.keys(), key=lambda q: compat.QUANT_QUALITY.get(q, 0), reverse=True)
+    for quant in quants:
+        mem = compat.estimate_memory_gb(params, quant)
+        fits = mem <= max(vram, ram) if max(vram, ram) > 0 else False
+        quality = compat.QUANT_QUALITY.get(quant, 0)
+        score = compat.score_model(params, quant, mem, vram, ram, backend,
+                                   downloads=model.get("downloads", 0),
+                                   likes=model.get("likes", 0))
+        fit_icon = "✅" if fits else "❌"
+        print(f"   {quant:<10} {mem:>9.1f}GB {fit_icon:>5} {quality:>7} {score['composite']:>6}")
+
+    # Best recommendation
+    best = compat.get_best_quantization(params, vram, ram, backend)
+    if best:
+        print(f"\n   ⭐ Recommended: {best[0]} ({best[1]:.1f} GB)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Search Hugging Face for compatible LLMs")
+    parser.add_argument("query", nargs="?", help="Search query")
+    parser.add_argument("--model", help="Show details for a specific model ID")
+    parser.add_argument("--limit", type=int, default=20, help="Max results (default: 20)")
+    parser.add_argument("--sort", default="downloads", choices=["downloads", "trending", "likes"],
+                        help="Sort order (default: downloads)")
+    parser.add_argument("--json", action="store_true", help="Output raw JSON")
+    args = parser.parse_args()
+
+    if not args.model and not args.query:
+        parser.print_help()
+        sys.exit(1)
+
+    hw = load_hw_info()
+
+    if args.model:
+        info = get_model_info(args.model)
+        if not info:
+            print(f"Model '{args.model}' not found on Hugging Face.")
+            sys.exit(1)
+        analyzed = analyze_model(info, hw)
+        if args.json:
+            print(json.dumps(analyzed, indent=2))
+        else:
+            print_model_detail(analyzed, hw)
+        return
+
+    results = search_hub(args.query, args.limit, args.sort)
+    analyzed = [analyze_model(r, hw) for r in results]
+
+    if args.json:
+        print(json.dumps(analyzed, indent=2))
+    else:
+        print_results(analyzed, hw)
+
+
+if __name__ == "__main__":
+    main()

--- a/targets/MegamanX/default.nix
+++ b/targets/MegamanX/default.nix
@@ -26,7 +26,7 @@
           host = "0.0.0.0";
           port = 8300;
         };
-        memoryBudgetGb = 32;
+        memoryBudgetGb = 90;
         contention = "preempt";
         models = {
           "qwen3.6-35b" = {

--- a/targets/MegamanX/default.nix
+++ b/targets/MegamanX/default.nix
@@ -20,8 +20,9 @@
         pi.enable = true;
         homebrew.enable = true;
       };
+      # vllm-mlx disabled — use Ollama instead. Config preserved for easy re-enable.
       vllmMlx = {
-        enable = true;
+        enable = false;
         server = {
           host = "0.0.0.0";
           port = 8300;
@@ -29,10 +30,10 @@
         memoryBudgetGb = 90;
         contention = "preempt";
         models = {
-          "qwen3.6-35b" = {
-            path = "mlx-community/Qwen3.6-35B-A3B-4bit";
+          "qwen3.6-27b" = {
+            path = "mlx-community/Qwen3.6-27B-4bit";
             type = "lm";
-            estimatedMemoryGb = 21;
+            estimatedMemoryGb = 16;
           };
         };
         enableAutoToolChoice = true;
@@ -41,22 +42,38 @@
         logLevel = "INFO";
       };
 
+      ollama = {
+        enable = true;
+        host = "127.0.0.1";
+        port = 11434;
+      };
+
       vane = {
         enable = true;
         openaiBaseUrl = "http://bifrost.internal/v1";
-        defaultModel = "qwen3.6-35b";
-        embeddingModel = "mlx-community/nomicai-modernbert-embed-base-4bit";
+        defaultModel = "qwen3.6:27b";
+        embeddingModel = "nomic-embed-text:latest";
+        ollamaUrl = "http://localhost:11434";
       };
       bifrost = {
         enable = true;
         logLevel = "debug";
-        upstreams.vllm-mlx-local = {
-          url = "http://localhost:8300";
-          type = "openai";
-          requestTimeout = 120;
-          models = [
-            "qwen3.6-35b"
-          ];
+        upstreams = {
+          # vllm-mlx disabled — preserved for easy re-enable
+          vllm-mlx-local = {
+            url = "http://localhost:8300";
+            type = "openai";
+            requestTimeout = 120;
+            models = [
+              "qwen3.6-27b"
+            ];
+          };
+          ollama-local = {
+            url = "http://localhost:11434";
+            type = "openai";
+            requestTimeout = 120;
+            models = [];
+          };
         };
       };
       searxng.enable = true;
@@ -90,13 +107,13 @@
         models.bifrost = {
           name = "Bifrost AI Gateway";
           provider = "openai";
-          modelId = "vllm-mlx-local/qwen3.6-35b";
+          modelId = "ollama-local/qwen3.6:27b";
           baseUrl = "http://bifrost.internal/v1";
         };
-        models.local-vllm-mlx = {
-          name = "Qwen3.6 35B A3B (Bifrost)";
+        models.local-ollama = {
+          name = "Local LLM (Ollama via Bifrost)";
           provider = "openai";
-          modelId = "vllm-mlx-local/qwen3.6-35b";
+          modelId = "ollama-local/qwen3.6:27b";
           baseUrl = "http://bifrost.internal/v1";
         };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -53,13 +53,6 @@ in
 
     # Per-role tests (all combined into one derivation for CI speed)
     all-role-tests = testRoles.allRoleTests;
-    role-evaluation = testRoles.allRoleTests;
-    role-composition = testRoles.allRoleTests;
-    role-packages = testRoles.allRoleTests;
-    role-cascades = testRoles.allRoleTests;
-    llm-host-shared-models = testRoles.allRoleTests;
-    no-dead-development-option = testRoles.allRoleTests;
-    entertainment-nixos = testRoles.allRoleTests;
 
     # Skills tests
     skills-manifest = testSkills.manifestValidationTest;

--- a/tests/test-pi.nix
+++ b/tests/test-pi.nix
@@ -137,6 +137,18 @@ in {
       else ''echo "  themes should default to {}!"; exit 1''
     }
 
+    ${
+      if piDefaults.pluginsSource == null
+      then ''echo "  pluginsSource default = null: OK"''
+      else ''echo "  pluginsSource should default to null!"; exit 1''
+    }
+
+    ${
+      if piDefaults.plugins == []
+      then ''echo "  plugins default = []: OK"''
+      else ''echo "  plugins should default to []!"; exit 1''
+    }
+
     echo "All Pi option defaults verified"
     touch $out
   '';

--- a/tests/test-roles.nix
+++ b/tests/test-roles.nix
@@ -148,7 +148,7 @@
     developer = ["clang" "python3" "nodejs" "yarn" "k9s" "gh-dash" "yaks"];
     creative = ["ffmpeg" "imagemagick" "pandoc"];
     gaming = ["moonlight-qt"];
-    desktop = ["logseq"];
+    desktop = []; # logseq removed due to electron-forge build hangs
     workstation = ["slack" "trippy" "unar"];
     # entertainment: NixOS packages (obs-studio, discord) are tested separately
     # in entertainmentNixosTest using linuxPkgs; they only appear on NixOS (isDarwin=false)

--- a/tests/test-vllm-mlx.nix
+++ b/tests/test-vllm-mlx.nix
@@ -236,9 +236,9 @@ in {
       else ''echo "  FAIL: toolCallParser should be qwen, got ${toString megamanxVllmMlx.toolCallParser}"; exit 1''
     }
     ${
-      if megamanxVllmMlx.memoryBudgetGb == 32
-      then ''echo "  memoryBudgetGb = 32: OK"''
-      else ''echo "  FAIL: memoryBudgetGb should be 32, got ${toString megamanxVllmMlx.memoryBudgetGb}"; exit 1''
+      if megamanxVllmMlx.memoryBudgetGb == 90
+      then ''echo "  memoryBudgetGb = 90: OK"''
+      else ''echo "  FAIL: memoryBudgetGb should be 90, got ${toString megamanxVllmMlx.memoryBudgetGb}"; exit 1''
     }
     ${
       if megamanxVllmMlx.enableAutoToolChoice

--- a/tests/test-vllm-mlx.nix
+++ b/tests/test-vllm-mlx.nix
@@ -220,15 +220,15 @@ in {
     echo ""
     ${
       let
-        hasModel = builtins.elem "qwen3.6-35b" (builtins.attrNames megamanxVllmMlx.models);
+        hasModel = builtins.elem "qwen3.6-27b" (builtins.attrNames megamanxVllmMlx.models);
         modelPath =
           if hasModel
-          then megamanxVllmMlx.models."qwen3.6-35b".path
+          then megamanxVllmMlx.models."qwen3.6-27b".path
           else null;
       in
-        if hasModel && modelPath == "mlx-community/Qwen3.6-35B-A3B-4bit"
-        then ''echo "  model = Qwen3.6-35B-A3B-4bit: OK"''
-        else ''echo "  FAIL: model should be mlx-community/Qwen3.6-35B-A3B-4bit, got ${toString modelPath}"; exit 1''
+        if hasModel && modelPath == "mlx-community/Qwen3.6-27B-4bit"
+        then ''echo "  model = Qwen3.6-27B-4bit: OK"''
+        else ''echo "  FAIL: model should be mlx-community/Qwen3.6-27B-4bit, got ${toString modelPath}"; exit 1''
     }
     ${
       if megamanxVllmMlx.toolCallParser == "qwen"


### PR DESCRIPTION
uwt feat: switch MegamanX to Ollama, add pi-plugins integration, and model-stack skill

- Replace vllm-mlx with Ollama as the local LLM host on MegamanX
- Add Ollama Darwin service module (launchd daemon)
- Add pi-plugins flake input and wire up pi-plugin-yaks extension
- Add model-stack skill for hardware-aware model research
- Update pi role to use valid plugin names and configure Ollama
- Add ollama options to common options.nix
- Update tests for new ollama and pi configuration
- Add gitignore for Python cache and skill runtime caches