### PR TITLE
fix: stabilize bifrost/vllm-mlx timeouts, logging, and KV cache

### DIFF
--- a/hosts/megamanx/default.nix
+++ b/hosts/megamanx/default.nix
@@ -49,17 +49,10 @@
         enableAutoToolChoice = true;
         toolCallParser = "gemma4";
         reasoningParser = "gemma4";
-        # maxKvSize caps the per-sequence KV cache (using RotatingKVCache) and
-        # must be >= pi's maxTokens for the bifrost model (131072). However, the
-        # current vllm-mlx 0.4.0 snapshot probe disables the system-prompt KV cache
-        # when RotatingKVCache is enabled, causing every agent turn to re-prefill
-        # the whole conversation. This is currently far worse than rotation:
-        # generations run 100-300s and time out. Leave maxKvSize unset to keep
-        # the system-prefix KV cache active. Upstream PR #574 (prefix-trie cache)
-        # may resolve this when released; until then, accept unbounded KV growth
-        # (the 90GB memory budget can absorb it; restart the service if needed).
-        #
-        # maxKvSize = 131072;
+        # Must match pi's maxTokens for the bifrost model (131072) — a lower
+        # cap silently rotates the system prompt and tool definitions out of
+        # the KV cache in long agent sessions.
+        maxKvSize = 131072;
         # Must be >= pi's provider.timeoutMs (600s); queued lock admission
         # plus long 31B generations would otherwise be killed server-side.
         timeout = 600;
@@ -80,21 +73,12 @@
 
       bifrost = {
         enable = true;
-        # Bifrost's log level. 'debug' produced ~99MB in 4 days; use 'info' for
-        # normal operations. The logs now live in ~/Library/Logs/bifrost instead
-        # of /tmp so they survive macOS's periodic /tmp cleanup.
-        logLevel = "info";
-        # Module defaults to ~/Library/Logs/bifrost for the primary user.
-        logDir = null;
+        logLevel = "debug";
         upstreams = {
           vllm-mlx-local = {
             url = "http://localhost:8300";
             type = "openai";
-            # Bifrost's per-upstream request timeout. Must be >= pi's provider
-            # timeout (600s) and vllm-mlx's server timeout (600s). Generations
-            # for large agent contexts can run 100-300s on a full prefill, so
-            # 120s was aborting valid mid-stream requests.
-            requestTimeout = 600;
+            requestTimeout = 120;
             # Retry transient 503s (busy engine, model-swap preemption) so a
             # single busy window doesn't fail an agent turn. Bifrost's stock
             # default is 0 retries.

--- a/hosts/megamanx/default.nix
+++ b/hosts/megamanx/default.nix
@@ -49,10 +49,17 @@
         enableAutoToolChoice = true;
         toolCallParser = "gemma4";
         reasoningParser = "gemma4";
-        # Must match pi's maxTokens for the bifrost model (131072) — a lower
-        # cap silently rotates the system prompt and tool definitions out of
-        # the KV cache in long agent sessions.
-        maxKvSize = 131072;
+        # maxKvSize caps the per-sequence KV cache (using RotatingKVCache) and
+        # must be >= pi's maxTokens for the bifrost model (131072). However, the
+        # current vllm-mlx 0.4.0 snapshot probe disables the system-prompt KV cache
+        # when RotatingKVCache is enabled, causing every agent turn to re-prefill
+        # the whole conversation. This is currently far worse than rotation:
+        # generations run 100-300s and time out. Leave maxKvSize unset to keep
+        # the system-prefix KV cache active. Upstream PR #574 (prefix-trie cache)
+        # may resolve this when released; until then, accept unbounded KV growth
+        # (the 90GB memory budget can absorb it; restart the service if needed).
+        #
+        # maxKvSize = 131072;
         # Must be >= pi's provider.timeoutMs (600s); queued lock admission
         # plus long 31B generations would otherwise be killed server-side.
         timeout = 600;
@@ -73,7 +80,12 @@
 
       bifrost = {
         enable = true;
-        logLevel = "debug";
+        # Bifrost's log level. 'debug' produced ~99MB in 4 days; use 'info' for
+        # normal operations. The logs now live in ~/Library/Logs/bifrost instead
+        # of /tmp so they survive macOS's periodic /tmp cleanup.
+        logLevel = "info";
+        # Module defaults to ~/Library/Logs/bifrost for the primary user.
+        logDir = null;
         upstreams = {
           vllm-mlx-local = {
             url = "http://localhost:8300";

--- a/hosts/megamanx/default.nix
+++ b/hosts/megamanx/default.nix
@@ -49,9 +49,12 @@
         enableAutoToolChoice = true;
         toolCallParser = "gemma4";
         reasoningParser = "gemma4";
-        # Must match pi's maxTokens for the bifrost model (131072) — a lower
-        # cap silently rotates the system prompt and tool definitions out of
-        # the KV cache in long agent sessions.
+        # maxKvSize caps the per-sequence KV cache. It must be >= pi's maxTokens
+        # for the bifrost model (131072) so a long agent session does not silently
+        # rotate the system prompt and tool definitions out of the KV cache.
+        # The bundled vllm-mlx patch supports system-prompt snapshots even when the
+        # model uses RotatingKVCache (Gemma 4's sliding-window layers), so the full
+        # prefix is reused each turn instead of re-prefilled.
         maxKvSize = 131072;
         # Must be >= pi's provider.timeoutMs (600s); queued lock admission
         # plus long 31B generations would otherwise be killed server-side.

--- a/hosts/megamanx/default.nix
+++ b/hosts/megamanx/default.nix
@@ -78,7 +78,11 @@
           vllm-mlx-local = {
             url = "http://localhost:8300";
             type = "openai";
-            requestTimeout = 120;
+            # Bifrost's per-upstream request timeout. Must be >= pi's provider
+            # timeout (600s) and vllm-mlx's server timeout (600s). Generations
+            # for large agent contexts can run 100-300s on a full prefill, so
+            # 120s was aborting valid mid-stream requests.
+            requestTimeout = 600;
             # Retry transient 503s (busy engine, model-swap preemption) so a
             # single busy window doesn't fail an agent turn. Bifrost's stock
             # default is 0 retries.

--- a/modules/services/bifrost/darwin.nix
+++ b/modules/services/bifrost/darwin.nix
@@ -17,13 +17,6 @@ with lib; let
   darwinHomeDir = commonLib.darwinHomeDir config;
   appDir = cfg.appDir;
 
-  # Durable log location. /tmp is cleaned by macOS every 3 days; launchd
-  # keeps writing to the deleted inode and all service output is lost.
-  logDir =
-    if cfg.logDir != null
-    then cfg.logDir
-    else "${darwinHomeDir}/Library/Logs/bifrost";
-
   upstreamList = mapAttrsToList (name: value: value // {inherit name;}) cfg.upstreams;
 
   mkOpenaiProviderKey = upstream: {
@@ -157,12 +150,6 @@ in {
       description = "Bifrost log level";
     };
 
-    logDir = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      description = "Directory for launchd stdout/stderr logs. Defaults to ~/Library/Logs/bifrost for the primary user. Do not use /tmp: macOS cleans it every 3 days and launchd keeps writing to the deleted inode, silently discarding all service logs.";
-    };
-
     appDir = mkOption {
       type = types.str;
       default = "$HOME/.config/bifrost";
@@ -231,8 +218,8 @@ in {
         RunAtLoad = true;
         KeepAlive = true;
         UserName = primaryUser;
-        StandardOutPath = "${logDir}/bifrost.log";
-        StandardErrorPath = "${logDir}/bifrost.error.log";
+        StandardOutPath = "/tmp/bifrost.log";
+        StandardErrorPath = "/tmp/bifrost.error.log";
         WorkingDirectory = darwinHomeDir;
         EnvironmentVariables = {
           HOME = darwinHomeDir;
@@ -242,7 +229,7 @@ in {
     };
 
     system.activationScripts.postActivation.text = mkAfter ''
-      mkdir -p "${appDir}" "${logDir}"
+      mkdir -p "${appDir}"
     '';
 
     # Register in service registry for port conflict detection and readiness checks
@@ -250,7 +237,7 @@ in {
       displayName = "Bifrost";
       port = cfg.port;
       label = "com.bifrost.service";
-      errorLog = "${logDir}/bifrost.error.log";
+      errorLog = "/tmp/bifrost.error.log";
       enabled = cfg.enable;
     };
   };

--- a/modules/services/bifrost/darwin.nix
+++ b/modules/services/bifrost/darwin.nix
@@ -17,6 +17,13 @@ with lib; let
   darwinHomeDir = commonLib.darwinHomeDir config;
   appDir = cfg.appDir;
 
+  # Durable log location. /tmp is cleaned by macOS every 3 days; launchd
+  # keeps writing to the deleted inode and all service output is lost.
+  logDir =
+    if cfg.logDir != null
+    then cfg.logDir
+    else "${darwinHomeDir}/Library/Logs/bifrost";
+
   upstreamList = mapAttrsToList (name: value: value // {inherit name;}) cfg.upstreams;
 
   mkOpenaiProviderKey = upstream: {
@@ -150,6 +157,12 @@ in {
       description = "Bifrost log level";
     };
 
+    logDir = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Directory for launchd stdout/stderr logs. Defaults to ~/Library/Logs/bifrost for the primary user. Do not use /tmp: macOS cleans it every 3 days and launchd keeps writing to the deleted inode, silently discarding all service logs.";
+    };
+
     appDir = mkOption {
       type = types.str;
       default = "$HOME/.config/bifrost";
@@ -218,8 +231,8 @@ in {
         RunAtLoad = true;
         KeepAlive = true;
         UserName = primaryUser;
-        StandardOutPath = "/tmp/bifrost.log";
-        StandardErrorPath = "/tmp/bifrost.error.log";
+        StandardOutPath = "${logDir}/bifrost.log";
+        StandardErrorPath = "${logDir}/bifrost.error.log";
         WorkingDirectory = darwinHomeDir;
         EnvironmentVariables = {
           HOME = darwinHomeDir;
@@ -229,7 +242,7 @@ in {
     };
 
     system.activationScripts.postActivation.text = mkAfter ''
-      mkdir -p "${appDir}"
+      mkdir -p "${appDir}" "${logDir}"
     '';
 
     # Register in service registry for port conflict detection and readiness checks
@@ -237,7 +250,7 @@ in {
       displayName = "Bifrost";
       port = cfg.port;
       label = "com.bifrost.service";
-      errorLog = "/tmp/bifrost.error.log";
+      errorLog = "${logDir}/bifrost.error.log";
       enabled = cfg.enable;
     };
   };

--- a/packages/vllm-mlx/default.nix
+++ b/packages/vllm-mlx/default.nix
@@ -33,7 +33,16 @@ python3Packages.buildPythonApplication rec {
   # stream ends tool_calls(finish_reason=null) -> [DONE] and OpenAI clients
   # (pi) abort with "Stream ended without finish_reason". Not fixed upstream
   # as of v0.4.0.
-  patches = [./emit-terminal-finish-chunk.patch];
+  #
+  # Allow system-prompt KV cache snapshots when the model mixes plain KVCache
+  # and RotatingKVCache (e.g. Gemma 4). The upstream 0.4.0 probe disables
+  # snapshots for any non-KVCache class, forcing a full re-prefill on every
+  # turn. mlx-lm exposes the extra cursor metadata via meta_state, so capture
+  # and restore it alongside the array state. Not fixed upstream as of v0.4.0.
+  patches = [
+    ./emit-terminal-finish-chunk.patch
+    ./snapshot-rotating-kv-cache.patch
+  ];
 
   pythonRemoveDeps = [
     "gradio"

--- a/packages/vllm-mlx/snapshot-rotating-kv-cache.patch
+++ b/packages/vllm-mlx/snapshot-rotating-kv-cache.patch
@@ -1,5 +1,5 @@
---- /Users/monkey/workspaces/fix-agent-pi-bifrost-vllm-mlx/tmp-patchgen/simple.py.orig	2026-08-06 00:25:46.448811097 -0400
-+++ /Users/monkey/workspaces/fix-agent-pi-bifrost-vllm-mlx/tmp-patchgen/simple.py.patched	2026-08-06 00:26:02.878066042 -0400
+--- a/vllm_mlx/engine/simple.py	2026-08-06 00:25:46.448811097 -0400
++++ b/vllm_mlx/engine/simple.py	2026-08-06 00:26:02.878066042 -0400
 @@ -249,16 +249,18 @@
              "evictions": 0,
          }

--- a/packages/vllm-mlx/snapshot-rotating-kv-cache.patch
+++ b/packages/vllm-mlx/snapshot-rotating-kv-cache.patch
@@ -1,0 +1,77 @@
+--- /Users/monkey/workspaces/fix-agent-pi-bifrost-vllm-mlx/tmp-patchgen/simple.py.orig	2026-08-06 00:25:46.448811097 -0400
++++ /Users/monkey/workspaces/fix-agent-pi-bifrost-vllm-mlx/tmp-patchgen/simple.py.patched	2026-08-06 00:26:02.878066042 -0400
+@@ -249,16 +249,18 @@
+             "evictions": 0,
+         }
+         # True only when the model's prompt cache can be snapshotted and
+-        # restored for the manual system-prefix cache branch. Plain KV caches
+-        # and hybrid ``ArraysCache`` entries are safe when their state
+-        # containers are copied at snapshot/restore boundaries. Sliding-window
+-        # cache classes such as ``RotatingKVCache`` remain disabled because
+-        # their extra cursor metadata is not captured by ``.state`` alone.
++        # restored for the manual system-prefix cache branch. Plain KV caches,
++        # hybrid ``ArraysCache`` entries, and ``RotatingKVCache`` are safe when
++        # their state and metadata are captured/restored at boundaries.
+         self._supports_system_kv_cache: bool = False
+ 
+     @staticmethod
+     def _clone_cache_state(value: Any) -> Any:
+-        """Copy cache state containers without duplicating immutable MLX arrays."""
++        """Copy cache state containers without duplicating immutable MLX arrays.
++
++        Also handles meta_state containers (e.g. RotatingKVCache metadata) so
++        that sliding-window caches can be snapshotted and restored safely.
++        """
+         if isinstance(value, tuple):
+             return tuple(SimpleEngine._clone_cache_state(v) for v in value)
+         if isinstance(value, list):
+@@ -266,9 +268,17 @@
+         return value
+ 
+     @classmethod
++    def _cache_entry_snapshot(cls, cache_entry: Any) -> Any:
++        """Capture both value state and cursor metadata for a cache entry."""
++        state = cls._clone_cache_state(cache_entry.state)
++        if hasattr(cache_entry, "meta_state"):
++            return (state, cache_entry.meta_state)
++        return state
++
++    @classmethod
+     def _snapshot_prompt_cache(cls, prompt_cache: list[Any]) -> list[Any]:
+         """Capture cache states without aliasing mutable state containers."""
+-        return [cls._clone_cache_state(c.state) for c in prompt_cache]
++        return [cls._cache_entry_snapshot(c) for c in prompt_cache]
+ 
+     @classmethod
+     def _restore_prompt_cache(
+@@ -276,7 +286,13 @@
+     ) -> None:
+         """Restore cache states without letting decode mutate the saved snapshot."""
+         for i, saved_state in enumerate(snapshot):
+-            prompt_cache[i].state = cls._clone_cache_state(saved_state)
++            cache_entry = prompt_cache[i]
++            if isinstance(saved_state, tuple) and len(saved_state) == 2:
++                value_state, meta_state = saved_state
++                cache_entry.state = cls._clone_cache_state(value_state)
++                cache_entry.meta_state = meta_state
++            else:
++                cache_entry.state = cls._clone_cache_state(saved_state)
+ 
+     @staticmethod
+     def _iter_cache_state_arrays(value: Any):
+@@ -295,12 +311,12 @@
+     @staticmethod
+     def _cache_class_is_system_snapshot_safe(cache_entry: Any) -> bool:
+         try:
+-            from mlx_lm.models.cache import ArraysCache, KVCache
++            from mlx_lm.models.cache import ArraysCache, KVCache, RotatingKVCache
+ 
+-            return isinstance(cache_entry, (KVCache, ArraysCache))
++            return isinstance(cache_entry, (KVCache, ArraysCache, RotatingKVCache))
+         except Exception:
+             cache_type = type(cache_entry).__name__
+-            return cache_type in {"KVCache", "ArraysCache"}
++            return cache_type in {"KVCache", "ArraysCache", "RotatingKVCache"}
+ 
+     @classmethod
+     def _probe_system_kv_cache_support(cls, model: Any, route: str) -> bool:


### PR DESCRIPTION
## Problem

Diagnosed the local bifrost + vllm-mlx stack and found three cascading issues:

1. **System KV cache disabled**: vllm-mlx 0.4.0's snapshot probe rejects any cache that is not plain `KVCache`/`ArraysCache`. Gemma 4's `make_cache()` returns a mix of `KVCache` and `RotatingKVCache` (sliding-window layers), so the probe disabled the system-prompt snapshot. Every agent turn re-prefilled the whole conversation → median 1.3 tok/s, 91% of completions >100s, 31 >200s.
2. **Timeout mismatch**: bifrost upstream `requestTimeout = 120s` was firing mid-generation, while pi and vllm-mlx expect up to 600s.
3. **Log hygiene**: bifrost ran at `debug` level with logs in `/tmp` (lost by macOS every 3 days) and a 1GB `logs.db` backlog.

Also cleaned up a stray `ollama-local` provider in the bifrost SQLite DB and a leftover repro vllm-mlx on port 8399.

## Changes

- `feat(vllm-mlx): patch system-prompt KV snapshot for RotatingKVCache` — capture and restore `meta_state` (cursor metadata) alongside array state; keep `maxKvSize = 131072` to match pi's `maxTokens`.
- `fix(vllm-mlx): restore maxKvSize=131072 with patched snapshot support` — re-enable the original cap now that the snapshot works.
- `fix(bifrost): raise upstream requestTimeout to 600s` — align with pi/vllm-mlx timeouts.
- `fix(bifrost): move logs off /tmp and default to info level` — new module `logDir` option defaulting to `~/Library/Logs/bifrost`; set host level to `info`.

Runtime cleanup already performed: killed stray port-8399 vllm-mlx, deleted `ollama-local` from `~/.config/bifrost/config.db`, and renamed `logs.db` to a backup.

## Verification

- `devenv tasks run check:lint` ✅
- `devenv tasks run test` ✅
- `nix build --impure .#darwinConfigurations.MegamanX.system --no-link` ✅

## To complete

The final `devenv tasks run system:switch` requires a sudo password from 1Password. Since `op` is not currently signed in in this session, I cannot finish the live activation. Please sign in to 1Password (`op signin`) and then run:

```bash
devenv tasks run system:switch
```

This will restart vllm-mlx with the patched binary and the new bifrost settings.
