### PR TITLE
feat: manage global AGENTS.md via Nix with per-machine override support

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1780630679,
-        "narHash": "sha256-hhQyVAYmNKziZ0T+T4Gsk0PYmnz4vdzOzpkJAmDASKM=",
+        "lastModified": 1783538213,
+        "narHash": "sha256-jNjKlmrejUrBgVAeiavlMLlkmC7ZEv1D9nhfuwMW5Q8=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "90ed6227ab389dd4e874a69a724f25dba312b754",
+        "rev": "d1fb321e73048d0e1e2b523580268ebb3df2ae90",
         "type": "github"
       },
       "original": {
@@ -36,43 +36,21 @@
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -81,11 +59,11 @@
         "nixpkgs-src": "nixpkgs-src"
       },
       "locked": {
-        "lastModified": 1778507786,
-        "narHash": "sha256-HzSQCKMsMr8r55LwM1JuzIOB+8bzk0FEv6sItKvsfoY=",
+        "lastModified": 1783345554,
+        "narHash": "sha256-LZhOm4kqjHUnwP4CNHpaqqEVcumGNd1PvOEOad8LkS0=",
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "8f24a228a782e24576b155d1e39f0d914b380691",
+        "rev": "6004ea8c229fe9d41b21c6f4c76bf6c2e10771dd",
         "type": "github"
       },
       "original": {
@@ -98,11 +76,11 @@
     "nixpkgs-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778274207,
-        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       },
       "original": {

--- a/modules/common/AGENTS.md
+++ b/modules/common/AGENTS.md
@@ -1,0 +1,22 @@
+# Global OpenCode Rules
+
+## Language & Communication
+
+- **Always respond in English** regardless of user input language
+- Write all documentation, code comments, and explanations in English
+
+## Version Control (jj)
+
+Repositories use Jujutsu (jj) for version control. Follow this discipline on every turn:
+
+1. **Start of turn** — run `jj status` first.
+   - If the working copy has uncommitted changes with no description, review them and `jj describe -m "..."` before proceeding.
+   - If the working copy is empty (no description set), proceed — you're already on a clean slate.
+
+2. **During the turn** — make changes freely. The working copy is always a commit in jj.
+
+3. **End of turn** — if any changes were made:
+   - `jj describe -m "<conventional-commit message>"` to name the commit.
+   - `jj new` to leave an empty commit ready for the next turn.
+
+4. **Never push** unless the user explicitly asks.

--- a/modules/common/options.nix
+++ b/modules/common/options.nix
@@ -342,6 +342,16 @@ with lib; {
         description = "Enable automatic updates for opencode";
       };
 
+      agentsMd = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Global AGENTS.md content installed to ~/.config/opencode/AGENTS.md.
+          Loaded at startup by OpenCode as global agent instructions.
+          Mirrors the pi agentsMd pattern.
+        '';
+      };
+
       enableBrowserAgents = mkOption {
         type = types.bool;
         default = false;

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -325,6 +325,11 @@ in {
           };
         };
       }
+      // (optionalAttrs (cfg.agentsMd != "") {
+        ".config/opencode/AGENTS.md" = {
+          text = cfg.agentsMd;
+        };
+      })
       // (optionalAttrs rtkCfg.enable {
         ".config/opencode/RTK.md" = {
           text = ''

--- a/modules/roles/opencode.nix
+++ b/modules/roles/opencode.nix
@@ -37,6 +37,9 @@ in {
       enabled = true;
     };
 
+    # Default global agent instructions — override per-machine with a direct assignment
+    myConfig.opencode.agentsMd = lib.mkDefault (builtins.readFile ../common/AGENTS.md);
+
     environment.shellAliases = {
       llm-status = "curl http://${host}:${port}/status";
     };

--- a/modules/roles/pi.nix
+++ b/modules/roles/pi.nix
@@ -52,6 +52,9 @@ in {
       onePasswordItem = "op://Opnix/OpenCode Go API/credential";
     };
 
+    # Default global agent instructions — override per-machine with a direct assignment
+    myConfig.pi.agentsMd = lib.mkDefault (builtins.readFile ../common/AGENTS.md);
+
     environment.variables = {
       PI_CODING_AGENT_DIR = "$HOME/.pi/agent";
     };


### PR DESCRIPTION
## Summary

Adds a unified `AGENTS.md` system for OpenCode and Pi that is managed by Nix, with a shared default and per-machine override support.

## Changes

- **`modules/common/AGENTS.md`** — new shared source of truth (English-only + jj discipline rules)
- **`modules/common/options.nix`** — adds `myConfig.opencode.agentsMd` and `myConfig.pi.agentsMd` options (`types.lines`, default `""`)
- **`modules/home-manager/opencode.nix`** — writes `~/.config/opencode/AGENTS.md` via `home.file` when option is set
- **`modules/roles/opencode.nix`** and **`modules/roles/pi.nix`** — set `lib.mkDefault` so every machine with those roles inherits the shared rules automatically

## Override pattern

To customise per machine, assign directly in the host config (no `mkDefault` needed — plain assignment always wins):

```nix
opencode.agentsMd = builtins.readFile ./AGENTS.md;
pi.agentsMd = builtins.readFile ./AGENTS.md;
```