### PR TITLE
feat: add mergiraf AST-aware merge tool to developer role

### DIFF
--- a/modules/roles/developer.nix
+++ b/modules/roles/developer.nix
@@ -21,6 +21,12 @@ in {
       slidev-cli
       temporal-cli
       yaks
+      # AST-aware merge tool. jj ships a default `merge-tools.mergiraf`
+      # entry out of the box (see `jj config list --include-defaults
+      # merge-tools`), so no jj config is needed here -- just the binary
+      # on PATH. Use `jj resolve --tool mergiraf [<path>]` to resolve
+      # conflicts. See https://mergiraf.org/usage.html.
+      mergiraf
     ];
 
     myConfig.fjj.enable = true;


### PR DESCRIPTION
## Summary

Adds `pkgs.mergiraf` to the `developer` role's package list. [Mergiraf](https://mergiraf.org/) resolves a wide range of merge conflicts by understanding the syntax tree of the files involved, rather than just diffing lines.

## Integration

No jj configuration is needed: jj ships a default `merge-tools.mergiraf` entry out of the box (confirmed via `jj config list --include-defaults merge-tools`), pointing at the `mergiraf` binary already. Adding the package to PATH is the only integration point required for `jj resolve --tool mergiraf [<path>]` to work.

## Scope note: git merge-driver registration intentionally left out

Mergiraf's docs also describe registering it as a git merge driver. While investigating that path, I found `modules/common/users.nix`'s `programs.git.settings` (commit signing, GPG/SSH config) never actually applies today because `programs.git.enable` is never set to `true` anywhere in this repo — home-manager's entire git module is gated behind that option. Since git itself isn't meaningfully configured through Nix yet, wiring a git merge driver here would be dead configuration on top of dead configuration.

Filed as a separate yak ("Fix `programs.git.enable` never set to true") rather than fixed inline here, since it's an unrelated pre-existing bug with real behavioral implications (commit signing silently inactive) that needs human sign-off before changing real machine behavior.

## Verification

- Built `pkgs.mergiraf` standalone and confirmed the binary runs (`mergiraf 0.17.0`)
- `nix eval` confirms it appears in `environment.systemPackages` on a real config (`darwinConfigurations.wweaver`, developer role enabled)
- `devenv tasks run check:lint` and `devenv tasks run test` pass

## Yak tracking

Completes "Implement mergiraf as AST-aware merge tool" under "Developer Experience".
