### PR TITLE
refactor: deduplicate nixpkgs config between flake.nix and library

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,54 +68,34 @@
     self,
     nix-darwin,
     nixpkgs,
-    nixpkgs-stable,
     home-manager,
     nix-homebrew,
     opnix,
     ...
   } @ inputs: let
-    # Base configuration shared by all systems
+    # Base configuration shared by all systems built via raw
+    # nix-darwin.lib.darwinSystem / nixpkgs.lib.nixosSystem calls below
+    # (MegamanX, zero, type-nas). Machines built via library/lib/mk-system.nix's
+    # mkDarwinSystem/mkNixosSystem get the same core nixpkgs.config +
+    # overlays from library/lib/nixpkgs-config.nix directly -- this
+    # `configuration` binding layers a couple of extra overlays
+    # (himalaya-tui, and an explicit claude-code allowUnfreePredicate,
+    # currently redundant since allowUnfree = true already permits it)
+    # on top of that shared module.
     configuration = _: {
       system.configurationRevision = self.rev or self.dirtyRev or null;
       nixpkgs = {
         config = {
-          allowUnfree = true;
           allowUnfreePredicate = pkg:
             builtins.elem (nixpkgs.lib.getName pkg) [
               "claude-code"
             ];
-          permittedInsecurePackages = [
-            "electron-39.8.10"
-            "google-chrome-144.0.7559.97"
-            "olm-3.2.16"
-          ];
-          allowInsecurePredicate = attrs: let
-            pname = attrs.pname or attrs.name or "";
-            fullName = "${pname}-${attrs.version or ""}";
-          in
-            pname
-            == "openclaw"
-            || builtins.elem fullName ["electron-39.8.10" "google-chrome-144.0.7559.97" "olm-3.2.16"];
         };
         overlays = [
-          (final: _prev: {
-            stable = import nixpkgs-stable {
-              inherit (final) system config;
-            };
-          })
-          # Use devenv 2.x from the cachix/devenv flake
-          (final: _prev: {
-            inherit (inputs.devenv.packages.${final.stdenv.hostPlatform.system}) devenv;
-          })
-          # zellij-pane-tracker WASM plugin from its own flake
-          (final: _prev: {
-            zellij-pane-tracker = inputs.zellij-pane-tracker.packages.${final.stdenv.hostPlatform.system}.default;
-          })
           # himalaya-tui from upstream Pimalaya flake
           (final: _prev: {
             himalaya-tui = inputs.himalaya-tui.packages.${final.stdenv.hostPlatform.system}.default;
           })
-          (import ./overlays {inherit inputs;})
         ];
       };
     };
@@ -150,6 +130,7 @@
     # Library helpers from the new modular library
     inherit (nixpkgs) lib;
     libraryLib = import ./library/lib/mk-system.nix {inherit lib;};
+    mkNixpkgsConfigModule = import ./library/lib/nixpkgs-config.nix;
   in {
     packages = forAllSystems (
       system: let
@@ -251,6 +232,7 @@
         specialArgs = {inherit inputs mkUser;};
         modules = [
           configuration
+          (mkNixpkgsConfigModule {inherit inputs;})
           ./library/archetypes/base-darwin.nix
           nix-homebrew.darwinModules.nix-homebrew
           ./library/archetypes/workstation-darwin.nix
@@ -286,6 +268,7 @@
         specialArgs = {inherit inputs mkUser;};
         modules = [
           configuration
+          (mkNixpkgsConfigModule {inherit inputs;})
           opnix.nixosModules.default
           ./modules
           ./modules/nixos/base.nix
@@ -323,6 +306,7 @@
         specialArgs = inputs // {inherit inputs;};
         modules = [
           configuration
+          (mkNixpkgsConfigModule {inherit inputs;})
           ./modules
           ./modules/nixos/base.nix
           home-manager.nixosModules.home-manager

--- a/library/lib/mk-system.nix
+++ b/library/lib/mk-system.nix
@@ -1,4 +1,6 @@
-{lib}: rec {
+{lib}: let
+  mkNixpkgsConfigModule = import ./nixpkgs-config.nix;
+in rec {
   mkDarwinSystem = {
     inputs,
     hostname,
@@ -17,38 +19,8 @@
           {
             networking.hostName = hostname;
             system.configurationRevision = inputs.self.rev or inputs.self.dirtyRev or null;
-            nixpkgs = {
-              config = {
-                allowUnfree = true;
-                permittedInsecurePackages = [
-                  "electron-39.8.10"
-                  "google-chrome-144.0.7559.97"
-                  "olm-3.2.16"
-                ];
-                allowInsecurePredicate = attrs: let
-                  pname = attrs.pname or attrs.name or "";
-                  fullName = "${pname}-${attrs.version or ""}";
-                in
-                  pname
-                  == "openclaw"
-                  || builtins.elem fullName ["electron-39.8.10" "google-chrome-144.0.7559.97" "olm-3.2.16"];
-              };
-              overlays = [
-                (final: _prev: {
-                  stable = import inputs.nixpkgs-stable {
-                    inherit (final) system config;
-                  };
-                })
-                (final: _prev: {
-                  inherit (inputs.devenv.packages.${final.stdenv.hostPlatform.system}) devenv;
-                })
-                (final: _prev: {
-                  zellij-pane-tracker = inputs.zellij-pane-tracker.packages.${final.stdenv.hostPlatform.system}.default;
-                })
-                (import ../../overlays {inherit inputs;})
-              ];
-            };
           }
+          (mkNixpkgsConfigModule {inherit inputs;})
           (import ../../modules)
         ]
         ++ modules
@@ -78,39 +50,9 @@
           {
             networking.hostName = hostname;
             system.configurationRevision = inputs.self.rev or inputs.self.dirtyRev or null;
-            nixpkgs = {
-              config = {
-                allowUnfree = true;
-                permittedInsecurePackages = [
-                  "electron-39.8.10"
-                  "google-chrome-144.0.7559.97"
-                  "olm-3.2.16"
-                ];
-                allowInsecurePredicate = attrs: let
-                  pname = attrs.pname or attrs.name or "";
-                  fullName = "${pname}-${attrs.version or ""}";
-                in
-                  pname
-                  == "openclaw"
-                  || builtins.elem fullName ["electron-39.8.10" "google-chrome-144.0.7559.97" "olm-3.2.16"];
-              };
-              hostPlatform = system;
-              overlays = [
-                (final: _prev: {
-                  stable = import inputs.nixpkgs-stable {
-                    inherit (final) system config;
-                  };
-                })
-                (final: _prev: {
-                  inherit (inputs.devenv.packages.${final.stdenv.hostPlatform.system}) devenv;
-                })
-                (final: _prev: {
-                  zellij-pane-tracker = inputs.zellij-pane-tracker.packages.${final.stdenv.hostPlatform.system}.default;
-                })
-                (import ../../overlays {inherit inputs;})
-              ];
-            };
+            nixpkgs.hostPlatform = system;
           }
+          (mkNixpkgsConfigModule {inherit inputs;})
           (import ../../modules)
           inputs.home-manager.nixosModules.home-manager
           {

--- a/library/lib/nixpkgs-config.nix
+++ b/library/lib/nixpkgs-config.nix
@@ -1,0 +1,52 @@
+# Shared nixpkgs.config + base overlays for every Darwin/NixOS system
+# built by this flake, whether through library/lib/mk-system.nix's
+# mkDarwinSystem/mkNixosSystem helpers or a raw nix-darwin.lib.darwinSystem /
+# nixpkgs.lib.nixosSystem call in flake.nix.
+#
+# Previously this same block (allowUnfree, permittedInsecurePackages,
+# allowInsecurePredicate, and the stable/devenv/zellij-pane-tracker overlay
+# list) was duplicated three times: once in flake.nix's `configuration`
+# let-binding, and once each in mkDarwinSystem and mkNixosSystem. All three
+# copies had drifted slightly (flake.nix's copy had two extra overlays
+# and an allowUnfreePredicate not present in the other two).
+#
+# Usage: `(mkNixpkgsConfigModule {inherit inputs;})` as a module in a
+# darwinSystem/nixosSystem modules list. Extra overlays specific to one
+# call site (e.g. flake.nix's himalaya-tui) can be appended by the caller
+# via a normal `nixpkgs.overlays = [...]` module alongside this one --
+# NixOS module merging concatenates overlay lists automatically.
+{inputs}: _: {
+  nixpkgs = {
+    config = {
+      allowUnfree = true;
+      permittedInsecurePackages = [
+        "electron-39.8.10"
+        "google-chrome-144.0.7559.97"
+        "olm-3.2.16"
+      ];
+      allowInsecurePredicate = attrs: let
+        pname = attrs.pname or attrs.name or "";
+        fullName = "${pname}-${attrs.version or ""}";
+      in
+        pname
+        == "openclaw"
+        || builtins.elem fullName ["electron-39.8.10" "google-chrome-144.0.7559.97" "olm-3.2.16"];
+    };
+    overlays = [
+      (final: _prev: {
+        stable = import inputs.nixpkgs-stable {
+          inherit (final) system config;
+        };
+      })
+      # Use devenv 2.x from the cachix/devenv flake
+      (final: _prev: {
+        inherit (inputs.devenv.packages.${final.stdenv.hostPlatform.system}) devenv;
+      })
+      # zellij-pane-tracker WASM plugin from its own flake
+      (final: _prev: {
+        zellij-pane-tracker = inputs.zellij-pane-tracker.packages.${final.stdenv.hostPlatform.system}.default;
+      })
+      (import ../../overlays {inherit inputs;})
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

Extracts the shared `nixpkgs.config` (`allowUnfree`, `permittedInsecurePackages`, `allowInsecurePredicate`) and base overlay list (`stable`, `devenv`, `zellij-pane-tracker`, the custom overlay) into a new `library/lib/nixpkgs-config.nix` module.

This block was previously duplicated **three times**: byte-for-byte identical in `library/lib/mk-system.nix`'s `mkDarwinSystem` and `mkNixosSystem`, and nearly identical (with two drifted extra overlays and an unused `allowUnfreePredicate`) in `flake.nix`'s `configuration` let-binding used by `MegamanX`, `zero`, and `type-nas`.

## Changes

- **`library/lib/nixpkgs-config.nix`** (new) — the shared module
- **`library/lib/mk-system.nix`** — `mkDarwinSystem`/`mkNixosSystem` now both import the shared module instead of inlining it
- **`flake.nix`** — `configuration` binding trimmed to only the extras it needs on top of the shared module (`himalaya-tui` overlay, and a `claude-code` `allowUnfreePredicate` — currently redundant since `allowUnfree = true` already permits it, kept for documentation of intent), wired in alongside the shared module at each of its three call sites (`MegamanX`, `zero`, `type-nas`)
- Removed the now-unused `nixpkgs-stable` destructured input binding from `flake.nix`'s `outputs` function signature (still available via `inputs.nixpkgs-stable`)

## Verification

Verified via `nix eval` that all 4 real configs that touch either code path (`darwinConfigurations.{wweaver,MegamanX}`, `nixosConfigurations.{zero,type-nas}`) produce **byte-identical** `nixpkgs.config` values and overlay-provided packages (`pkgs.stable`, `pkgs.devenv`, `pkgs.zellij-pane-tracker`, `pkgs.rtk`) before and after this change — plus confirmed `himalaya-tui` and the `claude-code` `allowUnfreePredicate` are preserved exactly where they were before (`MegamanX`/`zero`/`type-nas` only, not `wweaver`).

- `devenv tasks run check:lint` passes
- `devenv tasks run test` passes

## Yak tracking

Completes "Deduplicate nixpkgs config between flake.nix and library" under "repo-wide cleanup and refactoring".
