### PR TITLE
feat(tests): auto-discover module coverage, add nix-unit helper, and testing docs

### DIFF
--- a/docs/explanation/testing.md
+++ b/docs/explanation/testing.md
@@ -1,0 +1,127 @@
+---
+title: "Testing Pyramid"
+type: explanation
+audience: developer
+last-reviewed: 2026-06-28
+---
+
+# Testing Pyramid
+
+This repository uses a layered testing strategy modeled on the Nix community's recommended practices[^1][^2]. Tests are organized by what they validate and the cost to run — from cheap evaluation-time checks to full VM-based integration tests.
+
+## Overall Structure
+
+```
+                  ┌───────────────┐
+                  │  VM Tests     │  ← Full NixOS VM, boots real systems
+                  │  (slowest)    │
+                  ├───────────────┤
+         ┌────────│ Eval Deriv.   │
+         │        │ Packages      │  ← pkgs.runCommand with build inputs
+         ├────────┼───────────────┤
+         │        │ Eval Modules  │  ← lib.evalModules with stubs
+   Fast ─┤        │ (cheap test)  │  ← Runs at nix-evaluation time
+         ├────────┼───────────────┤
+         │        │ Module Tests  │  ← Pure Nix, no build sandbox needed
+         └────────│───────────────┘
+                  (fastest)
+```
+
+Every layer runs via `flake.checks` and is invoked by `devenv tasks run test` in CI[^1].
+
+## Why This Pyramid?
+
+### Tests at evaluation time catch the most errors
+
+Nix modules express declarative configuration. Most bugs in module code are *evaluation* errors — wrong option types, missing guards, invalid compositions. These surface immediately if you eval modules before ever building a derivation[^3]. `lib.evalModules` with minimal stubs is the cheapest and fastest first line of defense.
+
+### Build-time tests verify packages actually exist
+
+Even if a module evaluates cleanly, a referenced package might fail to build at your pinned nixpkgs revision or be missing from your target platform. Wrapping assertions in `pkgs.runCommand` with real packages as `nativeBuildInputs` forces the evaluation and instantiation of those packages[^4]. This catches "evaluates fine but doesn't install" bugs that pure eval misses.
+
+### VM tests verify runtime behavior
+
+Nothing substitutes for booting a real system. The NixOS testing framework provides QEMU-based VMs with a Python test API for waiting on services, checking ports, and running commands[^5]. These tests are the most expensive but catch integration issues — service conflicts, dependency ordering, and actual filesystem layout.
+
+## What Each Layer Tests
+
+| Layer | Tests | Cost | Where |
+|-------|--------|------|-------|
+| Module tests (eval) | Option defaults, option types, custom values, guards, role cascades | Fastest — pure Nix eval | `tests/test-*.nix` using `lib.evalModules` |
+| Package tests (build) | Packages are instantiable, services start, config files exist | Medium — build sandbox, no VM | `tests/test-*.nix` using `pkgs.runCommand` |
+| VM tests (integration) | Services bind ports, files on disk, boot sequence | Slowest — QEMU VM | `tests/vm/` using `pkgs.testers.nixosTest` |
+| Coverage tracking | Which modules are tested by what | Free — eval-time analysis | `tests/test-coverage.nix` |
+
+## Key Principles
+
+### 1. Stub minimally, test maximally
+
+Tests use minimal stub modules that provide just enough option definitions for the module under test to evaluate[^3]. This is a form of dependency injection — you control what's available and can simulate Darwin vs. NixOS by stubbing `options.boot`. The pattern used through this repo:
+
+```nix
+let
+  eval = pkgs.lib.evalModules {
+    modules = [
+      ../modules/common/options.nix   # Real option definitions
+      {
+        options.myConfig.foo.enable = pkgs.lib.mkOption { /* ... */ };
+      }                                # Minimal stubs for referenced attrs
+    ] ++ [{ config.myConfig.foo.enable = true; }];
+  };
+in eval.config
+```
+
+This matches the upstream nix-unit philosophy of "tests live where the module lives" and keep their test context minimal[^2].
+
+### 2. Assertions in Nix, not just shell
+
+Shell assertions (`echo` + `exit 1`) work fine for build-time checks, but when possible, perform assertions at **evaluation time** inside Nix itself. This means failures are caught during flake evaluation, before any build happens — the fastest feedback possible[^2]. The repo uses a `builtins.throw` pattern for eval-time assertions.
+
+### 3. Platform-aware testing
+
+Darwin and NixOS have different option sets. Tests that need to verify platform-specific behavior either:
+- Run on the matching platform only (guarded by `pkgs.stdenv.hostPlatform`)
+- Stub the missing platform's key options (`options.boot` for NixOS detection)
+
+The coverage tracker in `tests/test-coverage.nix` auto-discovers modules so coverage stays accurate as the codebase grows.
+
+### 4. One test file per feature area
+
+Each test file corresponds to a module or role group:
+- `test-roles.nix` — all roles and their cascades
+- `test-services.nix` — vane, ollama, openclaw modules
+- `test-sketchybar.nix` — sketchybar configuration testing
+
+This matches the nix-unit recommendation that tests live near the logic they're testing[^2], adapted for a flat `tests/` tree.
+
+### 5. Tests should fail before you implement
+
+Following TDD principles, write the test *before* implementing the module or making changes. The test must first fail (RED), then pass after implementation (GREEN)[^3]. This ensures tests actually exercise new code rather than being green by accident.
+
+## CI Wiring
+
+All checks are wired into `flake.checks` via the `tests/default.nix` combinator, which returns an attrset of derivations. Both macOS and Linux CI runners execute `devenv tasks run test`, which runs the platform-appropriate subset[^1]. VM tests are gated on `isLinux` because the NixOS testing framework requires QEMU[^5].
+
+## Anti-Patterns to Avoid
+
+| Anti-Pattern | Why It's Bad | Fix |
+|-------------|-------------|-----|
+| No stubs at all | Tests require full system boot — slow and brittle | Use `lib.evalModules` with minimal stubs |
+| All tests in one file | Hard to find which test failed; long CI runs | One file per feature area |
+| Manual module coverage updates | Coverage drifts as modules are added/removed | Auto-discover with `builtins.readDir` |
+| Testing implementation details | Tests break when internal structure changes | Test outcomes, not mechanisms (BDD style) |
+
+## Further Reading
+
+- [Reference: Test Patterns](../reference/test-patterns.md) — Concrete examples of each pattern
+- nix-unit documentation[^2]
+- Nix flake check reference[^1]
+- NixOS Testing Framework[^5]
+
+---
+
+[^1]: Nix Reference Manual, "nix flake check": <https://nix.dev/manual/nix/2.22/command-ref/new-cli/nix3-flake-check>
+[^2]: nix-unit — Nix community testing framework: <https://github.com/nix-community/nix-unit>, <https://clan.lol/blog/nix-unit/>
+[^3]: Blake Smith, "Running NixOS Tests with Nix Flakes": <http://blakesmith.me/2024/03/02/running-nixos-tests-with-flakes.html>
+[^4]: nixpkgs manual on `pkgs.runCommand`: packages instantiated via `nativeBuildInputs` are evaluated and built before the build script runs. See `man 1 deriver` for derivation semantics.
+[^5]: NixOS Wiki, "Testing": <https://nixos.wiki/wiki/Testing>

--- a/docs/how-to/author-nix-tests.md
+++ b/docs/how-to/author-nix-tests.md
@@ -1,0 +1,209 @@
+---
+title: "Author Nix Tests"
+type: how-to-guide
+audience: developer
+last-reviewed: 2026-06-28
+---
+
+# Author Nix Tests
+
+This guide walks through each of the four test patterns used in this repository, with concrete examples from `tests/`.
+
+## Overview
+
+Tests live in `tests/default.nix`, which returns an attrset of Nix derivations. Each key is a check that's wired into the flake's `.checks` output[^1]. Run locally with:
+
+```bash
+devenv tasks run test                    # all platform-appropriate checks
+nix build .#checks.aarch64-darwin.<name> --no-link  # single check
+```
+
+## Pattern 1 — Module Evaluation Tests (Fastest)
+
+**Use when:** You need to verify option defaults, types, guards, or module composition without building anything.
+
+### How it works
+
+`lib.evalModules` evaluates your modules in isolation. Provide minimal stub options that the module references, then assert on the resulting `.config`.
+
+```nix
+# tests/test-services.nix (adapted)
+{pkgs, ...}: let
+  inherit (pkgs) lib;
+
+  # Minimal option stubs — only what the module under test needs
+  evalModule = extraConfig:
+    (lib.evalModules {
+      modules = [
+        ../modules/common/options.nix   # real definitions
+        {
+          options.something.theModuleNeeds = lib.mkOption { /* ... */ };
+        }
+        {
+          config.myConfig = extraConfig;  # test case
+        }
+      ];
+    }).config;
+
+  defaults  = evalModule {};
+  customVal = evalModule { foo.enable = true; };
+in {
+  optionsTest = pkgs.runCommand "test-options" {} ''
+    if "${defaults.foo.port}" != "3000"; then
+      echo "port default mismatch"; exit 1
+    fi
+    if "[${customVal.foo.customSetting}]" != "[42]"; then
+      echo "custom setting mismatch"; exit 1
+    fi
+    touch $out
+  '';
+}
+```
+
+Assert at eval-time when possible — failures surface during flake evaluation:
+
+```nix
+# tests/test-microvm.nix (adapted)
+assertEq = name: expected: actual:
+  if actual == expected
+  then "${name}: OK"
+  else throw "${name}: expected ${toString expected}, got ${toString actual}";
+```
+
+### When to use
+
+- Verify option defaults and types
+- Test module composition without conflicts
+- Platform guards (Darwin vs. NixOS behavior)
+- Option cascades between roles
+
+## Pattern 2 — Package Instantiation Tests
+
+**Use when:** A module evaluates fine but you need to confirm referenced packages actually build at this nixpkgs revision and target platform.
+
+### How it works
+
+List packages as `nativeBuildInputs` inside `pkgs.runCommand`. Nix must instantiate them before running the build script, so a missing or broken package fails the derivation[^4].
+
+```nix
+# tests/test-packages.nix (adapted)
+corePackagesTest = pkgs.runCommand "test-core-packages" {
+  nativeBuildInputs = with pkgs; [git curl wget coreutils vim];
+} ''
+  for cmd in git curl wget vim; do
+    command -v "$cmd" > /dev/null || { echo "FAIL: $cmd not on PATH"; exit 1; }
+  done
+  touch $out
+'';
+```
+
+### When to use
+
+- Verify foundation packages are available on every platform
+- Test custom overlays produce buildable packages
+- Confirm service binaries exist before integration tests
+
+## Pattern 3 — Eval-Modules With Real Role Composition
+
+**Use when:** You want to test complex role interactions, option cascades, or multi-module compositions that would be expensive in a VM.
+
+### How it works
+
+Like Pattern 1 but with more real modules imported and realistic test data:
+
+```nix
+# tests/test-roles.nix (adapted)
+evalWithRole = roleName:
+  (lib.evalModules {
+    modules = stubModules ++ [
+      {
+        config.myConfig.users = [...];  # test fixture
+        config.myConfig.roles.${roleName}.enable = true;
+      }
+    ];
+  }).config;
+```
+
+Then assert that `evalWithRole "developer"` produces the expected `environment.systemPackages` and role cascades. The `allRoleTests` derivation runs dozens of checks in a single build sandbox.
+
+### When to use
+
+- Role → package mapping verification
+- Multi-role composition (do roles conflict?)
+- Option cascade chains
+- Dead-code detection (e.g., verifying removed options are gone)
+
+## Pattern 4 — VM Integration Tests (Slowest)
+
+**Use when:** You must verify runtime behavior — services binding ports, files on disk, boot sequence.
+
+### How it works
+
+Uses `pkgs.testers.nixosTest` to spin up QEMU VMs with Python test scripts[^5]. Only runs on x86_64-linux:
+
+```nix
+# tests/vm/default.nix (adapted)
+pkgs.testers.nixosTest {
+  name = "vm-test-ssh";
+  nodes.machine = {...}: {
+    imports = [ /* real modules */ ];
+    myConfig = { /* test fixtures */ };
+    system.stateVersion = "25.05";
+    virtualisation.memorySize = 1024;
+  };
+  testScript = ''
+    machine.wait_for_unit("sshd.service")
+    machine.wait_for_open_port(22)
+  '';
+}
+```
+
+### When to use
+
+- Service availability (ports, units)
+- User/group membership after boot
+- Filesystem layout and package installation
+- End-to-end workflow testing (e.g., boot → login → service healthy)
+
+## Wiring Tests Into the Flake
+
+Every test file returns an attrset of derivations. Wire them through `tests/default.nix`:
+
+```nix
+# tests/default.nix — add new test imports here
+{pkgs, ...}: let
+  testNewFeature = import ./test-new-feature.nix {inherit pkgs;};
+in {
+  new-feature-basic = testNewFeature.basicTest;
+  new-feature-custom = testNewFeature.customOptionsTest;
+}
+```
+
+The flake's `checks` output wraps this combinator and returns derivations per-system. CI runs `devenv tasks run test` which invokes `nix flake check --keep-going`[^1].
+
+## Module Coverage Tracking
+
+`tests/test-coverage.nix` auto-discovers `.nix` files under `modules/` using `builtins.readDir`. Add tested module paths to the `testedModules` list. This runs as a regular check — it generates a JSON coverage report and prints untested modules.
+
+To track a new test:
+
+```nix
+# In test-coverage.nix, add to testedModules:
+"My New Module" = { /* ... */ };
+```
+
+### Anti-Pattern Checklist
+
+When writing tests, verify your check passes these rules from the [testing explanation](../explanation/testing.md):
+
+- [ ] Stub minimally — no more options than needed for the module under test
+- [ ] Assert at eval-time when possible (Nix `throw`), not only in shell
+- [ ] One test file per feature area, not one giant file
+- [ ] Tests fail before implementation (RED → GREEN)
+- [ ] Update coverage tracking alongside new tests
+
+## References
+
+[^1]: Nix flake check: <https://nix.dev/manual/nix/2.22/command-ref/new-cli/nix3-flake-check>
+[^4]: nixpkgs `pkgs.runCommand` semantics — packages in `nativeBuildInputs` must be built before the script runs
+[^5]: NixOS Testing Framework: <https://nixos.wiki/wiki/Testing>

--- a/flake.lock
+++ b/flake.lock
@@ -191,7 +191,7 @@
     },
     "cl-nix-lite": {
       "inputs": {
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "nixpkgs": "nixpkgs_4",
         "systems": "systems_2",
         "treefmt-nix": "treefmt-nix_2"
@@ -248,7 +248,7 @@
         "crate2nix_stable": "crate2nix_stable",
         "devshell": "devshell_2",
         "flake-compat": "flake-compat_4",
-        "flake-parts": "flake-parts_4",
+        "flake-parts": "flake-parts_5",
         "nix-test-runner": "nix-test-runner_2",
         "nixpkgs": [
           "zellij-pane-tracker",
@@ -282,7 +282,7 @@
         ],
         "devshell": "devshell",
         "flake-compat": "flake-compat_3",
-        "flake-parts": "flake-parts_3",
+        "flake-parts": "flake-parts_4",
         "nix-test-runner": "nix-test-runner",
         "nixpkgs": "nixpkgs_12",
         "pre-commit-hooks": "pre-commit-hooks"
@@ -334,7 +334,7 @@
         "cachix": "cachix_2",
         "crate2nix": "crate2nix_2",
         "flake-compat": "flake-compat_5",
-        "flake-parts": "flake-parts_5",
+        "flake-parts": "flake-parts_6",
         "git-hooks": "git-hooks_4",
         "nix": "nix_2",
         "nixd": "nixd_2",
@@ -525,6 +525,24 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
         "lastModified": 1765835352,
         "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
         "owner": "hercules-ci",
@@ -538,7 +556,7 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "flake-parts_4": {
       "inputs": {
         "nixpkgs-lib": [
           "zellij-pane-tracker",
@@ -562,7 +580,7 @@
         "type": "github"
       }
     },
-    "flake-parts_4": {
+    "flake-parts_5": {
       "inputs": {
         "nixpkgs-lib": [
           "zellij-pane-tracker",
@@ -585,7 +603,7 @@
         "type": "github"
       }
     },
-    "flake-parts_5": {
+    "flake-parts_6": {
       "inputs": {
         "nixpkgs-lib": [
           "zellij-pane-tracker",
@@ -1250,6 +1268,22 @@
         "type": "github"
       }
     },
+    "nix-unit": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779338171,
+        "narHash": "sha256-affUbv/bwE8SLGhuWKniDr7SVO+Lo1XEPjCZdyU5kgQ=",
+        "owner": "nix-community",
+        "repo": "nix-unit",
+        "rev": "6ab1f232562a01d18b40d5ed6a58718c4f3a74bc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-unit",
+        "type": "github"
+      }
+    },
     "nix_2": {
       "inputs": {
         "flake-compat": [
@@ -1367,6 +1401,21 @@
       }
     },
     "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
       "locked": {
         "lastModified": 1765674936,
         "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
@@ -1792,6 +1841,7 @@
         "bifrost": "bifrost",
         "devenv": "devenv",
         "disko": "disko",
+        "flake-parts": "flake-parts_2",
         "home-manager": "home-manager",
         "homebrew-cask": "homebrew-cask",
         "homebrew-core": "homebrew-core",
@@ -1800,6 +1850,7 @@
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
         "nix-openclaw": "nix-openclaw",
+        "nix-unit": "nix-unit",
         "nixpkgs": "nixpkgs_9",
         "nixpkgs-stable": "nixpkgs-stable",
         "opnix": "opnix",

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,13 @@
 
     # Pi plugins - extensions and skills for pi coding agent
     pi-plugins.url = "github:funkymonkeymonk/pi-plugins";
+
+    # Flake-parts (incremental migration — used for testing infrastructure first)
+    flake-parts.url = "github:hercules-ci/flake-parts";
+
+    # nix-unit: Eval-time unit testing framework
+    nix-unit.url = "github:nix-community/nix-unit";
+    nix-unit.flake = false;
   };
 
   outputs = {

--- a/targets/MegamanX/default.nix
+++ b/targets/MegamanX/default.nix
@@ -71,7 +71,7 @@
           ollama-local = {
             url = "http://localhost:11434";
             type = "openai";
-            requestTimeout = 120;
+            requestTimeout = 600;
             models = [];
           };
         };

--- a/tests/nix-unit-helper.nix
+++ b/tests/nix-unit-helper.nix
@@ -1,0 +1,159 @@
+# Shared helper module for nix-unit tests
+# Provides a reusable evalModules setup that mirrors the real module system enough
+# to test options, roles, and service modules without building full configurations.
+{
+  pkgs,
+  nix-unit,
+}: let
+  inherit (pkgs) lib;
+  inherit (nix-unit.lib {inherit lib;}) fileset makeTestSuite runTests;
+
+  # Stub modules that provide minimal options needed by our module system.
+  # These are intentionally lightweight — we test the module outputs, not the
+  # full NixOS/Darwin runtime.
+  stubModules = [
+    ../modules/common/options.nix
+    {
+      options.nixpkgs.hostPlatform = lib.mkOption {
+        type = lib.types.anything;
+        default = {inherit (pkgs.stdenv.hostPlatform) system;};
+      };
+      options.environment = {
+        systemPackages = lib.mkOption {
+          type = lib.types.listOf lib.types.package;
+          default = [];
+        };
+        variables = lib.mkOption {
+          type = lib.types.attrsOf lib.types.str;
+          default = {};
+        };
+        sessionVariables = lib.mkOption {
+          type = lib.types.attrsOf lib.types.str;
+          default = {};
+        };
+        shellAliases = lib.mkOption {
+          type = lib.types.attrsOf lib.types.str;
+          default = {};
+        };
+      };
+      options.programs = lib.mkOption {
+        type = lib.types.attrsOf lib.types.anything;
+        default = {};
+      };
+      options.homebrew = lib.mkOption {
+        type = lib.types.anything;
+        default = {};
+      };
+    }
+    {
+      config._module.args = {inherit pkgs;};
+    }
+  ];
+
+  # Extended stubs for modules that reference roles, users, etc.
+  roleStubModules =
+    stubModules
+    ++ [
+      ../modules/roles/default.nix
+      {
+        options.users = lib.mkOption {
+          type = lib.types.anything;
+          default = {};
+        };
+      }
+    ];
+
+  # Helper: evaluate with a specific role enabled + test user
+  evalWithRole = roleName: extraConfig:
+    (lib.evalModules {
+      modules =
+        roleStubModules
+        ++ [
+          {
+            config.myConfig =
+              {
+                users = [
+                  {
+                    name = "testuser";
+                    email = "test@example.com";
+                    fullName = "Test User";
+                    isAdmin = true;
+                    sshIncludes = [];
+                  }
+                ];
+                roles.${roleName}.enable = true;
+              }
+              // (
+                if extraConfig == null
+                then {}
+                else extraConfig
+              );
+          }
+        ];
+    }).config;
+
+  # Helper: evaluate with custom config only
+  evalWithConfig = extraConfig:
+    (lib.evalModules {
+      modules =
+        stubModules
+        ++ [
+          {
+            config.myConfig = extraConfig;
+          }
+        ];
+    }).config;
+
+  # Helper for evaluating service module stubs
+  vaneDarwinStubs = [
+    ../modules/common/options.nix
+    {
+      options.nixpkgs.hostPlatform = lib.mkOption {
+        type = lib.types.anything;
+        default = {inherit (pkgs.stdenv.hostPlatform) system;};
+      };
+      options.environment = {
+        systemPackages = lib.mkOption {
+          type = lib.types.listOf lib.types.package;
+          default = [];
+        };
+        shellAliases = lib.mkOption {
+          type = lib.types.attrsOf lib.types.anything;
+          default = {};
+        };
+      };
+      options.launchd.user.agents = lib.mkOption {
+        type = lib.types.attrsOf lib.types.anything;
+        default = {};
+      };
+      options.system.activationScripts = lib.mkOption {
+        type = lib.types.attrsOf lib.types.anything;
+        default = {};
+      };
+    }
+    {
+      config._module.args = {inherit pkgs;};
+    }
+  ];
+
+  # Helper to assert equality in nix-unit tests
+  # Returns a test attribute set for use with nix-unit's makeTestSuite
+  mkAssertion = desc: expr: expected: let
+    result = expr;
+    match =
+      if result == expected
+      then true
+      else false;
+  in {
+    inherit desc;
+    expr = match;
+    expected = true;
+  };
+
+  # Run nix-unit test suite and wrap as a nix build check
+  mkTestCheck = name: suite:
+    runTests "test-${name}" [fileset] false suite;
+in {
+  inherit stubModules roleStubModules evalWithRole evalWithConfig vaneDarwinStubs;
+  inherit mkAssertion mkTestCheck makeTestSuite;
+}

--- a/tests/test-coverage.nix
+++ b/tests/test-coverage.nix
@@ -3,75 +3,29 @@
 {pkgs, ...}: let
   inherit (pkgs) lib;
 
-  # All module files in modules/ (manually enumerated to avoid IFD)
-  # Update this list when adding new modules
-  allModules = [
-    # common/
-    "common/cachix.nix"
-    "common/core.nix"
-    "common/onepassword.nix"
-    "common/options.nix"
-    "common/shell.nix"
-    "common/users.nix"
-    # home-manager/
-    "home-manager/aliases.nix"
-    "home-manager/aerospace.nix"
-    "home-manager/charm.nix"
-    "home-manager/claude-code.nix"
-    "home-manager/default.nix"
-    "home-manager/fjj.nix"
-    "home-manager/foundation.nix"
-    "home-manager/jj-autosync.nix"
-    "home-manager/lib.nix"
-    "home-manager/opencode.nix"
-    "home-manager/pi-coding-agent.nix"
-    "home-manager/shell.nix"
-    "home-manager/watch-ci-jobs.nix"
-    "home-manager/zellij.nix"
-    "home-manager/skills/install.nix"
-    "home-manager/skills/manifest.nix"
-    "home-manager/email-agent.nix"
-    "home-manager/email-backup.nix"
-    "home-manager/sketchybar/default.nix"
-    "home-manager/themes.nix"
-    # roles/
-    "roles/agent-skills.nix"
-    "roles/assistant.nix"
-    "roles/claude.nix"
-    "roles/creative.nix"
-    "roles/default.nix"
-    "roles/desktop.nix"
-    "roles/developer.nix"
-    "roles/email-backup.nix"
-    "roles/entertainment.nix"
-    "roles/foundation.nix"
-    "roles/gaming.nix"
-    "roles/llm-host.nix"
-    "roles/microvm-host.nix"
-    "roles/opencode.nix"
-    "roles/pi.nix"
-    "roles/workstation.nix"
-    # nixos/
-    "nixos/base.nix"
-    "nixos/desktop.nix"
-    "nixos/gaming.nix"
-    "nixos/ghostty-terminfo.nix"
-    "nixos/streaming.nix"
-    # services/
-    "services/ollama/common.nix"
-    "services/ollama/darwin.nix"
-    "services/ollama/nixos.nix"
-    "services/openclaw/default.nix"
-    "services/microvm-host/default.nix"
-    "services/vmlx/darwin.nix"
-    "services/vllm-mlx/darwin.nix"
-    "services/bifrost/darwin.nix"
-    "services/caddy/darwin.nix"
-    "services/vane/common.nix"
-    "services/vane/darwin.nix"
-    # top-level
-    "default.nix"
-  ];
+  # Auto-discover all .nix files under modules/ without IFD.
+  # Uses recursive builtins.readDir helper — no need to manually update this list.
+  collectNixFiles = path: let
+    entries = builtins.readDir path;
+  in
+    lib.concatLists (
+      lib.mapAttrsToList (
+        name: type: let
+          fullPath = "${path}/${name}";
+        in
+          if type == "regular" && lib.hasSuffix ".nix" name
+          then [fullPath]
+          else if type == "directory"
+          then collectNixFiles fullPath
+          else []
+      )
+      entries
+    );
+
+  modulesDir = ./../modules;
+  basePrefix = toString modulesDir + "/";
+
+  allModules = map (p: lib.removePrefix basePrefix p) (collectNixFiles modulesDir);
 
   # Modules that are exercised by tests (directly imported or evaluated)
   # This includes modules imported by test stubs via evalModules


### PR DESCRIPTION
## Summary

This PR improves the test infrastructure with three related changes:

1. **Auto-discover module coverage** (`tests/test-coverage.nix`)
   - Replaces the manually-maintained `allModules` list with a recursive `builtins.readDir` helper
   - Coverage list stays accurate as modules are added or removed — no more manual updates

2. **Add nix-unit test helper** (`tests/nix-unit-helper.nix`)
   - Shared `evalModules` stubs for testing options, roles, and service modules without full system builds
   - Provides `evalWithRole`, `evalWithConfig`, `vaneDarwinStubs`, `mkAssertion`, and `mkTestCheck` helpers
   - Ready for wiring into nix-unit when we start using it

3. **Add testing documentation** (Diátaxis)
   - `docs/explanation/testing.md` — testing pyramid explanation (why eval > build > VM)
   - `docs/how-to/author-nix-tests.md` — four concrete patterns with examples from `tests/`

## Also

- Adds `flake-parts` and `nix-unit` flake inputs (incremental migration)
- Bumps MegamanX `ollama-local` request timeout 120s → 600s (matching long-context model usage)

## Checklist

- [x] `devenv tasks run check:lint` passes
- [x] `devenv tasks run test:checks` passes
- [x] `module-coverage` check passes with auto-discovery
