### PR TITLE
test: add unit tests for library system builders

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -527,6 +527,8 @@
             phase3-zero
             phase4-darwin-server
             phase2-cattle
+            mk-darwin-system
+            mk-nixos-system
             claude-code-options
             claude-code-custom-options
             pi-options

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -31,6 +31,10 @@
   testPhase3Zero = import ./test-phase3-zero.nix {inherit pkgs self;};
   testPhase4DarwinServer = import ./test-phase4-darwin-server.nix {inherit pkgs self;};
   testPhase2Cattle = import ./test-phase2-cattle.nix {inherit pkgs self;};
+  testLibrary =
+    if self != null
+    then import ./test-library.nix {inherit pkgs self;}
+    else {};
 
   # VM tests only available on x86_64-linux (NixOS testing framework)
   inherit (pkgs.stdenv.hostPlatform) isLinux;
@@ -137,6 +141,16 @@ in
 
     # Phase 4: darwin-server v2 migration
     phase4-darwin-server = testPhase4DarwinServer.phase4DarwinServerTest;
+
+    # library/lib/mk-system.nix builder tests
+    mk-darwin-system =
+      if testLibrary != {}
+      then testLibrary.mkDarwinSystemTest
+      else null;
+    mk-nixos-system =
+      if testLibrary != {}
+      then testLibrary.mkNixosSystemTest
+      else null;
 
     # vMLX module tests
 

--- a/tests/test-library.nix
+++ b/tests/test-library.nix
@@ -1,0 +1,161 @@
+# Unit tests for library/lib/mk-system.nix
+#
+# Verifies mkDarwinSystem and mkNixosSystem produce the expected
+# hostName, overlays, nixpkgs config, home-manager wiring, and
+# override-priority behavior. A regression here affects every v2
+# system built through the library helpers.
+#
+# Uses the real flake inputs (via `self.inputs`) and real archetype
+# modules so these tests exercise the actual composition path rather
+# than a hand-rolled stand-in. Evaluation only (`lib.evalModules`-style
+# via nix-darwin/nixpkgs's own systemBuilders) — nothing is built.
+{
+  pkgs,
+  self,
+  ...
+}: let
+  lib = pkgs.lib;
+  inputs = self.inputs;
+  libraryLib = import ../library/lib/mk-system.nix {inherit lib;};
+
+  # ── mkDarwinSystem fixtures ────────────────────────────────────────────
+  darwinResult = libraryLib.mkDarwinSystem {
+    inherit inputs;
+    hostname = "test-darwin-host";
+    modules = [
+      ../library/archetypes/base-darwin.nix
+    ];
+  };
+
+  # ── mkNixosSystem fixtures ─────────────────────────────────────────────
+  minimalNixosBoot = {
+    boot.loader.grub.device = "nodev";
+    fileSystems."/" = {
+      device = "/dev/sda1";
+      fsType = "ext4";
+    };
+    system.stateVersion = "25.05";
+  };
+
+  nixosResult = libraryLib.mkNixosSystem {
+    inherit inputs;
+    hostname = "test-nixos-host";
+    system = "x86_64-linux";
+    modules = [
+      minimalNixosBoot
+      {
+        home-manager.users.testuser = {...}: {
+          home.stateVersion = "25.05";
+          home.username = "testuser";
+          home.homeDirectory = "/home/testuser";
+        };
+        users.users.testuser.isNormalUser = true;
+      }
+    ];
+  };
+
+  # Second fixture with a normal-priority module definition plus an
+  # `overrides` value, to verify override-priority (mkOverride 50) wins.
+  nixosOverrideResult = libraryLib.mkNixosSystem {
+    inherit inputs;
+    hostname = "test-nixos-override-host";
+    system = "x86_64-linux";
+    modules = [
+      (lib.recursiveUpdate minimalNixosBoot {
+        myConfig.tailscale.enable = true;
+      })
+    ];
+    overrides = {
+      tailscale.enable = false;
+    };
+  };
+in {
+  mkDarwinSystemTest =
+    pkgs.runCommand "test-mk-darwin-system"
+    {}
+    ''
+      echo "=== Testing mkDarwinSystem ==="
+
+      ${
+        if darwinResult.config.networking.hostName == "test-darwin-host"
+        then ''echo "  networking.hostName = test-darwin-host: OK"''
+        else ''echo "  FAIL: networking.hostName should be test-darwin-host, got ${darwinResult.config.networking.hostName}"; exit 1''
+      }
+
+      ${
+        if builtins.hasAttr "stable" darwinResult.pkgs
+        then ''echo "  overlay 'stable' present: OK"''
+        else ''echo "  FAIL: overlay 'stable' missing from pkgs"; exit 1''
+      }
+
+      ${
+        if builtins.hasAttr "devenv" darwinResult.pkgs
+        then ''echo "  overlay 'devenv' present: OK"''
+        else ''echo "  FAIL: overlay 'devenv' missing from pkgs"; exit 1''
+      }
+
+      ${
+        if builtins.hasAttr "zellij-pane-tracker" darwinResult.pkgs
+        then ''echo "  overlay 'zellij-pane-tracker' present: OK"''
+        else ''echo "  FAIL: overlay 'zellij-pane-tracker' missing from pkgs"; exit 1''
+      }
+
+      ${
+        if darwinResult.config.nixpkgs.config.allowUnfree == true
+        then ''echo "  nixpkgs.config.allowUnfree = true: OK"''
+        else ''echo "  FAIL: nixpkgs.config.allowUnfree should be true"; exit 1''
+      }
+
+      echo "All mkDarwinSystem tests passed"
+      touch $out
+    '';
+
+  mkNixosSystemTest =
+    pkgs.runCommand "test-mk-nixos-system"
+    {}
+    ''
+      echo "=== Testing mkNixosSystem ==="
+
+      ${
+        if nixosResult.config.networking.hostName == "test-nixos-host"
+        then ''echo "  networking.hostName = test-nixos-host: OK"''
+        else ''echo "  FAIL: networking.hostName should be test-nixos-host, got ${nixosResult.config.networking.hostName}"; exit 1''
+      }
+
+      ${
+        if builtins.hasAttr "home-manager" nixosResult.config
+        then ''echo "  home-manager.nixosModules.home-manager wired: OK"''
+        else ''echo "  FAIL: home-manager option not present"; exit 1''
+      }
+
+      ${
+        if builtins.hasAttr "onepassword-secrets" nixosResult.config.home-manager.users.testuser.programs
+        then ''echo "  opnix.homeManagerModules.default in sharedModules: OK"''
+        else ''echo "  FAIL: opnix.homeManagerModules.default missing from home-manager.sharedModules"; exit 1''
+      }
+
+      ${
+        if nixosResult.config.nixpkgs.hostPlatform.system == "x86_64-linux"
+        then ''echo "  nixpkgs.hostPlatform.system = x86_64-linux: OK"''
+        else ''echo "  FAIL: nixpkgs.hostPlatform.system should be x86_64-linux, got ${nixosResult.config.nixpkgs.hostPlatform.system}"; exit 1''
+      }
+
+      ${
+        if nixosResult.config.nixpkgs.config.allowUnfree == true
+        then ''echo "  nixpkgs.config.allowUnfree = true: OK"''
+        else ''echo "  FAIL: nixpkgs.config.allowUnfree should be true"; exit 1''
+      }
+
+      echo ""
+      echo "=== Testing mkNixosSystem override priority (mkOverride 50) ==="
+
+      ${
+        if nixosOverrideResult.config.myConfig.tailscale.enable == false
+        then ''echo "  overrides win over normal-priority module definition: OK"''
+        else ''echo "  FAIL: overrides.tailscale.enable = false should win over myConfig.tailscale.enable = true"; exit 1''
+      }
+
+      echo "All mkNixosSystem tests passed"
+      touch $out
+    '';
+}


### PR DESCRIPTION
## Summary

Adds `tests/test-library.nix` covering `mkDarwinSystem` and `mkNixosSystem` in `library/lib/mk-system.nix` — the central system builders used by every v2 `darwinConfigurations` and `nixosConfigurations` entry. A regression here would affect all of them, with no current test coverage.

## Approach

Uses the real flake inputs (`self.inputs`) and real archetype modules (`library/archetypes/base-darwin.nix`) so the tests exercise the actual composition path via `lib.evalModules`-backed `darwinSystem`/`nixosSystem` builders, rather than a hand-rolled stand-in. Evaluation only — nothing is built.

## Coverage

**`mkDarwinSystem`:**
- `networking.hostName` set correctly
- Custom overlays present (`stable`, `devenv`, `zellij-pane-tracker`)
- `nixpkgs.config.allowUnfree = true`

**`mkNixosSystem`:**
- `networking.hostName` set correctly
- `home-manager.nixosModules.home-manager` wired in
- opnix shared module presence — verified via `programs.onepassword-secrets` option availability on a stub home-manager user, since Nix function values aren't reliably comparable with `==`/`elem` (discovered while writing this test: `f == f` evaluates to `false` for lambdas in Nix)
- `nixpkgs.hostPlatform.system` set correctly
- `nixpkgs.config.allowUnfree = true`

**`mkNixosSystem` override priority:**
- Confirms the `overrides` argument (`mkOverride 50`) wins over a normal-priority module definition, matching real usage in `flake.nix` (e.g. `type-server`'s `overrides.autoUpgrade.flakeUrl`)

## Wiring

Added `mk-darwin-system` and `mk-nixos-system` to `flake.nix`'s `checks` attrset, following the same `self`-requiring pattern as `core-bootstrap`, `phase3-zero`, and `phase4-darwin-server`.

## Verification

- `devenv tasks run check:lint` passes
- `devenv tasks run test` passes (full foundation suite)
- Both new checks build and pass individually: `nix build .#checks.aarch64-darwin.mk-darwin-system .#checks.aarch64-darwin.mk-nixos-system`

## Yak tracking

Marks "Add unit tests for library system builders" done under "repo-wide cleanup and refactoring" in the shared yx tree.
