### PR TITLE
fix(homebrew): disable autoMigrate to prevent conflict with manual homebrew-core clone

### DIFF
--- a/modules/roles/homebrew.nix
+++ b/modules/roles/homebrew.nix
@@ -20,7 +20,10 @@ in {
       nix-homebrew = {
         enable = true;
         user = (builtins.head config.myConfig.users).name;
-        autoMigrate = mkDefault true;
+        # autoMigrate disabled: we manage homebrew-core as a real git clone
+        # so `brew update` works. nix-homebrew handles casks/brews installation
+        # without taking over the tap infrastructure.
+        autoMigrate = false;
       };
     })
     # homebrew casks (only if homebrew option exists)


### PR DESCRIPTION
After switching ollama to Homebrew, we cloned homebrew-core as a real git repo so `brew update` works. nix-homebrew's autoMigrate tries to replace this with a nix-store symlink, causing the switch to fail with:

> Error: An existing /opt/homebrew/Library/Taps/homebrew/homebrew-core is in the way

Disable autoMigrate since we now manage taps manually. nix-homebrew still handles cask/brew installation.