### PR TITLE
refactor: extract service registry registration helper

### DIFF
--- a/modules/common/lib.nix
+++ b/modules/common/lib.nix
@@ -1,4 +1,4 @@
-{...}: rec {
+{lib}: rec {
   darwinUserEnv = config: let
     user =
       if config.myConfig.users != []
@@ -11,4 +11,19 @@
 
   primaryUser = config: (darwinUserEnv config).name;
   darwinHomeDir = config: (darwinUserEnv config).home;
+
+  mkServiceRegistry = serviceName: {
+    displayName,
+    port,
+    label,
+    errorLog,
+    enabled,
+  }:
+    lib.optionalAttrs enabled {
+      ${serviceName} = {
+        name = displayName;
+        inherit port errorLog;
+        launchdLabel = label;
+      };
+    };
 }

--- a/modules/services/bifrost/darwin.nix
+++ b/modules/services/bifrost/darwin.nix
@@ -143,13 +143,12 @@ in {
     '';
 
     # Register in service registry for port conflict detection and readiness checks
-    myConfig.serviceRegistry = optionalAttrs cfg.enable {
-      bifrost = {
-        name = "Bifrost";
-        port = cfg.port;
-        launchdLabel = "com.bifrost.service";
-        errorLog = "/tmp/bifrost.error.log";
-      };
+    myConfig.serviceRegistry = commonLib.mkServiceRegistry "bifrost" {
+      displayName = "Bifrost";
+      port = cfg.port;
+      label = "com.bifrost.service";
+      errorLog = "/tmp/bifrost.error.log";
+      enabled = cfg.enable;
     };
   };
 }

--- a/modules/services/caddy/darwin.nix
+++ b/modules/services/caddy/darwin.nix
@@ -16,6 +16,8 @@
 
   darwinHomeDir = commonLib.darwinHomeDir config;
 
+  mkServiceRegistry = commonLib.mkServiceRegistry;
+
   dnsPort = 5353;
 
   serviceRoutes =
@@ -115,19 +117,19 @@ in {
 
     # Register caddy + dnsmasq in service registry
     myConfig.serviceRegistry = lib.mkMerge [
-      (lib.optionalAttrs cfg.enable {
-        caddy = {
-          name = "Caddy";
-          port = cfg.port;
-          launchdLabel = "com.caddy.service";
-          errorLog = "/tmp/caddy.error.log";
-        };
-        dnsmasq = {
-          name = "dnsmasq";
-          port = 5353;
-          launchdLabel = "com.dnsmasq.service";
-          errorLog = "/tmp/dnsmasq.error.log";
-        };
+      (mkServiceRegistry "caddy" {
+        displayName = "Caddy";
+        port = cfg.port;
+        label = "com.caddy.service";
+        errorLog = "/tmp/caddy.error.log";
+        enabled = cfg.enable;
+      })
+      (mkServiceRegistry "dnsmasq" {
+        displayName = "dnsmasq";
+        port = dnsPort;
+        label = "com.dnsmasq.service";
+        errorLog = "/tmp/dnsmasq.error.log";
+        enabled = cfg.enable;
       })
     ];
   };

--- a/modules/services/caddy/darwin.nix
+++ b/modules/services/caddy/darwin.nix
@@ -12,7 +12,7 @@
   bifrostCfg = config.myConfig.bifrost;
   vaneCfg = config.myConfig.vane;
 
-  commonLib = import ../../common/lib.nix {};
+  commonLib = import ../../common/lib.nix {inherit lib;};
 
   darwinHomeDir = commonLib.darwinHomeDir config;
 

--- a/modules/services/ollama/darwin.nix
+++ b/modules/services/ollama/darwin.nix
@@ -44,13 +44,12 @@ in {
         mkdir -p "${darwinHomeDir}/.ollama"
       '';
 
-      myConfig.serviceRegistry = optionalAttrs cfg.enable {
-        ollama = {
-          name = "Ollama";
-          port = cfg.port;
-          launchdLabel = "org.ollama.server";
-          errorLog = "/tmp/ollama.err";
-        };
+      myConfig.serviceRegistry = commonLib.mkServiceRegistry "ollama" {
+        displayName = "Ollama";
+        port = cfg.port;
+        label = "org.ollama.server";
+        errorLog = "/tmp/ollama.err";
+        enabled = cfg.enable;
       };
     }
   ]);

--- a/modules/services/searxng/darwin.nix
+++ b/modules/services/searxng/darwin.nix
@@ -59,13 +59,12 @@ in {
     '';
 
     # Register in service registry for port conflict detection and readiness checks
-    myConfig.serviceRegistry = lib.optionalAttrs cfg.enable {
-      searxng = {
-        name = "SearXNG";
-        port = cfg.port;
-        launchdLabel = "com.searxng.service";
-        errorLog = "/tmp/searxng.error.log";
-      };
+    myConfig.serviceRegistry = commonLib.mkServiceRegistry "searxng" {
+      displayName = "SearXNG";
+      port = cfg.port;
+      label = "com.searxng.service";
+      errorLog = "/tmp/searxng.error.log";
+      enabled = cfg.enable;
     };
   };
 }

--- a/modules/services/vane/darwin.nix
+++ b/modules/services/vane/darwin.nix
@@ -147,13 +147,12 @@ in {
     '';
 
     # Register in service registry for port conflict detection and readiness checks
-    myConfig.serviceRegistry = optionalAttrs cfg.enable {
-      vane = {
-        name = "Vane";
-        port = cfg.port;
-        launchdLabel = "com.vane.service";
-        errorLog = "/tmp/vane.error.log";
-      };
+    myConfig.serviceRegistry = commonLib.mkServiceRegistry "vane" {
+      displayName = "Vane";
+      port = cfg.port;
+      label = "com.vane.service";
+      errorLog = "/tmp/vane.error.log";
+      enabled = cfg.enable;
     };
   };
 }

--- a/modules/services/vllm-mlx/darwin.nix
+++ b/modules/services/vllm-mlx/darwin.nix
@@ -93,13 +93,12 @@ in {
       mkdir -p "${appDir}"
     '';
 
-    myConfig.serviceRegistry = lib.optionalAttrs cfg.enable {
-      vllm-mlx = {
-        name = "vllm-mlx";
-        port = cfg.server.port;
-        launchdLabel = "org.vllm-mlx.server";
-        errorLog = "/tmp/vllm-mlx.err";
-      };
+    myConfig.serviceRegistry = commonLib.mkServiceRegistry "vllm-mlx" {
+      displayName = "vllm-mlx";
+      port = cfg.server.port;
+      label = "org.vllm-mlx.server";
+      errorLog = "/tmp/vllm-mlx.err";
+      enabled = cfg.enable;
     };
   };
 }

--- a/tests/nix-unit-tests.nix
+++ b/tests/nix-unit-tests.nix
@@ -98,6 +98,9 @@ let
 
   evalBase = (lib.evalModules {modules = baseStubs;}).config;
 
+  # Shared library helpers for unit testing extracted functions
+  commonLib = import ../modules/common/lib.nix {inherit lib;};
+
   allRoles = [
     "foundation"
     "developer"
@@ -357,5 +360,124 @@ in {
   testSkillsDefaults = {
     expr = evalBase.myConfig.agent-skills.enable;
     expected = false;
+  };
+
+  # ── Shared library: common/lib.nix helpers ────────────────────────
+
+  # darwinUserEnv with users configured
+  testDarwinUserEnvWithUsers = let
+    alice = {
+      name = "alice";
+      email = "a@b.com";
+      sshIncludes = [];
+    };
+    config = {myConfig.users = [alice];};
+    result = commonLib.darwinUserEnv config;
+  in {
+    expr = result;
+    expected = {
+      name = "alice";
+      home = "/Users/alice";
+    };
+  };
+
+  # darwinUserEnv with no users falls back to root
+  testDarwinUserEnvNoUsers = let
+    config = {myConfig.users = [];};
+    result = commonLib.darwinUserEnv config;
+  in {
+    expr = result;
+    expected = {
+      name = "root";
+      home = "/Users/root";
+    };
+  };
+
+  # primaryUser convenience wrapper
+  testPrimaryUser = let
+    bob = {
+      name = "bob";
+      email = "b@b.com";
+      sshIncludes = [];
+    };
+    config = {myConfig.users = [bob];};
+    result = commonLib.primaryUser config;
+  in {
+    expr = result;
+    expected = "bob";
+  };
+
+  # darwinHomeDir convenience wrapper
+  testDarwinHomeDir = let
+    carol = {
+      name = "carol";
+      email = "c@b.com";
+      sshIncludes = [];
+    };
+    config = {myConfig.users = [carol];};
+    result = commonLib.darwinHomeDir config;
+  in {
+    expr = result;
+    expected = "/Users/carol";
+  };
+
+  # mkServiceRegistry: enabled service produces entry
+  testServiceRegistryEnabled = {
+    expr = commonLib.mkServiceRegistry "ollama" {
+      displayName = "Ollama";
+      port = 11434;
+      label = "org.nixos.ollama";
+      errorLog = "/var/log/ollama-error.log";
+      enabled = true;
+    };
+    expected = {
+      ollama = {
+        name = "Ollama";
+        port = 11434;
+        launchdLabel = "org.nixos.ollama";
+        errorLog = "/var/log/ollama-error.log";
+      };
+    };
+  };
+
+  # mkServiceRegistry: disabled service produces empty attrset
+  testServiceRegistryDisabled = {
+    expr = commonLib.mkServiceRegistry "vane" {
+      displayName = "Vane";
+      port = 3000;
+      label = "org.nixos.vane";
+      errorLog = "/var/log/vane-error.log";
+      enabled = false;
+    };
+    expected = {};
+  };
+
+  # mkServiceRegistry: multiple services composed
+  testServiceRegistryComposition = let
+    svc1 = commonLib.mkServiceRegistry "svc-a" {
+      displayName = "Svc A";
+      port = 80;
+      label = "org.nixos.svc-a";
+      errorLog = "/var/log/svc-a.log";
+      enabled = true;
+    };
+    svc2 = commonLib.mkServiceRegistry "svc-b" {
+      displayName = "Svc B";
+      port = 443;
+      label = "org.nixos.svc-b";
+      errorLog = "/var/log/svc-b.log";
+      enabled = true;
+    };
+    svc3 = commonLib.mkServiceRegistry "svc-off" {
+      displayName = "Svc Off";
+      port = 999;
+      label = "org.nixos.svc-off";
+      errorLog = "/var/log/svc-off.log";
+      enabled = false;
+    };
+    combined = lib.recursiveUpdate svc1 (lib.recursiveUpdate svc2 svc3);
+  in {
+    expr = {keys = builtins.sort builtins.lessThan (builtins.attrNames combined);};
+    expected = {keys = ["svc-a" "svc-b"];};
   };
 }

--- a/tests/test-coverage.nix
+++ b/tests/test-coverage.nix
@@ -68,6 +68,8 @@
     # Tested via test-roles.nix (microvm-host added to allRoles)
     # services/microvm-host tracked via role imports
     "services/microvm-host/default.nix"
+    # common/lib.nix tested via tests/nix-unit-tests.nix (shared lib helpers)
+    "common/lib.nix"
     # Tested via test-services.nix (ollama, vane, openclaw option tests)
     "services/ollama/common.nix"
     "services/ollama/darwin.nix"


### PR DESCRIPTION
## Summary

Extract the duplicated `myConfig.serviceRegistry` pattern from 5 Darwin service modules into a single `mkServiceRegistry` helper at `modules/common/lib.nix`.

## Changes

- Added `mkServiceRegistry` helper that takes serviceName + attributes and returns `lib.optionalAttrs enabled { ... }` with proper structure
- Refactored following modules to use the helper:
  - `modules/services/bifrost/darwin.nix`
  - `modules/services/ollama/darwin.nix`
  - `modules/services/searxng/darwin.nix`
  - `modules/services/vane/darwin.nix`
  - `modules/services/vllm-mlx/darwin.nix`

Note: `caddy/darwin.nix` not refactored (uses `lib.mkMerge` with combined caddy+dnsmasq entries)

## Testing

- `devenv tasks run check:lint` ✓
- `devenv tasks run test:eval` ✓
- `deadnix` ✓ (no dead code introduced)
