### PR TITLE
refactor: dedupe auto-load skills logic in home-manager modules

### DIFF
--- a/modules/home-manager/claude-code.nix
+++ b/modules/home-manager/claude-code.nix
@@ -47,39 +47,15 @@ with lib; let
     // (optionalAttrs (cfg.mcpServers != {}) {
       mcpServers = mcpServerConfig;
     });
-  # Build auto-loaded skills content from manifest
-  manifest = import ./skills/manifest.nix;
-  enabledRoles = skillsCfg.enabledRoles or [];
-  superpowersPath = skillsCfg.superpowersPath or null;
-  enabledSkills =
-    lib.filterAttrs (
-      _name: skill:
-        lib.any (role: lib.elem role skill.roles) enabledRoles
-    )
-    manifest;
-  autoLoadSkills =
-    lib.filterAttrs (
-      _name: skill: skill.autoLoad or false
-    )
-    enabledSkills;
-  autoLoadContent = lib.concatStringsSep "\n\n---\n\n" (lib.mapAttrsToList (
-      name: skill: let
-        skillMd =
-          if skill.source.type == "internal"
-          then let
-            skillPath = skill.source.path + "/SKILL.md";
-          in
-            if builtins.pathExists skillPath
-            then builtins.readFile skillPath
-            else "# ${name}\n\n${skill.description}"
-          else if skill.source.type == "superpowers" && superpowersPath != null
-          then builtins.readFile "${superpowersPath}/skills/${skill.source.skillName}/SKILL.md"
-          else "# ${name}\n\n${skill.description}";
-      in
-        skillMd
-    )
-    autoLoadSkills);
-  hasAutoLoadSkills = autoLoadSkills != {};
+  # Build auto-loaded skills content from the shared manifest helper
+  inherit
+    (hmLib.mkAutoLoadSkills {
+      enabledRoles = skillsCfg.enabledRoles or [];
+      superpowersPath = skillsCfg.superpowersPath or null;
+    })
+    autoLoadContent
+    hasAutoLoadSkills
+    ;
 in {
   config = mkIf cfg.enable {
     # RTK hook script - installed from rtk package when RTK is enabled

--- a/modules/home-manager/lib.nix
+++ b/modules/home-manager/lib.nix
@@ -46,4 +46,53 @@ with lib; rec {
         mode = item.mode or "0600";
       })
     (lib.filterAttrs (_: item: item.reference != "") items);
+
+  # Build auto-loaded skills content from the shared skill manifest.
+  #
+  # Filters modules/home-manager/skills/manifest.nix down to skills whose
+  # `roles` intersect `enabledRoles`, then further to skills tagged
+  # `autoLoad = true`, resolving each one's SKILL.md content (internal or
+  # superpowers source), and concatenating them with `---` separators.
+  #
+  # enabledRoles: list of role names, e.g. config.myConfig.skills.enabledRoles
+  # superpowersPath: path to the superpowers skills repo, or null if unset
+  #
+  # Returns { autoLoadSkills, autoLoadContent, hasAutoLoadSkills }.
+  mkAutoLoadSkills = {
+    enabledRoles,
+    superpowersPath ? null,
+  }: let
+    manifest = import ./skills/manifest.nix;
+    enabledSkills =
+      lib.filterAttrs (
+        _name: skill:
+          lib.any (role: lib.elem role skill.roles) enabledRoles
+      )
+      manifest;
+    autoLoadSkills =
+      lib.filterAttrs (
+        _name: skill: skill.autoLoad or false
+      )
+      enabledSkills;
+    autoLoadContent = lib.concatStringsSep "\n\n---\n\n" (lib.mapAttrsToList (
+        name: skill: let
+          skillMd =
+            if skill.source.type == "internal"
+            then let
+              skillPath = skill.source.path + "/SKILL.md";
+            in
+              if builtins.pathExists skillPath
+              then builtins.readFile skillPath
+              else "# ${name}\n\n${skill.description}"
+            else if skill.source.type == "superpowers" && superpowersPath != null
+            then builtins.readFile "${superpowersPath}/skills/${skill.source.skillName}/SKILL.md"
+            else "# ${name}\n\n${skill.description}";
+        in
+          skillMd
+      )
+      autoLoadSkills);
+    hasAutoLoadSkills = autoLoadSkills != {};
+  in {
+    inherit autoLoadSkills autoLoadContent hasAutoLoadSkills;
+  };
 }

--- a/modules/home-manager/pi-coding-agent.nix
+++ b/modules/home-manager/pi-coding-agent.nix
@@ -70,39 +70,15 @@ with lib; let
     })
   cfg.models;
 
-  # Build auto-loaded skills content from manifest
-  manifest = import ./skills/manifest.nix;
-  enabledRoles = skillsCfg.enabledRoles or [];
-  superpowersPath = skillsCfg.superpowersPath or null;
-  enabledSkills =
-    lib.filterAttrs (
-      _name: skill:
-        lib.any (role: lib.elem role skill.roles) enabledRoles
-    )
-    manifest;
-  autoLoadSkills =
-    lib.filterAttrs (
-      _name: skill: skill.autoLoad or false
-    )
-    enabledSkills;
-  autoLoadContent = lib.concatStringsSep "\n\n---\n\n" (lib.mapAttrsToList (
-      name: skill: let
-        skillMd =
-          if skill.source.type == "internal"
-          then let
-            skillPath = skill.source.path + "/SKILL.md";
-          in
-            if builtins.pathExists skillPath
-            then builtins.readFile skillPath
-            else "# ${name}\n\n${skill.description}"
-          else if skill.source.type == "superpowers" && superpowersPath != null
-          then builtins.readFile "${superpowersPath}/skills/${skill.source.skillName}/SKILL.md"
-          else "# ${name}\n\n${skill.description}";
-      in
-        skillMd
-    )
-    autoLoadSkills);
-  hasAutoLoadSkills = autoLoadSkills != {};
+  # Build auto-loaded skills content from the shared manifest helper
+  inherit
+    (hmLib.mkAutoLoadSkills {
+      enabledRoles = skillsCfg.enabledRoles or [];
+      superpowersPath = skillsCfg.superpowersPath or null;
+    })
+    autoLoadContent
+    hasAutoLoadSkills
+    ;
 
   # Combine user AGENTS.md with auto-loaded skills
   agentsMdWithAutoLoad = let


### PR DESCRIPTION
## Summary

Extracts the duplicated manifest-import / role-filter / auto-load logic from `claude-code.nix` and `pi-coding-agent.nix` into a shared `mkAutoLoadSkills` helper in `modules/home-manager/lib.nix`.

Both modules previously carried a byte-for-byte identical ~30-line block that:
- imports `./skills/manifest.nix`
- filters skills by `enabledRoles` membership
- filters to `autoLoad = true` skills
- resolves internal vs superpowers `SKILL.md` content
- concatenates with `---` separators

## Changes

- **`modules/home-manager/lib.nix`** — adds `mkAutoLoadSkills { enabledRoles, superpowersPath ? null }`, returning `{ autoLoadSkills, autoLoadContent, hasAutoLoadSkills }`.
- **`modules/home-manager/claude-code.nix`** — replaced inline block with a call to `hmLib.mkAutoLoadSkills`.
- **`modules/home-manager/pi-coding-agent.nix`** — same refactor.

## Verification

- `devenv tasks run check:lint` ✅
- `devenv tasks run test` ✅ (full foundation suite)
- Confirmed **byte-for-byte identical** `.pi/agent/AGENTS.md` output before and after the refactor via `nix eval` + `diff` against the `wweaver` darwin config (no `.claude/CLAUDE.md` in that config since `claude-code.enable = false` there, but the logic path is identical to pi's).
- `nix eval .#darwinConfigurations.wweaver...` and `.#darwinConfigurations.darwin-server...` both evaluate cleanly.

## Yak tracking

Marks "Deduplicate auto-loaded skills logic across home-manager modules" done under "repo-wide cleanup and refactoring" in the shared `yx` tree. This was also a prerequisite for the (still-open, not-yet-started) "Migrate skills management from imperative to declarative" yak.