### PR TITLE
feat(bifrost): retry support for flaky local upstreams

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -531,6 +531,7 @@
             pi-custom-options
             bifrost-options
             bifrost-custom-options
+            bifrost-retry-config
             caddy-options
             caddy-custom-options
             searxng-options

--- a/hosts/megamanx/default.nix
+++ b/hosts/megamanx/default.nix
@@ -74,6 +74,10 @@
             url = "http://localhost:8300";
             type = "openai";
             requestTimeout = 120;
+            # Retry transient 503s (busy engine, model-swap preemption) so a
+            # single busy window doesn't fail an agent turn. Bifrost's stock
+            # default is 0 retries.
+            maxRetries = 3;
             models = [
               "gemma4-31b"
               "gemma4-e4b"

--- a/modules/services/bifrost/darwin.nix
+++ b/modules/services/bifrost/darwin.nix
@@ -29,13 +29,21 @@ with lib; let
     weight = 1.0;
   };
 
+  mkNetworkConfig = upstream: {
+    allow_private_network = upstream.allowPrivateNetwork;
+    default_request_timeout_in_seconds = upstream.requestTimeout;
+    max_retries = upstream.maxRetries;
+    retry_backoff_initial = "${toString upstream.retryBackoffInitialMs}ms";
+    retry_backoff_max = "${toString upstream.retryBackoffMaxMs}ms";
+  };
+
   mkOpenaiProvider = upstreams: {
     keys = map mkOpenaiProviderKey upstreams;
-    network_config = {
-      base_url = (builtins.head upstreams).url;
-      allow_private_network = (builtins.head upstreams).allowPrivateNetwork;
-      default_request_timeout_in_seconds = (builtins.head upstreams).requestTimeout;
-    };
+    network_config =
+      (mkNetworkConfig (builtins.head upstreams))
+      // {
+        base_url = (builtins.head upstreams).url;
+      };
     custom_provider_config = {
       base_provider_type = "openai";
       allowed_requests = {
@@ -69,10 +77,7 @@ with lib; let
     firstUpstream = builtins.head upstreams;
   in {
     keys = upstreamKeys;
-    network_config = {
-      allow_private_network = firstUpstream.allowPrivateNetwork;
-      default_request_timeout_in_seconds = firstUpstream.requestTimeout;
-    };
+    network_config = mkNetworkConfig firstUpstream;
   };
 
   providers = let
@@ -177,6 +182,21 @@ in {
             type = types.ints.unsigned;
             default = 120;
             description = "Default request timeout in seconds";
+          };
+          maxRetries = mkOption {
+            type = types.ints.unsigned;
+            default = 0;
+            description = "Maximum retry attempts for retryable upstream errors (e.g. 503 from a busy local engine). Bifrost's stock default is 0 — a single attempt — so transient failures fail the whole request. Local agent gateways should set 2-3.";
+          };
+          retryBackoffInitialMs = mkOption {
+            type = types.ints.positive;
+            default = 500;
+            description = "Initial retry backoff in milliseconds (matches Bifrost's upstream default of 500ms). Retries back off exponentially up to retryBackoffMaxMs.";
+          };
+          retryBackoffMaxMs = mkOption {
+            type = types.ints.positive;
+            default = 5000;
+            description = "Maximum retry backoff in milliseconds (matches Bifrost's upstream default of 5s).";
           };
           models = mkOption {
             type = types.listOf types.str;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -205,6 +205,7 @@ in
     # Bifrost AI gateway module tests
     bifrost-options = testBifrost.bifrostOptionsTest;
     bifrost-custom-options = testBifrost.bifrostCustomOptionsTest;
+    bifrost-retry-config = testBifrost.bifrostRetryConfigTest;
 
     # Caddy reverse proxy module tests
     caddy-options = testCaddy.caddyOptionsTest;

--- a/tests/test-bifrost.nix
+++ b/tests/test-bifrost.nix
@@ -1,30 +1,18 @@
 # Bifrost AI gateway option tests
-# Validates option defaults and custom values
+# Validates option defaults, custom values, and generated provider config
 {pkgs, ...}: let
   inherit (pkgs) lib;
-
-  stubModules = [
-    ../modules/common/options.nix
-    {
-      options.nixpkgs.hostPlatform = lib.mkOption {
-        type = lib.types.anything;
-        default = {inherit (pkgs.stdenv.hostPlatform) system;};
-      };
-    }
-    {
-      config._module.args = {inherit pkgs;};
-    }
-  ];
+  stubs = import ./stubs.nix {inherit pkgs;};
 
   bifrostDefaults =
     (lib.evalModules {
-      modules = stubModules;
+      modules = stubs.bifrost;
     }).config.myConfig.bifrost;
 
   bifrostCustom =
     (lib.evalModules {
       modules =
-        stubModules
+        stubs.bifrost
         ++ [
           {
             config.myConfig.bifrost = {
@@ -40,6 +28,9 @@
                   apiKey = "dummy";
                   allowPrivateNetwork = true;
                   requestTimeout = 60;
+                  maxRetries = 4;
+                  retryBackoffInitialMs = 250;
+                  retryBackoffMaxMs = 8000;
                   models = ["qwen3.5"];
                 };
               };
@@ -148,7 +139,95 @@ in {
       else ''echo "  upstream models should contain qwen3.5!"; exit 1''
     }
 
+    ${
+      if bifrostCustom.upstreams."vllm-mlx-local".maxRetries == 4
+      then ''echo "  upstream maxRetries = 4: OK"''
+      else ''echo "  upstream maxRetries should be 4!"; exit 1''
+    }
+
+    ${
+      if bifrostCustom.upstreams."vllm-mlx-local".retryBackoffInitialMs == 250
+      then ''echo "  upstream retryBackoffInitialMs = 250: OK"''
+      else ''echo "  upstream retryBackoffInitialMs should be 250!"; exit 1''
+    }
+
+    ${
+      if bifrostCustom.upstreams."vllm-mlx-local".retryBackoffMaxMs == 8000
+      then ''echo "  upstream retryBackoffMaxMs = 8000: OK"''
+      else ''echo "  upstream retryBackoffMaxMs should be 8000!"; exit 1''
+    }
+
     echo "All Bifrost custom options verified"
     touch $out
   '';
+
+  # Verify the generated provider config (embedded in the launchd script)
+  # carries retry settings into network_config. Bifrost's upstream default is
+  # max_retries = 0 — one attempt, no retries — which is what let transient
+  # 503s from a busy local engine fail whole agent turns.
+  bifrostRetryConfigTest = let
+    retryEval =
+      (lib.evalModules {
+        modules =
+          stubs.bifrost
+          ++ [
+            {
+              config.myConfig.users = [{name = "monkey";}];
+              config.myConfig.bifrost = {
+                enable = true;
+                upstreams."local" = {
+                  url = "http://localhost:8300";
+                  type = "openai";
+                  maxRetries = 3;
+                  retryBackoffInitialMs = 250;
+                  retryBackoffMaxMs = 4000;
+                };
+                upstreams."local-defaults" = {
+                  url = "http://localhost:8301";
+                  type = "openai";
+                };
+              };
+            }
+          ];
+      })
+      .config;
+  in
+    pkgs.runCommand "test-bifrost-retry-config" {} ''
+      echo "=== Testing Bifrost Generated Retry Config ==="
+      SCRIPT=${retryEval.launchd.daemons.bifrost.command}
+
+      if grep -q '"max_retries":3' "$SCRIPT"; then
+        echo "  max_retries = 3 in generated config: OK"
+      else
+        echo "  FAIL: generated config should contain \"max_retries\":3"; exit 1
+      fi
+
+      if grep -q '"retry_backoff_initial":"250ms"' "$SCRIPT"; then
+        echo "  retry_backoff_initial = 250ms: OK"
+      else
+        echo "  FAIL: generated config should contain \"retry_backoff_initial\":\"250ms\""; exit 1
+      fi
+
+      if grep -q '"retry_backoff_max":"4000ms"' "$SCRIPT"; then
+        echo "  retry_backoff_max = 4000ms: OK"
+      else
+        echo "  FAIL: generated config should contain \"retry_backoff_max\":\"4000ms\""; exit 1
+      fi
+
+      # Upstreams that don't opt in stay at Bifrost's stock defaults
+      if grep -q '"max_retries":0' "$SCRIPT"; then
+        echo "  default max_retries = 0 (upstream default preserved): OK"
+      else
+        echo "  FAIL: unconfigured upstream should keep max_retries = 0"; exit 1
+      fi
+
+      if grep -q '"retry_backoff_initial":"500ms"' "$SCRIPT" && grep -q '"retry_backoff_max":"5000ms"' "$SCRIPT"; then
+        echo "  default backoffs = 500ms/5000ms (upstream defaults): OK"
+      else
+        echo "  FAIL: unconfigured upstream should keep upstream backoff defaults"; exit 1
+      fi
+
+      echo "All Bifrost retry config tests passed"
+      touch $out
+    '';
 }


### PR DESCRIPTION
## Problem

During the gemma4 tool-use diagnosis (see #380), Bifrost's debug log showed transient upstream 503s failing requests immediately:

```
"encountered error that should be retried: provider API error (status 503)"
"request failed after 1 attempt"
```

Root cause: Bifrost's stock default is **`max_retries = 0`** — a single attempt — and this module never set it.

## Changes

- **`modules/services/bifrost/darwin.nix`**: new per-upstream options `maxRetries` (default 0 — upstream behavior unchanged unless opted in), `retryBackoffInitialMs` (500) and `retryBackoffMaxMs` (5000), matching Bifrost's `NetworkConfig` schema (`max_retries`, `retry_backoff_initial`, `retry_backoff_max`; backoffs rendered as duration strings, e.g. `"250ms"`). Wired into both the `openai` and `vllm` provider constructors via a shared `mkNetworkConfig` helper.
- **`hosts/megamanx/default.nix`**: `vllm-mlx-local` sets `maxRetries = 3` — hardening on top of the server-side queued lock admission from #380, covering residual busy windows (e.g. model-swap preemption).

## Tests

- Repaired `tests/test-bifrost.nix` — both evals were broken on main by the #361 options migration (same root cause as the vllm-mlx tests fixed in #380); rebuilt on `stubs.bifrost`.
- New `bifrost-retry-config` check greps the generated launchd script's embedded `config.json`: custom retry values land in `network_config`, and unconfigured upstreams keep Bifrost's stock defaults.
- TDD: assertions verified RED before implementation. `check:lint` passes; `stack-integration` still green.

## Note

Touches `hosts/megamanx/default.nix` (bifrost block) — non-overlapping with #380's changes to the same file (vllmMlx block), so either merge order is clean.