### PR TITLE
fix: correct module coverage bug, add regression guard to CI

### DIFF
--- a/tests/test-coverage.nix
+++ b/tests/test-coverage.nix
@@ -5,13 +5,24 @@
 
   # Auto-discover all .nix files under modules/ without IFD.
   # Uses recursive builtins.readDir helper — no need to manually update this list.
+  #
+  # IMPORTANT: build fullPath with `(toString path) + "/${name}"`, NOT
+  # `"${path}/${name}"`. String-interpolating a Nix `path` value forces
+  # Nix's path-to-string coercion, which copies the path into the Nix
+  # store and yields a `/nix/store/HASH-...` string — completely
+  # different from `basePrefix` below (computed once via `toString
+  # modulesDir`, the plain filesystem path). That mismatch meant
+  # `removePrefix basePrefix p` never actually stripped anything, so
+  # `allModules` silently contained full store paths instead of clean
+  # relative paths, and EVERY module always ended up in
+  # `untestedModules` regardless of whether it was actually tested.
   collectNixFiles = path: let
     entries = builtins.readDir path;
   in
     lib.concatLists (
       lib.mapAttrsToList (
         name: type: let
-          fullPath = "${path}/${name}";
+          fullPath = (toString path) + "/${name}";
         in
           if type == "regular" && lib.hasSuffix ".nix" name
           then [fullPath]
@@ -66,20 +77,17 @@
     # common/onepassword.nix was already listed above via onepasswordOptionsTest
     # common/lib.nix tested via tests/nix-unit-tests.nix (shared lib helpers)
     "common/lib.nix"
-    # Tested via test-services.nix (ollama, vane option tests) and
+    # Tested via test-services.nix (vane option tests) and
     # indirectly via zero/zero-v2 config eval (openclaw shared config +
     # hardening options, imported through flake.nix)
-    "services/ollama/common.nix"
-    "services/ollama/darwin.nix"
-    "services/ollama/nixos.nix"
     "services/openclaw/default.nix"
     "services/vane/darwin.nix"
-    "services/vmlx/darwin.nix"
+    # Tested via test-vllm-mlx.nix (vllm-mlx option defaults, custom
+    # values, and MegamanX target config)
+    "services/vllm-mlx/darwin.nix"
     # Tested via test-stack-integration.nix (LLM stack composition)
     "services/bifrost/darwin.nix"
     "services/caddy/darwin.nix"
-    # Tested via test-vmlx.nix (vMLX option defaults and custom values)
-    # Tested via test-vllm-mlx.nix (vllm-mlx option defaults and custom values)
     # Tested via test-home-manager.nix (opencode, shell aliases)
     "home-manager/opencode.nix"
     "home-manager/aliases.nix"
@@ -95,6 +103,16 @@
 
   # Integer percentage (avoid floating point in Nix)
   coveragePct = (testedCount * 100) / totalCount;
+
+  # Regression guard: coverage must not drop below this baseline.
+  # Raise this number whenever testedModules grows (i.e. whenever you add
+  # a new test that covers a previously-untested module) — this check
+  # exists to catch coverage silently regressing (e.g. a module getting
+  # added without a matching test, or a testedModules entry going stale
+  # after a rename/deletion so it stops actually matching a real file),
+  # not to block progress. It should almost always be equal to the
+  # current coveragePct, or slightly below it as a small buffer.
+  minCoveragePct = 46;
 in {
   moduleCoverageTest =
     pkgs.runCommand "test-module-coverage"
@@ -114,6 +132,19 @@ in {
       ${lib.concatMapStringsSep "\n" (m: ''echo "  [ ] ${m}"'') untestedModules}
       echo ""
 
+      ${
+        if coveragePct >= minCoveragePct
+        then ''echo "Coverage ${toString coveragePct}% meets the minimum of ${toString minCoveragePct}%: OK"''
+        else ''
+          echo "FAIL: Coverage regressed to ${toString coveragePct}%, below the minimum of ${toString minCoveragePct}%."
+          echo "Either add tests for the newly-untested module(s) above, or if this is"
+          echo "expected (e.g. a module was genuinely removed), lower minCoveragePct in"
+          echo "tests/test-coverage.nix to match the new, deliberate baseline."
+          exit 1
+        ''
+      }
+      echo ""
+
       # Write coverage data for CI consumption
       mkdir -p $out
       echo '${builtins.toJSON {
@@ -121,6 +152,7 @@ in {
         tested = testedCount;
         untested = untestedCount;
         percentage = coveragePct;
+        minPercentage = minCoveragePct;
         untestedList = untestedModules;
       }}' > $out/coverage.json
 


### PR DESCRIPTION
## Summary

Fixes a real bug in `tests/test-coverage.nix`'s module-discovery logic that silently corrupted the "untested modules" report, and adds a coverage regression guard so CI now actually enforces a minimum.

## The bug

`collectNixFiles`'s helper built each recursive path via string interpolation: `fullPath = "${path}/${name}"`. When `path` is a Nix `path` value (as it is on the very first call), string-interpolating it triggers Nix's path-to-string coercion, which **copies the path into the Nix store** and yields a string like `/nix/store/HASH-modules/...` — not the plain filesystem path.

Meanwhile `basePrefix` was computed separately via `toString modulesDir + "/"`, which gives the plain filesystem path (e.g. `/Users/wweaver/.../modules/`).

Since these two path representations never matched, `removePrefix basePrefix p` silently failed to strip anything, so `untestedModules` always contained **literally every module** — the "Untested Modules" section and `untestedList` in `coverage.json` were completely wrong, even though the top-level percentage happened to look plausible (since `coveragePct` is computed independently from `testedCount`/`totalCount`).

Fixed by building `fullPath` via `(toString path) + "/${name}"` instead.

## Stale `testedModules` entries

Fixing the path bug surfaced 3 stale entries in the curated list that don't correspond to any real file:
- `"services/ollama/common.nix"` and `"services/ollama/nixos.nix"` — don't exist; only `services/ollama/darwin.nix` does, and it isn't actually tested anywhere (a real, additional gap)
- `"services/vmlx/darwin.nix"` — stale rename; the real path is `services/vllm-mlx/darwin.nix`, which IS tested via `test-vllm-mlx.nix`

Corrected coverage: **46%** (32/69), down from the previously-reported (bogus) 50% — this is the real, trustworthy baseline.

## The regression guard

Added `minCoveragePct = 46` and an assertion in `moduleCoverageTest` that fails the build if `coveragePct` drops below it, with a message explaining how to respond.

**Verified RED/GREEN**: temporarily set `minCoveragePct = 99` and confirmed the build fails with a clear message listing untested modules; reverted and confirmed it passes again at the real threshold.

## Verification

- `devenv tasks run check:lint` and `devenv tasks run test` pass
- `nix build .#checks.aarch64-darwin.module-coverage` passes with the corrected, internally-consistent `coverage.json` (`tested + untested == total`)

## Yak tracking

Completes "Add coverage regression guard to CI pipeline" under "Test Suite".
