### PR TITLE
fix(vllm-mlx): emit terminal finish_reason chunk when parsers swallow it

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -450,7 +450,7 @@
           inherit pkgs self;
           inherit (nixpkgs) lib;
         };
-        inherit (pkgs.stdenv.hostPlatform) isLinux;
+        inherit (pkgs.stdenv.hostPlatform) isLinux isDarwin;
       in
         {
           inherit
@@ -540,6 +540,10 @@
             lume-options
             lume-custom-options
             ;
+        }
+        // nixpkgs.lib.optionalAttrs isDarwin {
+          # Builds the darwin-only vllm-mlx package; excluded on Linux.
+          inherit (tests) vllm-mlx-finish-reason;
         }
         // nixpkgs.lib.optionalAttrs isLinux {
           inherit

--- a/packages/vllm-mlx/default.nix
+++ b/packages/vllm-mlx/default.nix
@@ -27,6 +27,14 @@ python3Packages.buildPythonApplication rec {
     pythonRelaxDepsHook
   ];
 
+  # Emit a terminal finish_reason chunk when the engine's finished output is
+  # swallowed by a parser `continue` in stream_chat_completion (e.g. a bare
+  # <turn|> end-of-turn token after a completed tool call). Without it the
+  # stream ends tool_calls(finish_reason=null) -> [DONE] and OpenAI clients
+  # (pi) abort with "Stream ended without finish_reason". Not fixed upstream
+  # as of v0.4.0.
+  patches = [./emit-terminal-finish-chunk.patch];
+
   pythonRemoveDeps = [
     "gradio"
     "opencv-python"

--- a/packages/vllm-mlx/emit-terminal-finish-chunk.patch
+++ b/packages/vllm-mlx/emit-terminal-finish-chunk.patch
@@ -1,0 +1,92 @@
+--- a/vllm_mlx/server.py	2026-08-02 21:45:45.790750141 -0400
++++ b/vllm_mlx/server.py	2026-08-02 21:47:32.600047111 -0400
+@@ -6036,6 +6036,11 @@
+     tool_calls_detected = False
+     tool_markup_possible = False  # Fast path: skip parsing until markers appear
+     tool_parser = _get_streaming_tool_parser(request, engine)
++    # Whether any emitted chunk carried a terminal finish_reason. The engine's
++    # finished=True output can be swallowed by a parser `continue` below (e.g.
++    # a bare end-of-turn token arriving after a completed tool call); without
++    # the post-loop guard the stream would end with no finish_reason chunk.
++    finish_reason_emitted = False
+ 
+     try:
+         # Stream content
+@@ -6152,6 +6157,9 @@
+                                 usage=get_usage(output) if output.finished else None,
+                             )
+                             yield f"data: {chunk.model_dump_json()}\n\n"
++                            finish_reason_emitted = (
++                                finish_reason_emitted or bool(output.finished)
++                            )
+                             continue
+ 
+                         # Normal content from tool parser
+@@ -6187,6 +6195,9 @@
+                     usage=get_usage(output) if output.finished else None,
+                 )
+                 yield f"data: {chunk.model_dump_json()}\n\n"
++                finish_reason_emitted = finish_reason_emitted or bool(
++                    output.finished
++                )
+             else:
+                 # Standard path without reasoning parsing
+                 content = delta_text
+@@ -6254,6 +6265,9 @@
+                                 usage=get_usage(output) if output.finished else None,
+                             )
+                             yield f"data: {chunk.model_dump_json()}\n\n"
++                            finish_reason_emitted = (
++                                finish_reason_emitted or bool(output.finished)
++                            )
+                             continue
+ 
+                         # Normal content from tool parser
+@@ -6288,6 +6302,9 @@
+                     usage=get_usage(output) if output.finished else None,
+                 )
+                 yield f"data: {chunk.model_dump_json()}\n\n"
++                finish_reason_emitted = finish_reason_emitted or bool(
++                    output.finished
++                )
+ 
+         # Fallback: if tool parser accumulated text but never emitted tool_calls
+         # (e.g., </tool_call> never arrived, or <function= block still incomplete)
+@@ -6327,6 +6344,37 @@
+                     ],
+                 )
+                 yield f"data: {tool_chunk.model_dump_json()}\n\n"
++                finish_reason_emitted = True
++
++        # Terminal-chunk guard: if the engine's finished output was swallowed
++        # by a parser `continue` above (e.g. a bare end-of-turn token arriving
++        # after a completed tool call), no chunk carried finish_reason and
++        # OpenAI clients abort with "stream ended without finish_reason".
++        # Emit the terminal chunk now.
++        if (
++            last_output is not None
++            and getattr(last_output, "finished", False)
++            and not finish_reason_emitted
++        ):
++            terminal_chunk = ChatCompletionChunk(
++                id=response_id,
++                model=_response_model_name(request.model),
++                choices=[
++                    ChatCompletionChunkChoice(
++                        delta=ChatCompletionChunkDelta(),
++                        finish_reason=(
++                            "tool_calls"
++                            if tool_calls_detected
++                            else (
++                                getattr(last_output, "finish_reason", None)
++                                or "stop"
++                            )
++                        ),
++                    )
++                ],
++                usage=get_usage(last_output),
++            )
++            yield f"data: {terminal_chunk.model_dump_json()}\n\n"
+ 
+         # Safety-net validation: if response_format was requested, verify the
+         # accumulated output still parses.  When constrained decoding is active

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -21,6 +21,7 @@
   testLlmClient = import ./test-llm-client.nix {inherit pkgs;};
 
   testVllmMlx = import ./test-vllm-mlx.nix {inherit pkgs;};
+  testVllmMlxStream = import ./test-vllm-mlx-stream.nix {inherit pkgs;};
   testClaudeCode = import ./test-claude-code.nix {inherit pkgs;};
   testPi = import ./test-pi.nix {inherit pkgs;};
   testBifrost = import ./test-bifrost.nix {inherit pkgs;};
@@ -194,6 +195,9 @@ in
     vllm-mlx-options = testVllmMlx.vllmMlxOptionsTest;
     vllm-mlx-launchd = testVllmMlx.vllmMlxLaunchdTest;
     megamanx-vllm = testVllmMlx.megamanxVllmMlxTest;
+
+    # vllm-mlx package streaming tests (builds the package; darwin-only)
+    vllm-mlx-finish-reason = testVllmMlxStream.vllmMlxFinishReasonTest;
 
     # Claude Code module tests
     claude-code-options = testClaudeCode.claudeCodeOptionsTest;

--- a/tests/test-vllm-mlx-stream.nix
+++ b/tests/test-vllm-mlx-stream.nix
@@ -1,0 +1,153 @@
+# vllm-mlx streaming regression tests (functional, package-level)
+#
+# Drives the real stream_chat_completion() from the packaged vllm-mlx with a
+# fake engine reproducing the production failure: gemma4-31b emits a complete
+# canonical tool call (including <tool_call|>) in one delta, then a terminal
+# engine output carrying only the <turn|> end-of-turn token. The gemma4 tool
+# parser finds nothing new in that delta and swallows it with `continue`, so
+# without a terminal-chunk guard no SSE chunk ever carries finish_reason and
+# OpenAI clients (pi) abort with "Stream ended without finish_reason".
+#
+# Scenario 1 (reasoning parser enabled) is the exact live failure; it is
+# covered by the repo's <turn|> stripping postPatch. Scenario 2 (no reasoning
+# parser) exercises the same swallow class on the plain tool-parser branch,
+# which only the terminal-chunk guard fixes.
+{pkgs, ...}: let
+  reproScript = pkgs.writeText "vllm-mlx-finish-reason-repro.py" ''
+    """Regression repro: terminal engine output swallowed by the tool parser."""
+    import asyncio
+    import json
+
+    import vllm_mlx.server as S
+    from vllm_mlx.api.models import ChatCompletionRequest
+    from vllm_mlx.engine.base import GenerationOutput
+    from vllm_mlx.reasoning import get_parser as get_reasoning_parser
+
+
+    class FakeEngine:
+        """Minimal engine stand-in matching the gemma4-31b production stream."""
+
+        model_name = "gemma4-31b"
+        tokenizer = None
+
+        async def stream_chat(self, messages=None, **kwargs):
+            # 1. Thinking block (Gemma 4 channel protocol)
+            for piece in ["<|channel>thought\n", "Let", " me", " check", ".", "\n<channel|>\n"]:
+                yield GenerationOutput(
+                    text=piece,
+                    new_text=piece,
+                    prompt_tokens=10,
+                    completion_tokens=1,
+                    finish_reason=None,
+                    finished=False,
+                )
+            # 2. Complete canonical tool call markup INCLUDING the end marker,
+            #    all in one delta (what gemma4-31b produced in production).
+            #    The parser emits the tool_calls chunk here with
+            #    finish_reason=null (finished=False).
+            markup = '<|tool_call>call:get_weather{<|"|>city<|"|>: <|"|>Paris<|"|>}<tool_call|>'
+            yield GenerationOutput(
+                text=markup,
+                new_text=markup,
+                prompt_tokens=10,
+                completion_tokens=20,
+                finish_reason=None,
+                finished=False,
+            )
+            # 3. Terminal output: bare end-of-turn token, engine reports
+            #    finished (stop-string hit on <turn|>). The tool parser
+            #    re-enters, finds nothing new to emit and swallows this delta
+            #    with `continue` — the bug path: no finish_reason chunk.
+            yield GenerationOutput(
+                text="<turn|>",
+                new_text="<turn|>",
+                prompt_tokens=10,
+                completion_tokens=21,
+                finish_reason="stop",
+                finished=True,
+            )
+
+
+    def make_request():
+        return ChatCompletionRequest(
+            model="gemma4-31b",
+            messages=[{"role": "user", "content": "weather in Paris?"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
+                    },
+                }
+            ],
+        )
+
+
+    async def run_scenario(name, reasoning_parser):
+        S._enable_auto_tool_choice = True
+        S._tool_call_parser = "gemma4"
+        S._tool_parser_instance = None
+        S._reasoning_parser = reasoning_parser
+
+        request = make_request()
+        finish_reasons = []
+        tool_chunks = 0
+        async for frame in S.stream_chat_completion(
+            FakeEngine(), request.messages, request, stop=["<turn|>"]
+        ):
+            assert frame.startswith("data: "), f"unexpected frame: {frame!r}"
+            payload = frame[len("data: ") :].strip()
+            if payload == "[DONE]":
+                continue
+            chunk = json.loads(payload)
+            choice = chunk["choices"][0]
+            if choice["delta"].get("tool_calls"):
+                tool_chunks += 1
+            if choice.get("finish_reason"):
+                finish_reasons.append(choice["finish_reason"])
+
+        print(f"[{name}] tool_chunks={tool_chunks} finish_reasons={finish_reasons}")
+        assert tool_chunks == 1, (
+            f"[{name}] expected exactly one tool_calls chunk, got {tool_chunks}"
+        )
+        assert finish_reasons == ["tool_calls"], (
+            f"[{name}] stream must terminate with a finish_reason='tool_calls' "
+            f"chunk; got finish_reasons={finish_reasons}"
+        )
+
+
+    async def main():
+        await run_scenario(
+            "reasoning-parser", get_reasoning_parser("gemma4")()
+        )
+        await run_scenario("no-reasoning-parser", None)
+        print("OK: terminal finish_reason chunk emitted in both scenarios")
+
+
+    asyncio.run(main())
+  '';
+in {
+  vllmMlxFinishReasonTest =
+    pkgs.runCommand "test-vllm-mlx-finish-reason"
+    {
+      env.HF_HUB_OFFLINE = "1";
+      env.TRANSFORMERS_OFFLINE = "1";
+      env.HOME = "/tmp/vllm-mlx-test-home";
+    }
+    ''
+      mkdir -p "$HOME"
+      # Reuse the exact site-packages closure that wraps the vllm-mlx binary
+      # (withPackages skips buildPythonApplication outputs).
+      PYTHONPATH=$(grep -oP "(?<=')/nix/store/[^']+site-packages(?=')" \
+        ${pkgs.vllm-mlx}/bin/.vllm-mlx-wrapped | tr '\n' ':')
+      export PYTHONPATH
+      ${pkgs.python3}/bin/python ${reproScript}
+      touch $out
+    '';
+}


### PR DESCRIPTION
## Problem

pi aborts gemma4-31b tool calls with **`Stream ended without finish_reason`**.

Reproduced live by replaying the exact failing request (captured from bifrost's logs DB) directly against vllm-mlx: the stream ends with the `tool_calls` chunk (`finish_reason: null`) followed immediately by `data: [DONE]` — no chunk ever carries `finish_reason`, and pi (correctly) throws.

**Important:** the live daemon already runs the current main build (`c6hrmppq…`, with the `<turn|>`-stripping postPatch) and still fails — the bug is *non-deterministic*. It bites when the model keeps its thought channel open through the tool call: the terminal engine output (`finished=True`, bare `<turn|>`) then travels the reasoning path into the gemma4 tool parser, which finds nothing new to emit and swallows the delta with `continue`. When the model closes the channel first, the strip patch saves the stream (empty content → normal chunk carries `finish_reason`). Replays show both outcomes on identical code; the failing pi session hit the bad path 4 times in a row.

## Root cause

In `stream_chat_completion` (vllm_mlx/server.py), every parser `continue` on a `finished=True` output destroys the only chunk that could carry `finish_reason`; there is no post-loop recovery. Affects both the reasoning-parser branch and the plain tool-parser branch (the latter fails deterministically even on closed-channel streams).

Upstream v0.4.0 (latest release) and upstream main have no fix. Related upstream work is narrower or stalled: #629 (open) stamps `finish_reason` on the engine's natural-stop epilogue (different mechanism, doesn't cover parser swallows); #653/#663 (flush reasoning parser at stream end) were closed unmerged after breaking streaming tests in CI.

## Fix

Downstream patch `emit-terminal-finish-chunk.patch`: track whether any emitted chunk carried `finish_reason`; after the streaming loop, if the engine's finished output was suppressed, emit the terminal chunk (`finish_reason="tool_calls"` when tool calls were detected, else the engine's reason or `"stop"`). Single insertion point, parser-agnostic, never alters existing chunks.

## Verification

- **Regression test** (`tests/test-vllm-mlx-stream.nix`, darwin-only check `vllm-mlx-finish-reason`): drives the real `stream_chat_completion` with a fake engine reproducing the production stream through **both** parser branches. RED on unpatched (`finish_reasons=[]` for the no-reasoning-parser scenario), GREEN with the patch.
- **Live replay**: patched server on a scratch port, exact production payload against gemma4-31b → stream ends `tool_calls` chunk → `finish_reason: "tool_calls"` → `[DONE]` (model called `bash ls -R` as in the original failing session).
- `vllm-mlx-options`, `vllm-mlx-launchd`, `megamanx-vllm` checks pass; `check:lint` passes.

## Notes

- After merge, `system:switch` on megamanx restarts the daemon with the patched package.
- Candidate for upstream submission: the swallow class (any parser `continue` on a `finished=True` output loses `finish_reason`) affects all tool parsers, not just gemma4.