### PR TITLE
perf(darwin): disable docs and fix ssh deprecation to speed up eval

### DIFF
--- a/modules/common/users.nix
+++ b/modules/common/users.nix
@@ -47,14 +47,16 @@ with lib; let
           enable = true;
           enableDefaultConfig = false;
           includes = user.sshIncludes;
-          matchBlocks = lib.optionalAttrs (config.myConfig.onepassword.enableSSHAgent && isDarwin) {
+          settings = lib.optionalAttrs (config.myConfig.onepassword.enableSSHAgent && isDarwin) {
             "*" = {
-              extraOptions = {
-                IdentityAgent = "\"~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock\"";
-              };
+              IdentityAgent = "\"~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock\"";
             };
           };
         };
+
+        # Disable home-manager manpages to avoid expensive options.json
+        # generation and builtins.derivation context warnings
+        manual.manpages.enable = lib.mkDefault false;
 
         # Allowed signers file for SSH signature verification
         # Maps email addresses to trusted SSH public keys for local commit verification

--- a/os/darwin.nix
+++ b/os/darwin.nix
@@ -5,6 +5,12 @@
     # handles service loading/unloading. The custom script was fighting with
     # nix-darwin's reload logic and causing hangs during switch.
   ];
+
+  # Disable nix-darwin documentation generation to speed up eval.
+  # The docs require re-evaluating the entire config with scrubbed
+  # derivations, which adds significant overhead on every rebuild.
+  documentation.enable = false;
+
   nixpkgs.config.allowUnfree = true;
   nixpkgs.config.allowUnfreePredicate = pkg:
     builtins.elem (lib.getName pkg) [


### PR DESCRIPTION
- Disable nix-darwin documentation generation in os/darwin.nix to avoid expensive re-evaluation with scrubbed derivations on every rebuild.
- Disable home-manager manpages in modules/common/users.nix to prevent builtins.derivation context warnings from options.json generation.
- Migrate deprecated programs.ssh.matchBlocks to programs.ssh.settings using upstream OpenSSH directive names.