### PR TITLE
feat: add reasoning and maxTokens options for local pi models

### DIFF
--- a/modules/common/options.nix
+++ b/modules/common/options.nix
@@ -1295,6 +1295,16 @@ with lib; {
               default = "";
               description = "Base URL for the API (for custom endpoints)";
             };
+            reasoning = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Whether the model supports extended thinking/reasoning";
+            };
+            maxTokens = mkOption {
+              type = types.nullOr types.int;
+              default = null;
+              description = "Maximum output tokens for the model";
+            };
           };
         });
         default = {};

--- a/modules/home-manager/pi-coding-agent.nix
+++ b/modules/home-manager/pi-coding-agent.nix
@@ -47,12 +47,19 @@ with lib; let
         else null;
       models =
         if model.modelId != ""
-        then [
-          {
-            id = model.modelId;
-            name = model.name;
-          }
-        ]
+        then let
+          baseModel =
+            {
+              id = model.modelId;
+              name = model.name;
+            }
+            // lib.optionalAttrs model.reasoning {
+              reasoning = true;
+            }
+            // lib.optionalAttrs (model.maxTokens != null) {
+              maxTokens = model.maxTokens;
+            };
+        in [baseModel]
         else null;
       compat =
         if model.modelId == ""

--- a/targets/MegamanX/default.nix
+++ b/targets/MegamanX/default.nix
@@ -128,12 +128,16 @@
           provider = "openai";
           modelId = "ollama-local/qwen3.6:27b";
           baseUrl = "http://bifrost.internal/v1";
+          reasoning = true;
+          maxTokens = 131072;
         };
         models.local-ollama = {
           name = "Local LLM (Ollama via Bifrost)";
           provider = "openai";
           modelId = "ollama-local/qwen3.6:27b";
           baseUrl = "http://bifrost.internal/v1";
+          reasoning = true;
+          maxTokens = 131072;
         };
 
         prompts.review = ''


### PR DESCRIPTION
Extends the pi model config schema with `reasoning` (bool) and `maxTokens` (optional int) options, and updates the models.json generator to emit them.

Also enables `reasoning = true` and sets `maxTokens = 131072` on bifrost/local-ollama models to prevent tool call formatting errors and stream idle timeouts with local models.