### PR TITLE
feat: package jj-hooks and wire up jj push alias

### DIFF
--- a/modules/home-manager/foundation.nix
+++ b/modules/home-manager/foundation.nix
@@ -2,6 +2,7 @@
 # Provides universal development tools on all systems
 {
   lib,
+  pkgs,
   userConfig,
   myConfig,
   earthsong,
@@ -13,6 +14,11 @@
     overrideDevices = false;
     overrideFolders = false;
   };
+
+  # jj-hooks: runs pre-commit/prek/lefthook/hk hooks against jj bookmark
+  # pushes in an ephemeral git worktree. Provides the `jj-hp` binary that
+  # the `push` alias below delegates to.
+  home.packages = [pkgs.jj-hooks];
 
   # Jujutsu version control with Earthsong color-words theme
   programs.jujutsu = lib.mkIf (userConfig.name != "") {
@@ -37,7 +43,15 @@
       };
       aliases = {
         ba = ["bookmark" "advance"];
+        # Delegate `jj push` to jj-hp, which runs the repo's configured
+        # hook runner (pre-commit/prek/lefthook/hk) in an ephemeral git
+        # worktree before pushing. Falls through to plain `jj git push`
+        # when a repo has no hook-runner config.
+        push = ["util" "exec" "--" "jj-hp" "push"];
       };
+      # Automatically advance the local bookmark to the fixup commit when
+      # jj-hooks autofixes files during a push (e.g. alejandra formatting).
+      jj-hooks.advance-bookmarks = true;
       # Treat pushed commits as immutable. Prevents `jj squash`, `jj describe`,
       # `jj rebase`, etc. from rewriting any commit reachable from a remote
       # bookmark. See modules/home-manager/skills/external/jj/SKILL.md

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -3,6 +3,7 @@
 {
   rtk = final.callPackage ../packages/rtk {};
   yaks = final.callPackage ../packages/yaks {};
+  jj-hooks = final.callPackage ../packages/jj-hooks {};
   lume = final.callPackage ../packages/lume {};
   vane = final.callPackage ../packages/vane {};
   mlx-audio = final.callPackage ../packages/mlx-audio {};

--- a/packages/jj-hooks/default.nix
+++ b/packages/jj-hooks/default.nix
@@ -1,0 +1,68 @@
+# jj-hooks - Run pre-commit/prek/lefthook/hk hooks against jj bookmark pushes
+# https://github.com/mattwilkinsonn/zireael/tree/main/tools/jj-hooks
+#
+# Ships two identical binaries: jj-hooks (canonical) and jj-hp (shorter alias).
+# `jj-hp push` is a drop-in replacement for `jj git push` that runs the
+# configured hook runner in an ephemeral git worktree before pushing.
+#
+# Packaged from prebuilt release tarballs (Rust project originally lived at
+# mattwilkinsonn/jj-hooks, now developed in the mattwilkinsonn/zireael
+# monorepo). Update the version + hashes together when bumping.
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}: let
+  version = "0.3.7";
+
+  sources = {
+    x86_64-linux = {
+      platform = "linux-x64";
+      hash = "sha256-UxGgtvfYmmIzyxwSWgAdqcKdSSwg5ld+lC1qvRxoJpQ=";
+    };
+    aarch64-linux = {
+      platform = "linux-arm64";
+      hash = "sha256-LOSBpcLgDik9x5QrVkjI+bl5DSOIwOHukuYET98OihY=";
+    };
+    aarch64-darwin = {
+      platform = "darwin-arm64";
+      hash = "sha256-Wq8QMc76Ubt5UeR1nujAnXePs/+g3NWR20t6Awlj5oU=";
+    };
+  };
+
+  system = stdenvNoCC.hostPlatform.system;
+  source =
+    sources.${system}
+    or (throw "jj-hooks: no prebuilt release for system '${system}'");
+in
+  stdenvNoCC.mkDerivation rec {
+    pname = "jj-hooks";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://github.com/mattwilkinsonn/zireael/releases/download/v${version}/jj-hooks-v${version}-${source.platform}.tar.gz";
+      hash = source.hash;
+    };
+
+    sourceRoot = "jj-hooks-v${version}-${source.platform}";
+
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm755 jj-hooks $out/bin/jj-hooks
+      install -Dm755 jj-hp $out/bin/jj-hp
+
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "Run pre-commit/prek/lefthook/hk hooks against jj bookmark pushes";
+      homepage = "https://github.com/mattwilkinsonn/zireael/tree/main/tools/jj-hooks";
+      license = licenses.asl20;
+      maintainers = [];
+      mainProgram = "jj-hp";
+      platforms = builtins.attrNames sources;
+    };
+  }


### PR DESCRIPTION
## Summary

Wires up `jj-hooks` (pre-push hook runner for jj) so `jj push` automatically runs the repo's pre-commit hooks in an ephemeral git worktree before pushing.

The original `mattwilkinsonn/jj-hooks` repo was archived on 2026-05-26 with no flake outputs, which is why this yak had stalled. Development moved to the `mattwilkinsonn/zireael` monorepo, which also doesn't publish a flake — but it does publish prebuilt release binaries on GitHub. This PR packages those binaries directly rather than waiting on/adding a flake input.

## Changes

- **`packages/jj-hooks/default.nix`** (new) — fetches prebuilt `jj-hooks`/`jj-hp` binaries from GitHub Releases (v0.3.7) for `aarch64-darwin`, `x86_64-linux`, and `aarch64-linux`, with real sha256 hashes verified locally.
- **`overlays/default.nix`** — registers `pkgs.jj-hooks` via the custom overlay.
- **`modules/home-manager/foundation.nix`**:
  - Adds `pkgs.jj-hooks` to `home.packages`
  - Adds a `jj push` alias delegating to `jj-hp push`
  - Enables `jj-hooks.advance-bookmarks = true` so autofix commits (e.g. alejandra formatting) are picked up automatically on retry

## Verification

- Built and ran the actual `jj-hp`/`jj-hooks` binaries locally (`jj-hp 0.3.7`, `jj-hooks 0.3.7`)
- `devenv tasks run check:lint` ✅
- `devenv tasks run test` ✅ (full foundation suite)
- `nix eval` confirms `jj-hooks` lands in the `wweaver` darwin config's home packages, and the `push` alias / `advance-bookmarks` settings appear correctly in the generated jj config
- Repo already has `.pre-commit-config.yaml` (devenv-generated), so `jj-hooks` will autodetect `pre-commit`/`prek` as the hook runner

## Yak tracking

Marks the following yaks done in the shared `yx` tree, with resolution notes on the pivot from flake-input to packaged-binary:
- Add jj-hooks flake input
- Install jj-hooks in foundation packages
- Wire up jj-hooks for pre-push hooks with jj (parent story)