### PR TITLE
fix(ollama): install Ollama via Homebrew on Darwin

### DIFF
--- a/modules/home-manager/pi-coding-agent.nix
+++ b/modules/home-manager/pi-coding-agent.nix
@@ -393,7 +393,7 @@ in {
 
       if [ ! -f "$stamp_file" ] || [ "$(cat "$stamp_file" 2>/dev/null)" != "$current_target" ]; then
         $DRY_RUN_CMD mkdir -p "$npm_dir"
-        $DRY_RUN_CMD cd "$npm_dir" && ${pkgs.nodejs}/bin/npm install
+        $DRY_RUN_CMD cd "$npm_dir" && PATH="${pkgs.nodejs}/bin:$PATH" ${pkgs.nodejs}/bin/npm install
         $DRY_RUN_CMD echo "$current_target" > "$stamp_file"
       fi
     '');

--- a/modules/roles/llm-host.nix
+++ b/modules/roles/llm-host.nix
@@ -1,14 +1,15 @@
+# LLM host role — provides ollama for local LLM hosting
+#
+# Note: ollama itself is installed by modules/services/ollama/darwin.nix
+#       via homebrew. This role exists only to enable the service option.
 {
   config,
   lib,
-  pkgs,
   ...
 }: let
   cfg = config.myConfig.roles.llm-host;
 in {
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = with pkgs; [
-      ollama
-    ];
+    myConfig.ollama.enable = true;
   };
 }

--- a/modules/services/ollama/darwin.nix
+++ b/modules/services/ollama/darwin.nix
@@ -1,14 +1,16 @@
 # Ollama service module for Darwin (macOS)
 #
 # Uses launchd to manage Ollama as a system daemon.
+# Ollama is installed via homebrew — no nixpkgs dependency.
 {
   config,
   lib,
-  pkgs,
+  options,
   ...
 }:
 with lib; let
   cfg = config.myConfig.ollama;
+  hasHomebrew = builtins.hasAttr "homebrew" options;
 
   primaryUser =
     if config.myConfig.users != []
@@ -17,37 +19,40 @@ with lib; let
 
   darwinHomeDir = "/Users/${primaryUser}";
 in {
-  config = mkIf cfg.enable {
-    environment.systemPackages = [pkgs.ollama];
-
-    launchd.daemons.ollama = {
-      command = "${pkgs.ollama}/bin/ollama serve";
-      serviceConfig = {
-        Label = "org.ollama.server";
-        RunAtLoad = true;
-        KeepAlive = true;
-        StandardOutPath = "/tmp/ollama.log";
-        StandardErrorPath = "/tmp/ollama.err";
-        UserName = primaryUser;
-        EnvironmentVariables = {
-          HOME = darwinHomeDir;
-          OLLAMA_HOST = "${cfg.host}:${toString cfg.port}";
-          OLLAMA_KEEPALIVE = "8h";
+  config = mkIf cfg.enable (mkMerge [
+    (optionalAttrs hasHomebrew {
+      homebrew.brews = ["ollama"];
+    })
+    {
+      launchd.daemons.ollama = {
+        command = "ollama serve";
+        serviceConfig = {
+          Label = "org.ollama.server";
+          RunAtLoad = true;
+          KeepAlive = true;
+          StandardOutPath = "/tmp/ollama.log";
+          StandardErrorPath = "/tmp/ollama.err";
+          UserName = primaryUser;
+          EnvironmentVariables = {
+            HOME = darwinHomeDir;
+            OLLAMA_HOST = "${cfg.host}:${toString cfg.port}";
+            OLLAMA_KEEPALIVE = "8h";
+          };
         };
       };
-    };
 
-    system.activationScripts.postActivation.text = mkAfter ''
-      mkdir -p "${darwinHomeDir}/.ollama"
-    '';
+      system.activationScripts.postActivation.text = mkAfter ''
+        mkdir -p "${darwinHomeDir}/.ollama"
+      '';
 
-    myConfig.serviceRegistry = optionalAttrs cfg.enable {
-      ollama = {
-        name = "Ollama";
-        port = cfg.port;
-        launchdLabel = "org.ollama.server";
-        errorLog = "/tmp/ollama.err";
+      myConfig.serviceRegistry = optionalAttrs cfg.enable {
+        ollama = {
+          name = "Ollama";
+          port = cfg.port;
+          launchdLabel = "org.ollama.server";
+          errorLog = "/tmp/ollama.err";
+        };
       };
-    };
-  };
+    }
+  ]);
 }

--- a/modules/services/ollama/darwin.nix
+++ b/modules/services/ollama/darwin.nix
@@ -37,6 +37,7 @@ in {
             HOME = darwinHomeDir;
             OLLAMA_HOST = "${cfg.host}:${toString cfg.port}";
             OLLAMA_KEEPALIVE = "8h";
+            PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
           };
         };
       };

--- a/targets/MegamanX/default.nix
+++ b/targets/MegamanX/default.nix
@@ -86,6 +86,7 @@
         npmPackages = {
           "pi-opencode-provider" = "^0.7.3";
           "pi-web-access" = "^0.10.7";
+          "pi-subagents" = "^0.33.1";
         };
 
         settings = {

--- a/tests/test-roles.nix
+++ b/tests/test-roles.nix
@@ -155,7 +155,7 @@
     opencode = ["opencode" "rtk"];
     claude = ["claude-code" "rtk"];
     pi = ["pi-coding-agent" "rtk"];
-    llm-host = ["ollama"]; # package still installed even though service option removed
+    llm-host = []; # ollama now installed via homebrew, not nixpkgs
     assistant = ["himalaya" "gmailctl"];
     email-backup = ["isync" "notmuch" "restic"];
     # microvm-host packages are NixOS-only (guarded by isNixOS check).


### PR DESCRIPTION
Switches Darwin Ollama installation from nixpkgs to Homebrew, removing the nixpkgs package from the llm-host role and updating tests accordingly.