### PR TITLE
fix: gemma4 tool-use failures — queue lock admission, durable logs, aligned serving limits

### DIFF
--- a/docs/how-to/configure-llm-stack.md
+++ b/docs/how-to/configure-llm-stack.md
@@ -199,7 +199,7 @@ sudo ./scripts/restart-stack.sh
 Check the vllm-mlx log for HuggingFace errors:
 
 ```bash
-tail -f /tmp/vllm-mlx.log
+tail -f ~/Library/Logs/vllm-mlx/server.log
 ```
 
 Ensure you have sufficient disk space and network connectivity.
@@ -209,7 +209,7 @@ Ensure you have sufficient disk space and network connectivity.
 Check the error log:
 
 ```bash
-cat /tmp/vllm-mlx.err      # vllm-mlx errors
+cat ~/Library/Logs/vllm-mlx/server.error.log # vllm-mlx errors
 cat /tmp/bifrost.error.log # Bifrost errors
 cat /tmp/caddy.error.log   # Caddy errors
 ```

--- a/docs/reference/llm-stack.md
+++ b/docs/reference/llm-stack.md
@@ -253,7 +253,7 @@ Use `restart-stack.sh` which properly frees ports between stop and start cycles.
 Check the service log:
 
 ```bash
-cat /tmp/vllm-mlx.err     # vllm-mlx errors
+cat ~/Library/Logs/vllm-mlx/server.error.log # vllm-mlx errors
 cat /tmp/bifrost.error.log  # Bifrost errors
 cat /tmp/caddy.error.log    # Caddy errors
 ```
@@ -263,5 +263,5 @@ cat /tmp/caddy.error.log    # Caddy errors
 vllm-mlx downloads models from HuggingFace on first use. Check download progress:
 
 ```bash
-cat /tmp/vllm-mlx.log | grep -i "loading\|download\|error"
+cat ~/Library/Logs/vllm-mlx/server.log | grep -i "loading\|download\|error"
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -504,6 +504,7 @@
             fjj-options
             fjj-custom-options
             vllm-mlx-options
+            vllm-mlx-launchd
             megamanx-vllm
             llm-client-opencode
             llm-client-claude

--- a/hosts/megamanx/default.nix
+++ b/hosts/megamanx/default.nix
@@ -49,8 +49,13 @@
         enableAutoToolChoice = true;
         toolCallParser = "gemma4";
         reasoningParser = "gemma4";
-        maxKvSize = 65536;
-        timeout = 120;
+        # Must match pi's maxTokens for the bifrost model (131072) — a lower
+        # cap silently rotates the system prompt and tool definitions out of
+        # the KV cache in long agent sessions.
+        maxKvSize = 131072;
+        # Must be >= pi's provider.timeoutMs (600s); queued lock admission
+        # plus long 31B generations would otherwise be killed server-side.
+        timeout = 600;
         logLevel = "INFO";
       };
 

--- a/modules/roles/pi.nix
+++ b/modules/roles/pi.nix
@@ -34,11 +34,14 @@ in {
       serverPort = lib.mkDefault "8080";
     };
 
-    # Auto-configure bifrost as a model provider
+    # Auto-configure bifrost as a model provider.
+    # modelId must be a model alias served by the local stack — the vllm-mlx
+    # registry on megamanx serves gemma4-31b/gemma4-e4b (the old gemma4:26b
+    # ollama-style tag predates the vllm-mlx stack and matched nothing).
     myConfig.pi.models.bifrost = lib.mkDefault {
       name = "Bifrost AI Gateway";
       provider = "bifrost";
-      modelId = "gemma4:26b";
+      modelId = "gemma4-31b";
       baseUrl = "http://${host}:${port}/v1";
     };
 

--- a/modules/services/vllm-mlx/darwin.nix
+++ b/modules/services/vllm-mlx/darwin.nix
@@ -15,6 +15,13 @@
   darwinHomeDir = commonLib.darwinHomeDir config;
   appDir = "${darwinHomeDir}/.config/vllm-mlx";
 
+  # Durable log location. /tmp is cleaned by macOS every 3 days; launchd
+  # keeps writing to the deleted inode and all server output is lost.
+  logDir =
+    if cfg.logDir != null
+    then cfg.logDir
+    else "${darwinHomeDir}/Library/Logs/vllm-mlx";
+
   # Resolve a model path to either a Nix store path (if a matching overlay
   # package exists) or the raw HuggingFace ID for runtime download.
   # Model overlay names are derived from the HuggingFace path segment
@@ -71,6 +78,7 @@
 
     APP_DIR="${appDir}"
     mkdir -p "$APP_DIR"
+    mkdir -p ${logDir}
 
     # Copy registry into writable location
     cat ${registryYaml} > "$APP_DIR/registry.yaml"
@@ -218,6 +226,18 @@ in {
       description = "Reasoning parser for extracting thinking/reasoning content from model output. 'gemma4' for Gemma 4 models.";
     };
 
+    lockAdmission = lib.mkOption {
+      type = lib.types.enum ["wait" "fail_fast"];
+      default = "wait";
+      description = "Admission policy when a request arrives while another generation holds the serialized engine lock. 'wait' queues requests (correct for a single-user local server behind agent traffic, where parallel requests are normal); 'fail_fast' rejects with 503 text_generation_busy. Maps to VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION.";
+    };
+
+    logDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Directory for launchd stdout/stderr logs. Defaults to ~/Library/Logs/vllm-mlx for the primary user. Do not use /tmp: macOS cleans it every 3 days and launchd keeps writing to the deleted inode, silently discarding all server logs.";
+    };
+
     maxKvSize = lib.mkOption {
       type = lib.types.nullOr lib.types.ints.positive;
       default = null;
@@ -245,12 +265,13 @@ in {
         RunAtLoad = true;
         KeepAlive = true;
         ExitTimeOut = 30;
-        StandardOutPath = "/tmp/vllm-mlx.log";
-        StandardErrorPath = "/tmp/vllm-mlx.err";
+        StandardOutPath = "${logDir}/server.log";
+        StandardErrorPath = "${logDir}/server.error.log";
         UserName = primaryUser;
         EnvironmentVariables = {
           HOME = darwinHomeDir;
           PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
+          VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION = cfg.lockAdmission;
         };
       };
     };
@@ -262,8 +283,8 @@ in {
         RunAtLoad = true;
         KeepAlive = false;
         ExitTimeOut = 600;
-        StandardOutPath = "/tmp/vllm-mlx-warmup.log";
-        StandardErrorPath = "/tmp/vllm-mlx-warmup.err";
+        StandardOutPath = "${logDir}/warmup.log";
+        StandardErrorPath = "${logDir}/warmup.error.log";
         UserName = primaryUser;
         EnvironmentVariables = {
           HOME = darwinHomeDir;
@@ -273,14 +294,14 @@ in {
     };
 
     system.activationScripts.postActivation.text = lib.mkAfter ''
-      mkdir -p "${appDir}"
+      mkdir -p "${appDir}" "${logDir}"
     '';
 
     myConfig.serviceRegistry = commonLib.mkServiceRegistry "vllm-mlx" {
       displayName = "vllm-mlx";
       port = cfg.server.port;
       label = "org.vllm-mlx.server";
-      errorLog = "/tmp/vllm-mlx.err";
+      errorLog = "${logDir}/server.error.log";
       enabled = cfg.enable;
     };
   };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -192,6 +192,7 @@ in
 
     # vllm-mlx module tests
     vllm-mlx-options = testVllmMlx.vllmMlxOptionsTest;
+    vllm-mlx-launchd = testVllmMlx.vllmMlxLaunchdTest;
     megamanx-vllm = testVllmMlx.megamanxVllmMlxTest;
 
     # Claude Code module tests

--- a/tests/stubs.nix
+++ b/tests/stubs.nix
@@ -29,6 +29,7 @@
 #   stubs.searxng         — base ++ darwinService ++ services/searxng/darwin.nix
 #   stubs.bifrost         — base ++ darwinService ++ services/bifrost/darwin.nix
 #   stubs.caddy           — base ++ darwinService ++ services/caddy/darwin.nix
+#   stubs.vllmMlx         — base ++ darwinService ++ services/vllm-mlx/darwin.nix
 #
 {pkgs}: let
   lib = pkgs.lib;
@@ -193,4 +194,5 @@ in rec {
   searxng = base ++ darwinService ++ [../modules/services/searxng/darwin.nix];
   bifrost = base ++ darwinService ++ [../modules/services/bifrost/darwin.nix];
   caddy = base ++ darwinService ++ [../modules/services/caddy/darwin.nix];
+  vllmMlx = base ++ darwinService ++ [../modules/services/vllm-mlx/darwin.nix];
 }

--- a/tests/test-roles.nix
+++ b/tests/test-roles.nix
@@ -119,6 +119,10 @@
     pi = {
       "agent-skills.enable" = true;
       "pi.enable" = true;
+      # Default local model served by the vllm-mlx registry via Bifrost.
+      # Must match a model alias in myConfig.vllmMlx.models on hosts that
+      # run the local stack (megamanx serves gemma4-31b).
+      "pi.models.bifrost.modelId" = "gemma4-31b";
     };
     # llm-host no longer cascades to ollama.enable (service option removed)
     assistant = {"email-agent.enable" = true;};

--- a/tests/test-vllm-mlx.nix
+++ b/tests/test-vllm-mlx.nix
@@ -1,24 +1,11 @@
-# vllm-mlx inference server option tests
-# Validates option defaults and custom values
+# vllm-mlx inference server tests
+# Validates option defaults, custom values, launchd daemon wiring, and the
+# MegamanX target's Gemma 4 configuration.
 {pkgs, ...}: let
   inherit (pkgs) lib;
+  stubs = import ./stubs.nix {inherit pkgs;};
 
-  stubModules = [
-    ../modules/common/options.nix
-    ../modules/common/llm-client.nix
-    ../modules/common/charm.nix
-    ../modules/common/syncthing.nix
-    ../modules/common/zellij.nix
-    {
-      options.nixpkgs.hostPlatform = lib.mkOption {
-        type = lib.types.anything;
-        default = {inherit (pkgs.stdenv.hostPlatform) system;};
-      };
-    }
-    {
-      config._module.args = {inherit pkgs;};
-    }
-  ];
+  vllmMlxModule = ../modules/services/vllm-mlx/darwin.nix;
 
   # Stub mkUser matching the flake.nix helper shape
   mkUserStub = name: email: {
@@ -40,58 +27,15 @@
   };
   stubInputs = {superpowers = "/stub/superpowers";};
 
-  # Evaluate the actual MegamanX target to verify its vllm-mlx config
-  megamanxVllmMlx =
-    (lib.evalModules {
-      modules = [
-        ../modules/common/options.nix
-        (import ../hosts/megamanx/default.nix)
-        {
-          options.nixpkgs.hostPlatform = lib.mkOption {
-            type = lib.types.anything;
-            default = {inherit (pkgs.stdenv.hostPlatform) system;};
-          };
-          options.system.stateVersion = lib.mkOption {
-            type = lib.types.anything;
-            default = 4;
-          };
-          options.system.primaryUser = lib.mkOption {
-            type = lib.types.anything;
-            default = "monkey";
-          };
-          options.system.activationScripts = lib.mkOption {
-            type = lib.types.anything;
-            default = {};
-          };
-          # Stubs for nix-darwin options imported by workstation archetype
-          options.launchd = lib.mkOption {
-            type = lib.types.anything;
-            default = {};
-          };
-          options.homebrew = lib.mkOption {
-            type = lib.types.anything;
-            default = {};
-          };
-        }
-        {
-          config._module.args = {
-            inherit pkgs;
-            mkUser = mkUserStub;
-            inputs = stubInputs;
-          };
-        }
-      ];
-    }).config.myConfig.vllmMlx;
-
   vllmMlxDefaults =
     (lib.evalModules {
-      modules = stubModules;
+      modules = stubs.vllmMlx;
     }).config.myConfig.vllmMlx;
 
   vllmMlxCustom =
     (lib.evalModules {
       modules =
-        stubModules
+        stubs.vllmMlx
         ++ [
           {
             config.myConfig.vllmMlx = {
@@ -111,12 +55,72 @@
               enableAutoToolChoice = true;
               toolCallParser = "gemma4";
               reasoningParser = "gemma4";
+              lockAdmission = "fail_fast";
               timeout = 300;
               logLevel = "DEBUG";
             };
           }
         ];
     }).config.myConfig.vllmMlx;
+
+  # Evaluate the launchd wiring for an enabled server. `extra` is merged into
+  # myConfig.vllmMlx so tests can flip individual knobs.
+  mkLaunchdEval = extra:
+    (lib.evalModules {
+      modules =
+        stubs.vllmMlx
+        ++ [
+          {
+            config.myConfig.users = [{name = "monkey";}];
+            config.myConfig.vllmMlx =
+              {
+                enable = true;
+                models.test-model.path = "mlx-community/test-model-4bit";
+              }
+              // extra;
+          }
+        ];
+    })
+    .config;
+
+  launchdDefault = mkLaunchdEval {};
+  launchdFailFast = mkLaunchdEval {lockAdmission = "fail_fast";};
+
+  # Evaluate the actual MegamanX target to verify its vllm-mlx config
+  megamanxEval = lib.evalModules {
+    modules =
+      stubs.base
+      ++ stubs.darwinService
+      ++ stubs.onepassword
+      ++ [
+        vllmMlxModule
+        ../modules/services/bifrost/darwin.nix
+        ../modules/services/vane/darwin.nix
+        ../modules/services/searxng/darwin.nix
+        ../modules/services/caddy/darwin.nix
+        {
+          options.system.stateVersion = lib.mkOption {
+            type = lib.types.anything;
+            default = 4;
+          };
+          options.system.primaryUser = lib.mkOption {
+            type = lib.types.anything;
+            default = "monkey";
+          };
+        }
+        (import ../hosts/megamanx/default.nix)
+        {
+          # pkgs comes from stubs.base (moduleArgsStub); only add what the
+          # host file needs beyond it.
+          config._module.args = {
+            mkUser = mkUserStub;
+            inputs = stubInputs;
+          };
+        }
+      ];
+  };
+  megamanxVllmMlx = megamanxEval.config.myConfig.vllmMlx;
+  megamanxVllmDaemon = megamanxEval.config.launchd.daemons."vllm-mlx".serviceConfig;
 in {
   vllmMlxOptionsTest =
     pkgs.runCommand "test-vllm-mlx-options"
@@ -170,6 +174,12 @@ in {
         if vllmMlxDefaults.reasoningParser == null
         then ''echo "  reasoningParser default = null: OK"''
         else ''echo "  reasoningParser should default to null!"; exit 1''
+      }
+
+      ${
+        if vllmMlxDefaults.lockAdmission == "wait"
+        then ''echo "  lockAdmission default = wait: OK"''
+        else ''echo "  lockAdmission should default to wait (queue instead of 503)!"; exit 1''
       }
 
       ${
@@ -235,12 +245,75 @@ in {
         else ''echo "  reasoningParser should be gemma4!"; exit 1''
       }
 
+      ${
+        if vllmMlxCustom.lockAdmission == "fail_fast"
+        then ''echo "  lockAdmission = fail_fast: OK"''
+        else ''echo "  lockAdmission should be fail_fast!"; exit 1''
+      }
+
       echo ""
       echo "All vllm-mlx option tests passed"
       touch $out
     '';
 
+  # Verify the launchd daemon wiring: lock-admission env var and durable log
+  # paths (not /tmp, which macOS cleans every 3 days).
+  vllmMlxLaunchdTest = pkgs.runCommand "test-vllm-mlx-launchd" {} ''
+    echo "=== Testing vllm-mlx launchd Wiring ==="
+
+    ${
+      let
+        env = launchdDefault.launchd.daemons."vllm-mlx".serviceConfig.EnvironmentVariables;
+      in
+        if env.VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION == "wait"
+        then ''echo "  lock admission env = wait: OK"''
+        else ''echo "  FAIL: VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION should be wait, got ${env.VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION or "(unset)"}"; exit 1''
+    }
+    ${
+      let
+        env = launchdFailFast.launchd.daemons."vllm-mlx".serviceConfig.EnvironmentVariables;
+      in
+        if env.VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION == "fail_fast"
+        then ''echo "  lock admission env = fail_fast (opt-out): OK"''
+        else ''echo "  FAIL: VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION should be fail_fast, got ${env.VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION or "(unset)"}"; exit 1''
+    }
+    ${
+      let
+        sc = launchdDefault.launchd.daemons."vllm-mlx".serviceConfig;
+      in
+        if sc.StandardOutPath == "/Users/monkey/Library/Logs/vllm-mlx/server.log"
+        then ''echo "  server stdout log durable: OK"''
+        else ''echo "  FAIL: StandardOutPath should be /Users/monkey/Library/Logs/vllm-mlx/server.log, got ${sc.StandardOutPath}"; exit 1''
+    }
+    ${
+      let
+        sc = launchdDefault.launchd.daemons."vllm-mlx".serviceConfig;
+      in
+        if sc.StandardErrorPath == "/Users/monkey/Library/Logs/vllm-mlx/server.error.log"
+        then ''echo "  server stderr log durable: OK"''
+        else ''echo "  FAIL: StandardErrorPath should be /Users/monkey/Library/Logs/vllm-mlx/server.error.log, got ${sc.StandardErrorPath}"; exit 1''
+    }
+    ${
+      let
+        sc = launchdDefault.launchd.daemons."vllm-mlx-warmup".serviceConfig;
+      in
+        if sc.StandardOutPath == "/Users/monkey/Library/Logs/vllm-mlx/warmup.log" && sc.StandardErrorPath == "/Users/monkey/Library/Logs/vllm-mlx/warmup.error.log"
+        then ''echo "  warmup logs durable: OK"''
+        else ''echo "  FAIL: warmup logs should live in /Users/monkey/Library/Logs/vllm-mlx/"; exit 1''
+    }
+    ${
+      if launchdDefault.myConfig.serviceRegistry.vllm-mlx.errorLog == "/Users/monkey/Library/Logs/vllm-mlx/server.error.log"
+      then ''echo "  serviceRegistry errorLog durable: OK"''
+      else ''echo "  FAIL: serviceRegistry errorLog should point at the durable log path"; exit 1''
+    }
+
+    echo ""
+    echo "All vllm-mlx launchd tests passed"
+    touch $out
+  '';
+
   # Verify the actual MegamanX target config targets Gemma 4 with gemma4 parsers
+  # and that its serving limits line up with the pi client's expectations.
   megamanxVllmMlxTest = pkgs.runCommand "test-megamanx-vllm" {} ''
     echo "=== Testing MegamanX vllm-mlx Configuration ==="
     echo ""
@@ -279,14 +352,23 @@ in {
       else ''echo "  FAIL: reasoningParser should be gemma4, got ${toString megamanxVllmMlx.reasoningParser}"; exit 1''
     }
     ${
-      if megamanxVllmMlx.maxKvSize == 65536
-      then ''echo "  maxKvSize = 65536: OK"''
-      else ''echo "  FAIL: maxKvSize should be 65536, got ${toString megamanxVllmMlx.maxKvSize}"; exit 1''
+      # pi advertises maxTokens = 131072 for the bifrost model; the server KV
+      # cap must match or long sessions silently rotate out the system prompt
+      # and tool definitions.
+      if megamanxVllmMlx.maxKvSize == 131072
+      then ''echo "  maxKvSize = 131072 (matches pi maxTokens): OK"''
+      else ''echo "  FAIL: maxKvSize should be 131072 to match pi maxTokens, got ${toString megamanxVllmMlx.maxKvSize}"; exit 1''
     }
     ${
       if megamanxVllmMlx.memoryBudgetGb == 90
       then ''echo "  memoryBudgetGb = 90: OK"''
       else ''echo "  FAIL: memoryBudgetGb should be 90, got ${toString megamanxVllmMlx.memoryBudgetGb}"; exit 1''
+    }
+    ${
+      # pi's provider timeout is 600s; the server must not kill requests first.
+      if megamanxVllmMlx.timeout == 600
+      then ''echo "  timeout = 600 (matches pi provider timeout): OK"''
+      else ''echo "  FAIL: timeout should be 600 to match pi provider timeoutMs, got ${toString megamanxVllmMlx.timeout}"; exit 1''
     }
     ${
       if megamanxVllmMlx.enableAutoToolChoice
@@ -297,6 +379,13 @@ in {
       if megamanxVllmMlx.enable
       then ''echo "  enable = true: OK"''
       else ''echo "  FAIL: vllmMlx should be enabled"; exit 1''
+    }
+    ${
+      # Queued admission is the whole fix for the 503 text_generation_busy
+      # storms that broke agent tool use — assert it on the real target.
+      if megamanxVllmDaemon.EnvironmentVariables.VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION == "wait"
+      then ''echo "  daemon lock admission = wait: OK"''
+      else ''echo "  FAIL: daemon should queue concurrent requests (VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION=wait)"; exit 1''
     }
     echo ""
     echo "All MegamanX vllm-mlx tests passed"


### PR DESCRIPTION
## Problem

Local gemma4 (vllm-mlx → Bifrost → pi) failed constantly on tool use. Live diagnosis showed the model itself produces well-formed tool calls — the failures were infrastructure:

1. **503 `text_generation_busy` storms**: vllm-mlx's SimpleEngine serializes generation through one lock, and its default admission policy is `fail_fast` — any request arriving during another generation is rejected instantly (reproduced: 5/6 parallel requests 503'd). Agents fire parallel requests constantly (subagents, compaction), and Bifrost recognizes the 503 as retryable but gives up after one attempt, so turns failed wholesale.
2. **Context mismatch**: pi advertises `maxTokens: 131072` but the server capped KV at 65536 — the system prompt and tool definitions silently rotated out of cache mid-session, degrading tool calling as sessions grew.
3. **Timeout inversion**: server `--timeout 120` killed requests long before pi's 600s provider timeout.
4. **Zero logs**: launchd logged to /tmp, which macOS cleans every 3 days; the daemon kept writing to a deleted inode.
5. **Stale pi role default**: `gemma4:26b` (ollama-style tag) matched no served model.

## Changes

- **`modules/services/vllm-mlx/darwin.nix`**: new `lockAdmission` option (default `"wait"`) → `VLLM_MLX_SIMPLE_ENGINE_LOCK_ADMISSION`, so concurrent requests queue instead of 503ing. New `logDir` option (default `~/Library/Logs/vllm-mlx`) for server + warmup daemon logs and `serviceRegistry.errorLog`; directory created by activation script and service wrapper.
- **`hosts/megamanx/default.nix`**: `maxKvSize` 65536 → 131072 (matches pi maxTokens); `timeout` 120 → 600 (matches pi provider timeoutMs).
- **`modules/roles/pi.nix`**: default bifrost `modelId` `gemma4:26b` → `gemma4-31b` (the vllm-mlx registry alias).
- **docs**: troubleshooting guides point at the durable log location.

## Tests

- Repaired `tests/test-vllm-mlx.nix` — both evals were broken on main by the #361 options migration; rebuilt on `tests/stubs.nix` with the real service modules imported.
- New `vllm-mlx-launchd` check: lock-admission env var (default + opt-out), durable log paths, serviceRegistry errorLog.
- megamanx check now asserts maxKvSize/timeout alignment with pi and daemon-level lock admission.
- Role-cascade test pins the pi default `modelId`.

All changes were TDD'd (assertions verified RED before implementation). `devenv tasks run check:lint` and `devenv tasks run test` pass.

## Not included (follow-ups)

- ~~Bifrost retry support~~ → #382 (merged-ready, CI green)
- Stray `~` gitlink cleanup → #381
- Upstream issues (not yet filed): `prompt_tokens: 0` on the registry path; missing `finish_reason: "tool_calls"` chunk in streaming

## Deployment

After merge, `system:switch` on megamanx restarts vllm-mlx with the new config (also clears 16 days of stale engine state).
