### PR TITLE
refactor: move darwin-server to hosts/ with enriched headless-server archetype

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -300,9 +300,8 @@
           }
           configuration
           ./modules
-          ./modules/services/lume/darwin.nix
           ./os/darwin.nix
-          ./targets/darwin-server
+          ./library/archetypes/headless-server-darwin.nix
           home-manager.darwinModules.home-manager
           {
             home-manager.sharedModules = [
@@ -310,6 +309,7 @@
               inputs.nix-openclaw.homeManagerModules.openclaw
             ];
           }
+          ./hosts/darwin-server
         ];
       };
 

--- a/hosts/darwin-server/default.nix
+++ b/hosts/darwin-server/default.nix
@@ -1,0 +1,289 @@
+# darwin-server — headless macOS server for VM hosting
+# Hardware: Mac M4 with 24GB RAM
+{
+  mkUser,
+  inputs,
+  pkgs,
+  lib,
+  ...
+}: {
+  nixpkgs.hostPlatform = "aarch64-darwin";
+  nixpkgs.config.allowInsecurePredicate = attrs: let
+    pname = attrs.pname or attrs.name or "";
+    fullName = "${pname}-${attrs.version or ""}";
+  in
+    pname
+    == "openclaw"
+    || builtins.elem fullName ["olm-3.2.16"];
+  system.stateVersion = 4;
+  system.primaryUser = "monkey";
+
+  myConfig =
+    mkUser "monkey" "me@willweaver.dev"
+    // {
+      skills.superpowersPath = inputs.superpowers;
+      opencode.model = null;
+      lume = {
+        enable = true;
+        enableBackgroundService = true;
+        port = 7777;
+        enableAutoUpdater = true;
+        prePullImages = ["macos-tahoe-vanilla:latest"];
+      };
+    };
+
+  # Add MegamanX SSH key for passwordless login
+  users.users.monkey.openssh.authorizedKeys.keys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIIxGvpCUmx1UV3K22/+sWLdRknZmlTmQgckoAUCApF8 monkey@MegamanX"
+  ];
+
+  # Allow passwordless sudo for deploy-rs automated deployments
+  security.sudo.extraConfig = lib.mkForce ''
+    Defaults timestamp_timeout=0
+    monkey ALL=(ALL) NOPASSWD: ALL
+  '';
+
+  # OpenClaw wadsworth configuration
+  home-manager.users.monkey.programs.openclaw = {
+    enable = true;
+    documents = ./documents;
+    instances.wadsworth = {
+      enable = true;
+      gatewayPort = 18789;
+      config = {
+        gateway = {
+          mode = "local";
+          bind = "lan";
+        };
+        secrets = {
+          providers = {
+            file = {
+              source = "file";
+              path = "/Users/monkey/.config/openclaw/secrets.json";
+              mode = "json";
+            };
+          };
+          defaults = {file = "file";};
+        };
+        channels.discord = {
+          token = {
+            source = "file";
+            provider = "file";
+            id = "/discord/token";
+          };
+          allowFrom = ["279110923438915586"];
+          dmPolicy = "pairing";
+        };
+        agents.defaults = {
+          model = "ollama/qwen3:14b";
+        };
+      };
+      environment = {
+        OLLAMA_HOST = "127.0.0.1:11434";
+        OLLAMA_API_KEY = "ollama-local";
+      };
+    };
+  };
+
+  # 1Password secrets for wadsworth
+  home-manager.users.monkey.programs.onepassword-secrets = {
+    enable = true;
+    tokenFile = "/Users/monkey/.config/opnix/token";
+    secrets = {
+      openclawDiscordToken = {
+        reference = "op://openclaw/Wadsworth - Discord API Token/credential";
+        path = ".config/openclaw/secrets/discord-token-raw";
+        mode = "0600";
+      };
+    };
+  };
+
+  # Activation script to create JSON secrets file for OpenClaw
+  home-manager.users.monkey.home.activation.createOpenclawSecretsJson = lib.mkForce ''
+    TOKEN_FILE="/Users/monkey/.config/openclaw/secrets/discord-token-raw"
+    SECRETS_JSON="/Users/monkey/.config/openclaw/secrets.json"
+    if [[ -f "$TOKEN_FILE" ]]; then
+      TOKEN=$(cat "$TOKEN_FILE")
+      echo '{"discord":{"token":"'"$TOKEN"'"}}' > "$SECRETS_JSON"
+      chmod 600 "$SECRETS_JSON"
+      echo "OpenClaw secrets.json created/updated"
+    else
+      echo "Note: Discord token file not found (1Password not configured). Run: op signin && opnix sync"
+    fi
+  '';
+
+  # Activation script to fix OpenClaw plugin dependencies
+  home-manager.users.monkey.home.activation.fixOpenclawDeps = lib.mkForce ''
+    PLUGIN_DEPS_DIR="/Users/monkey/.openclaw-wadsworth/plugin-runtime-deps"
+    OPENCLAW_PKG="${pkgs.openclaw}/lib/openclaw"
+    create_openclaw_symlinks() {
+      if [[ -d "$PLUGIN_DEPS_DIR" ]]; then
+        for dir in "$PLUGIN_DEPS_DIR"/openclaw-*/; do
+          if [[ -d "$dir/node_modules" ]] && [[ ! -e "$dir/node_modules/openclaw" ]]; then
+            if [[ -d "$OPENCLAW_PKG" ]]; then
+              ln -sf "$OPENCLAW_PKG" "$dir/node_modules/openclaw"
+              echo "Created symlink for openclaw package in: $dir"
+            fi
+          fi
+        done
+      fi
+    }
+    create_openclaw_symlinks
+    (sleep 10 && create_openclaw_symlinks) &
+  '';
+
+  # Fix openclaw script
+  home-manager.users.monkey.home.file.".local/bin/fix-openclaw-deps" = {
+    executable = true;
+    text = ''
+      #!/bin/bash
+      PLUGIN_DEPS_DIR="/Users/monkey/.openclaw-wadsworth/plugin-runtime-deps"
+      OPENCLAW_PKG="${pkgs.openclaw}/lib/openclaw"
+      if [[ -d "$PLUGIN_DEPS_DIR" ]]; then
+        for dir in "$PLUGIN_DEPS_DIR"/openclaw-*/; do
+          if [[ -d "$dir/node_modules" ]] && [[ ! -e "$dir/node_modules/openclaw" ]]; then
+            if [[ -d "$OPENCLAW_PKG" ]]; then
+              ln -sf "$OPENCLAW_PKG" "$dir/node_modules/openclaw"
+              echo "Created symlink in: $dir"
+            fi
+          fi
+        done
+      fi
+      echo "OpenClaw plugin dependencies fixed. Restart the service with:"
+      echo "  launchctl kickstart -k gui/$(id -u)/com.steipete.openclaw.gateway.wadsworth"
+    '';
+  };
+
+  home-manager.users.monkey.home.file.".local/bin/fix-openclaw-plist" = {
+    executable = true;
+    text = ''
+      #!/bin/bash
+      PLIST="$HOME/Library/LaunchAgents/com.steipete.openclaw.gateway.wadsworth.plist"
+      LOG_DIR="$HOME/.openclaw-wadsworth/logs"
+      if [[ ! -f "$PLIST" ]]; then
+        echo "Error: Plist not found at $PLIST"
+        exit 1
+      fi
+      mkdir -p "$LOG_DIR"
+      chmod 644 "$PLIST" 2>/dev/null || true
+      /usr/libexec/PlistBuddy -c "Set :StandardOutPath $LOG_DIR/openclaw-gateway-wadsworth.log" "$PLIST" 2>/dev/null || \
+        /usr/libexec/PlistBuddy -c "Add :StandardOutPath string $LOG_DIR/openclaw-gateway-wadsworth.log" "$PLIST"
+      /usr/libexec/PlistBuddy -c "Set :StandardErrorPath $LOG_DIR/openclaw-gateway-wadsworth.log" "$PLIST" 2>/dev/null || \
+        /usr/libexec/PlistBuddy -c "Add :StandardErrorPath string $LOG_DIR/openclaw-gateway-wadsworth.log" "$PLIST"
+      PROGRAM_ARGS="/nix/store/in4yc03diyvs2n2wgf3nva4hbvml8v1j-bash-interactive-5.3p9/bin/bash"
+      /usr/libexec/PlistBuddy -c "Set :ProgramArguments:0 $PROGRAM_ARGS" "$PLIST"
+      echo "OpenClaw plist fixed. Reload: launchctl unload $PLIST && launchctl load $PLIST"
+    '';
+  };
+
+  home-manager.users.monkey.home.activation.fixOpenclawPlist = lib.mkForce ''
+    export PATH="/usr/bin:/bin:$PATH"
+    PLIST="/Users/monkey/Library/LaunchAgents/com.steipete.openclaw.gateway.wadsworth.plist"
+    LOG_DIR="/Users/monkey/.openclaw-wadsworth/logs"
+    NEEDS_RESTART=false
+    if [[ -f "$PLIST" ]]; then
+      mkdir -p "$LOG_DIR"
+      chmod 644 "$PLIST" 2>/dev/null || true
+      /usr/libexec/PlistBuddy -c "Set :StandardOutPath /Users/monkey/.openclaw-wadsworth/logs/openclaw-gateway-wadsworth.log" "$PLIST" 2>/dev/null || true
+      /usr/libexec/PlistBuddy -c "Set :StandardErrorPath /Users/monkey/.openclaw-wadsworth/logs/openclaw-gateway-wadsworth.log" "$PLIST" 2>/dev/null || true
+      /usr/libexec/PlistBuddy -c "Set :ProgramArguments:0 /nix/store/in4yc03diyvs2n2wgf3nva4hbvml8v1j-bash-interactive-5.3p9/bin/bash" "$PLIST" 2>/dev/null || true
+      CURRENT_CMD=$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:2" "$PLIST" 2>/dev/null || echo "")
+      if [[ -n "$CURRENT_CMD" ]] && [[ "$CURRENT_CMD" != *"--host"* ]]; then
+        FIXED_CMD=$(echo "$CURRENT_CMD" | sed 's/gateway --port/gateway --host 0.0.0.0 --port/')
+        /usr/libexec/PlistBuddy -c "Set :ProgramArguments:2 $FIXED_CMD" "$PLIST" 2>/dev/null || true
+        echo "OpenClaw gateway bind fixed: added --host 0.0.0.0"
+        NEEDS_RESTART=true
+      fi
+      chmod 444 "$PLIST" 2>/dev/null || true
+      if [[ "$NEEDS_RESTART" == "true" ]]; then
+        if launchctl list | grep -q "com.steipete.openclaw.gateway.wadsworth"; then
+          launchctl unload "$PLIST" 2>/dev/null || true
+          sleep 1
+          launchctl load "$PLIST" 2>/dev/null || true
+          echo "OpenClaw gateway restarted"
+        fi
+      fi
+    fi
+  '';
+
+  # Background fix-openclaw-deps daemon
+  launchd.agents.fix-openclaw-deps = {
+    serviceConfig = {
+      Label = "com.funkymonkeymonk.fix-openclaw-deps";
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "-c"
+        ''
+          PLUGIN_DEPS_DIR="/Users/monkey/.openclaw-wadsworth/plugin-runtime-deps"
+          OPENCLAW_PKG="${pkgs.openclaw}/lib/openclaw"
+          while true; do
+            if [[ -d "$PLUGIN_DEPS_DIR" ]]; then
+              for dir in "$PLUGIN_DEPS_DIR"/openclaw-*/; do
+                if [[ -d "$dir/node_modules" && ! -e "$dir/node_modules/openclaw" ]]; then
+                  ln -sf "$OPENCLAW_PKG" "$dir/node_modules/openclaw"
+                  logger "Created openclaw symlink in: $dir"
+                fi
+              done
+            fi
+            sleep 5
+          done
+        ''
+      ];
+      RunAtLoad = true;
+      KeepAlive = true;
+      StandardOutPath = "/tmp/fix-openclaw-deps.log";
+      StandardErrorPath = "/tmp/fix-openclaw-deps.log";
+    };
+  };
+
+  # Cloud-init support
+  launchd.daemons.apply-cloud-init = {
+    serviceConfig = {
+      Label = "com.funkymonkeymonk.cloud-init";
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "-c"
+        ''
+          set -e
+          CONFIG_FILE="/etc/cloud-init.yaml"
+          LOG_FILE="/var/log/cloud-init.log"
+          log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $1" | tee -a "$LOG_FILE"; }
+          if [[ -f "$CONFIG_FILE" ]]; then
+            log "Applying cloud-init configuration from $CONFIG_FILE"
+            hostname=$(grep -E '^hostname:' "$CONFIG_FILE" | head -1 | sed 's/^hostname:[[:space:]]*//' | tr -d '"' | tr -d "'" | tr -d '[:space:]')
+            if [[ -n "$hostname" ]]; then
+              scutil --set HostName "$hostname"
+              scutil --set LocalHostName "$hostname"
+              scutil --set ComputerName "$hostname"
+              log "Set hostname to: $hostname"
+            fi
+            log "Cloud-init configuration applied successfully"
+          else
+            log "No cloud-init configuration found at $CONFIG_FILE"
+          fi
+        ''
+      ];
+      RunAtLoad = true;
+      StandardOutPath = "/var/log/cloud-init.stdout";
+      StandardErrorPath = "/var/log/cloud-init.stderr";
+    };
+  };
+
+  system.activationScripts.cloud-init = {
+    text = ''
+      echo "Applying cloud-init configuration during activation..."
+      CONFIG_FILE="/etc/cloud-init.yaml"
+      if [[ -f "$CONFIG_FILE" ]]; then
+        hostname=$(grep -E '^hostname:' "$CONFIG_FILE" | head -1 | sed 's/^hostname:[[:space:]]*//' | tr -d '"' | tr -d "'" | tr -d '[:space:]')
+        if [[ -n "$hostname" ]]; then
+          scutil --set HostName "$hostname"
+          scutil --set LocalHostName "$hostname"
+          scutil --set ComputerName "$hostname"
+        fi
+        echo "Cloud-init configuration applied during activation"
+      else
+        echo "No cloud-init configuration found at $CONFIG_FILE"
+      fi
+    '';
+  };
+}

--- a/hosts/darwin-server/documents/AGENTS.md
+++ b/hosts/darwin-server/documents/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md - Agent Instructions
+
+## Identity
+You are an AI assistant running via OpenClaw gateway on macOS.
+You help the user accomplish tasks through natural conversation.
+
+## Capabilities
+- Execute shell commands
+- Read and write files
+- Control macOS applications
+- Take screenshots
+- Process text and data
+- Access web resources
+- Manage system services
+
+## Constraints
+- Always ask for permission before destructive operations
+- Never send messages (email, SMS, iMessage) without explicit confirmation
+- Show full message content and ask "Send? (y/n)" before sending
+- Prefer explicit, readable solutions over clever one-liners
+- When in doubt, ask rather than guess
+
+## Communication Style
+- Be concise but complete
+- Use bullet points for lists
+- Show commands before executing them when possible
+- Explain the "why" behind recommendations
+- If something will take time, say so upfront
+
+## Security
+- Never expose secrets or API keys in responses
+- Use /run/agenix/ paths for sensitive files
+- Prefer Nix-managed configurations over manual edits
+- Follow principle of least privilege

--- a/hosts/darwin-server/documents/HEARTBEAT.md
+++ b/hosts/darwin-server/documents/HEARTBEAT.md
@@ -1,0 +1,44 @@
+# HEARTBEAT.md - Health and Monitoring
+
+## Service Status
+Check if OpenClaw gateway is running:
+```bash
+launchctl print gui/$UID/com.steipete.openclaw.gateway | grep state
+```
+
+## Logs
+View recent gateway logs:
+```bash
+tail -50 /tmp/openclaw/openclaw-gateway.log
+```
+
+## Restart Service
+If the gateway needs restarting:
+```bash
+launchctl kickstart -k gui/$UID/com.steipete.openclaw.gateway
+```
+
+## Update Configuration
+After editing flake.nix:
+```bash
+cd ~/code/openclaw-local
+home-manager switch --flake .#monkey
+```
+
+## Common Issues
+- **Service not starting**: Check logs for config errors
+- **Bot not responding**: Verify Telegram token and chat ID
+- **Tools not found**: Ensure plugins are enabled in flake.nix
+
+## Health Check
+A healthy system should show:
+- Gateway service: "state = running"
+- Bot responds to /start command
+- Logs show no errors
+- Home Manager generation exists
+
+## Recovery
+If something breaks:
+1. Check logs: `tail -f /tmp/openclaw/openclaw-gateway.log`
+2. Rollback: `home-manager switch --rollback`
+3. Restart: `launchctl kickstart -k gui/$UID/com.steipete.openclaw.gateway`

--- a/hosts/darwin-server/documents/IDENTITY.md
+++ b/hosts/darwin-server/documents/IDENTITY.md
@@ -1,0 +1,23 @@
+# IDENTITY.md - Self-Knowledge
+
+## What I Am
+An AI assistant powered by Claude, running through the OpenClaw gateway on macOS.
+I operate as a system-integrated agent with access to shell commands, file operations,
+and various tools through a Telegram chat interface.
+
+## How I Work
+1. Receive messages via Telegram bot
+2. Process through OpenClaw gateway
+3. Execute tools/commands as needed
+4. Respond with results
+
+## My Purpose
+To help the user accomplish tasks more efficiently by:
+- Automating repetitive operations
+- Providing quick access to system capabilities
+- Offering technical guidance and solutions
+- Managing configurations and services
+
+## Evolution
+This identity evolves as I learn the user's preferences and patterns.
+Updates should be made collaboratively, with the user approving changes.

--- a/hosts/darwin-server/documents/LORE.md
+++ b/hosts/darwin-server/documents/LORE.md
@@ -1,0 +1,27 @@
+# LORE.md - History and Context
+
+## Project Genesis
+This OpenClaw installation was set up on April 11, 2026.
+It represents a move toward declarative, reproducible AI assistant configuration.
+
+## System Philosophy
+- Nix-first approach to all system management
+- Documentation lives with configuration
+- Secrets managed separately from code
+- Version control for all configuration changes
+
+## Key Decisions
+1. **Platform**: macOS with Apple Silicon - native app support, Unix environment
+2. **Package Manager**: Determinate Nix - reproducible, declarative, rollback-capable
+3. **Configuration**: Home Manager - user-level declarative management
+4. **Interface**: Telegram - accessible from anywhere, simple bot model
+
+## Evolution Notes
+- Initial setup: Basic gateway with essential plugins
+- Future: Additional plugins as needs emerge
+- Goal: Fully automated, self-documenting system
+
+## References
+- Repository: github:openclaw/nix-openclaw
+- Documentation: ~/code/openclaw-local/documents/
+- Configuration: ~/code/openclaw-local/flake.nix

--- a/hosts/darwin-server/documents/PROMPTING-EXAMPLES.md
+++ b/hosts/darwin-server/documents/PROMPTING-EXAMPLES.md
@@ -1,0 +1,76 @@
+# PROMPTING-EXAMPLES.md - Effective Usage Patterns
+
+## Basic Interactions
+
+### System Information
+"What's my current system status?"
+- Check disk space, memory, uptime
+- Show running services
+
+### File Operations
+"Show me the contents of ~/Documents"
+- List files, show sizes, recent modifications
+
+### Web Queries
+"Check if github.com is up"
+- Use curl to test connectivity
+
+## Advanced Patterns
+
+### Development Tasks
+"Update my Nix flake and switch"
+```
+cd ~/code/openclaw-local
+# Update inputs
+nix flake update
+# Switch to new generation
+home-manager switch --flake .#monkey
+```
+
+### Troubleshooting
+"The gateway isn't responding, check logs"
+```
+tail -100 /tmp/openclaw/openclaw-gateway.log
+# Look for errors
+launchctl print gui/$UID/com.steipete.openclaw.gateway | grep state
+```
+
+### System Maintenance
+"Clean up old Nix generations"
+```
+# List generations
+home-manager generations
+# Delete older than 30 days
+nix-collect-garbage --delete-older-than 30d
+```
+
+## Best Practices
+
+### Be Specific
+- Good: "Show me the last 10 lines of the gateway log"
+- Vague: "Check the logs" (which logs?)
+
+### Provide Context
+- Good: "I just edited flake.nix, can you verify the syntax?"
+- Missing context: "Check if it's right"
+
+### Ask for Confirmation
+- Good: "I need to delete 3 files: a.txt, b.txt, c.txt. Proceed? (y/n)"
+- Risky: (deletes without asking)
+
+### Chain Operations
+"Update the system: pull latest config, update flake, switch, verify"
+- Multi-step with verification at each stage
+
+## Things I Handle Well
+- Configuration management (Nix/home-manager)
+- File and system operations
+- Service management
+- Development workflows
+- Troubleshooting and diagnostics
+
+## Things to Ask a Human
+- Complex architectural decisions
+- Security policy changes
+- Irreversible destructive operations
+- Personal or sensitive matters

--- a/hosts/darwin-server/documents/SOUL.md
+++ b/hosts/darwin-server/documents/SOUL.md
@@ -1,0 +1,32 @@
+# SOUL.md - Personality and Values
+
+## Core Identity
+I am a helpful AI assistant integrated deeply into the user's macOS system.
+I bridge natural language and system capabilities through the OpenClaw gateway.
+
+## Values
+1. **Helpfulness First**: The user's goals are paramount
+2. **Transparency**: Explain what I'm doing and why
+3. **Safety**: Protect the user from accidental harm
+4. **Efficiency**: Get things done with minimal friction
+5. **Learning**: Adapt to the user's patterns over time
+
+## Personality Traits
+- Professional but approachable
+- Technically proficient
+- Patient with explanations
+- Proactive about suggesting improvements
+- Respectful of user's time and attention
+
+## Interaction Style
+- Start with the direct answer, elaborate if needed
+- Use examples to illustrate concepts
+- Admit when I don't know something
+- Offer alternatives when the ideal path is blocked
+- Celebrate successes, learn from failures
+
+## Boundaries
+- I don't pretend to be human
+- I don't make commitments on behalf of the user
+- I don't access or share data without clear purpose
+- I respect the user's right to privacy and control

--- a/hosts/darwin-server/documents/TOOLS.md
+++ b/hosts/darwin-server/documents/TOOLS.md
@@ -1,0 +1,43 @@
+# TOOLS.md - Available Tools and Commands
+
+## System Tools
+- `nix` - Nix package manager
+- `home-manager` - User environment management
+- `darwin-rebuild` - macOS system configuration (if nix-darwin)
+- `launchctl` - macOS service management
+- `systemctl` - Service control (Linux only)
+
+## File Operations
+- `ls`, `cat`, `find`, `grep`, `rg` (ripgrep)
+- `cp`, `mv`, `rm`, `mkdir`
+- `jq` - JSON processing
+- `curl` - HTTP requests
+
+## Development Tools
+- `git` - Version control
+- `nodejs`, `pnpm` - JavaScript/TypeScript
+- `python3` - Python scripting
+- `ffmpeg` - Media processing
+
+## macOS-Specific Tools
+- `osascript` - AppleScript/JS for automation
+- `screencapture` - Screenshots
+- `open` - Open files/URLs/apps
+- `pbpaste`, `pbcopy` - Clipboard access
+
+## Media and AI Tools
+- `whisper` - Audio transcription (OpenAI)
+- `spotify-player` - Spotify control
+- `peekaboo` - Screenshots (if enabled)
+- `camsnap` - Camera snapshots (if enabled)
+
+## Network Tools
+- `curl`, `wget` - HTTP clients
+- `ssh` - Remote access
+- `ping`, `netstat` - Network diagnostics
+
+## How to Use Tools
+- Always check if a tool is available before using it
+- Prefer Nix-managed tools over system defaults
+- Use explicit paths for scripts and binaries
+- Document any custom tool installations

--- a/hosts/darwin-server/documents/USER.md
+++ b/hosts/darwin-server/documents/USER.md
@@ -1,0 +1,29 @@
+# USER.md - User Profile
+
+## Identity
+- **Name**: monkey
+- **System**: macOS on Apple Silicon (aarch64-darwin)
+- **Primary Interface**: Telegram via OpenClaw
+
+## Technical Background
+- Uses Nix for system configuration
+- Prefers declarative, version-controlled setups
+- Comfortable with command line operations
+- Values automation and efficiency
+
+## Preferences
+- Permission-based execution for sensitive operations
+- Clear explanations before actions
+- Concise responses with details available on request
+- Documentation kept alongside configurations
+
+## Communication Style
+- Direct and practical
+- Appreciates technical accuracy
+- Open to suggestions for improvement
+- Values system reliability
+
+## Notes
+- Keep configurations in ~/code/
+- Use Nix/home-manager for environment management
+- Prefer Nix-managed tools over Homebrew where possible

--- a/library/archetypes/headless-server-darwin.nix
+++ b/library/archetypes/headless-server-darwin.nix
@@ -1,18 +1,66 @@
-{inputs, ...}: {
+# Headless Darwin server archetype
+#
+# Generic headless macOS server profile:
+# - SSH hardened (keys only, no root)
+# - Lume VM runtime for macOS VMs
+# - Developer & opencode tools for remote management
+# - No heavy LLM stack (remote APIs only)
+{
+  inputs,
+  pkgs,
+  ...
+}: {
+  imports = [
+    ../../modules/services/lume/darwin.nix
+  ];
+
   myConfig = {
     skills.superpowersPath = inputs.superpowers or null;
+
+    roles = {
+      developer.enable = true; # Basic dev tools for VM management
+      opencode.enable = true; # AI assistant for management tasks
+    };
+
+    opencode = {
+      enable = true;
+      model = null; # User selects on first run
+    };
+
+    llmClient.rtk.enable = true;
+
+    lume = {
+      enable = true;
+      enableBackgroundService = true;
+      port = 7777;
+      enableAutoUpdater = true;
+      prePullImages = ["macos-tahoe-vanilla:latest"];
+    };
   };
 
-  users.users.root.openssh.authorizedKeys.keys = [];
-
+  # SSH hardening (Darwin uses extraConfig, not settings.)
   services.openssh = {
     enable = true;
     extraConfig = ''
       PermitRootLogin no
+      PubkeyAuthentication yes
       PasswordAuthentication no
       AllowAgentForwarding yes
     '';
   };
+
+  users.users.root.openssh.authorizedKeys.keys = [];
+
+  # Passwordless sudo for remote deployment (deploy-rs)
+  security.sudo.extraConfig = ''
+    Defaults timestamp_timeout=0
+  '';
+
+  # Basic management tools
+  environment.systemPackages = with pkgs; [
+    curl
+    jq
+  ];
 
   time.timeZone = "America/New_York";
 }


### PR DESCRIPTION
Stacked on #348 (archetypes).

- Enrich `headless-server-darwin` archetype with Lume VM hosting, developer/opencode roles, SSH hardening
- Move darwin-server target to `hosts/darwin-server/` as a lean host file (only OpenClaw-specific config)
- Remove `targets/darwin-server/` directory