### PR TITLE
feat: add base-darwin and workstation-darwin archetypes

### DIFF
--- a/library/archetypes/base-darwin.nix
+++ b/library/archetypes/base-darwin.nix
@@ -1,0 +1,19 @@
+# Base Darwin archetype
+#
+# Shared boilerplate for every darwinConfigurations entry:
+# - Main modules directory (roles, common modules)
+# - Darwin OS defaults (dark mode, allowUnfree, no home-manager docs)
+# - Home-manager integration with opnix shared modules
+#
+# This does NOT include the nixpkgs configuration/overlays from flake.nix's
+# `configuration` let-binding — that stays in flake.nix because it references
+# `self` (the flake itself) which is not available via module specialArgs.
+{inputs, ...}: {
+  imports = [
+    ../../modules
+    ../../os/darwin.nix
+    inputs.home-manager.darwinModules.home-manager
+  ];
+
+  home-manager.sharedModules = [inputs.opnix.homeManagerModules.default];
+}

--- a/library/archetypes/workstation-darwin.nix
+++ b/library/archetypes/workstation-darwin.nix
@@ -3,7 +3,11 @@
 # Lightweight LLM stack (gemma3:4b only via Ollama) designed for
 # 24GB machines running other apps alongside — no heavy inference
 # servers, container overlays, or gateway proxies.
-{inputs, ...}: {
+{
+  inputs,
+  lib,
+  ...
+}: {
   imports = [
     ../../modules/roles/homebrew.nix
     ../../modules/services/ollama/darwin.nix
@@ -26,7 +30,7 @@
       port = 11434;
     };
 
-    pi.models.local-ollama = {
+    pi.models.local-ollama = lib.mkDefault {
       name = "Local LLM (gemma3 via Ollama)";
       provider = "openai";
       modelId = "gemma3:4b";

--- a/library/archetypes/workstation-darwin.nix
+++ b/library/archetypes/workstation-darwin.nix
@@ -1,0 +1,36 @@
+# Workstation Darwin archetype — personal developer workstation
+#
+# Lightweight LLM stack (gemma3:4b only via Ollama) designed for
+# 24GB machines running other apps alongside — no heavy inference
+# servers, container overlays, or gateway proxies.
+{inputs, ...}: {
+  imports = [
+    ../../modules/roles/homebrew.nix
+    ../../modules/services/ollama/darwin.nix
+  ];
+
+  myConfig = {
+    skills.superpowersPath = inputs.superpowers or null;
+
+    roles = {
+      developer.enable = true;
+      desktop.enable = true;
+      workstation.enable = true;
+      pi.enable = true;
+      homebrew.enable = true;
+    };
+
+    ollama = {
+      enable = true;
+      host = "127.0.0.1";
+      port = 11434;
+    };
+
+    pi.models.local-ollama = {
+      name = "Local LLM (gemma3 via Ollama)";
+      provider = "openai";
+      modelId = "gemma3:4b";
+      baseUrl = "http://127.0.0.1:11434/v1";
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Add reusable archetype modules for personal Darwin workstations as the foundation of migrating to a community-standard `hosts/` + `profiles/` pattern (replacing the prior `targets/` artisanal approach).

## Changes

- `library/archetypes/base-darwin.nix` (new): shared boilerplate import — `modules/`, `os/darwin`, home-manager, opnix shared modules
- `library/archetypes/workstation-darwin.nix` (new): personal workstation profile with developer/desktop/workstation/pi/homebrew roles, lightweight Ollama stack (gemma3:4b), and pi local model

## Design

Researched community patterns (FilipNowakowicz, bomba5, nix-arbor, NixOS Discourse) before settling on the profiles + per-host approach. Archetypes are composed at the flake level; host files declare only machine-specific deltas.

This is PR 1 of 3 in the target restructuring.