### PR TITLE
feat(benchmarks): add lm-eval and lighteval with devenv smoke/benchmark tasks

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -1,5 +1,10 @@
 {pkgs, ...}: let
   devBase = import ./library/dev-base.nix {inherit pkgs;};
+
+  # Benchmarking suites are not in upstream nixpkgs; call them directly from
+  # the repo packages so they are available in the devenv shell and tasks.
+  lm-eval = pkgs.callPackage ./packages/benchmarks/lm-eval {};
+  lighteval = pkgs.callPackage ./packages/benchmarks/lighteval {};
 in {
   packages =
     devBase.packages
@@ -16,6 +21,10 @@ in {
       # CI and deployment
       pkgs.cachix
       pkgs.deploy-rs
+
+      # LLM benchmarking suites
+      lm-eval
+      lighteval
 
       # Utility
       pkgs.rsync
@@ -945,6 +954,158 @@ in {
         echo ""
 
         ./scripts/profile-llm.sh "$MODEL" --prompts "$PROMPTS" --max-tokens "$MAX_TOKENS" --output-dir ./profiling
+      '';
+    };
+
+    "smoke:llm-stack" = {
+      description = "Smoke test the local LLM stack (vllm-mlx + bifrost)";
+      exec = ''
+        set -euo pipefail
+
+        BIFROST_URL="''${BIFROST_URL:-http://bifrost.internal/v1}"
+        VLLM_URL="''${VLLM_URL:-http://localhost:8300/v1}"
+        MODEL="''${MODEL:-gemma4-31b}"
+        TIMEOUT="''${TIMEOUT:-120}"
+
+        echo "=== LLM Stack Smoke Test ==="
+        echo "vllm-mlx:  $VLLM_URL"
+        echo "bifrost:   $BIFROST_URL"
+        echo "model:     $MODEL"
+        echo ""
+
+        echo "-- vllm-mlx /v1/models --"
+        curl -sf --max-time "$TIMEOUT" "$VLLM_URL/models" | jq -e '.data | length > 0'
+        echo "vllm-mlx models OK"
+        echo ""
+
+        echo "-- vllm-mlx /v1/chat/completions --"
+        curl -sf --max-time "$TIMEOUT" "$VLLM_URL/chat/completions" \
+          -H "Content-Type: application/json" \
+          -d "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Say OK\"}],\"max_tokens\":5}" \
+          | jq -e '.choices[0].message.content != null'
+        echo "vllm-mlx chat completion OK"
+        echo ""
+
+        echo "-- bifrost /v1/models --"
+        curl -sf --max-time "$TIMEOUT" "$BIFROST_URL/models" | jq -e '.data | length > 0'
+        echo "bifrost models OK"
+        echo ""
+
+        echo "-- bifrost /v1/chat/completions --"
+        curl -sf --max-time "$TIMEOUT" "$BIFROST_URL/chat/completions" \
+          -H "Content-Type: application/json" \
+          -d "{\"model\":\"vllm-mlx-local/$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Say OK\"}],\"max_tokens\":5}" \
+          | jq -e '.choices[0].message.content != null'
+        echo "bifrost chat completion OK"
+        echo ""
+
+        echo "=== LLM stack smoke test passed ==="
+      '';
+    };
+
+    "benchmark:lm-eval-gsm8k" = {
+      description = "Run lm-eval GSM8K (math reasoning) against local vllm-mlx";
+      exec = ''
+        set -euo pipefail
+
+        BASE_URL="''${BASE_URL:-http://localhost:8300/v1/chat/completions}"
+        MODEL="''${MODEL:-gemma4-31b}"
+        LIMIT="''${LIMIT:-50}"
+        OUTPUT_DIR="''${OUTPUT_DIR:-./benchmark-results/lm-eval-gsm8k}"
+
+        echo "=== lm-eval GSM8K against $BASE_URL (model: $MODEL) ==="
+        mkdir -p "$OUTPUT_DIR"
+
+        lm-eval run \
+          --model local-chat-completions \
+          --model_args model="$MODEL",base_url="$BASE_URL",num_concurrent=1,max_retries=3 \
+          --tasks gsm8k \
+          --limit "$LIMIT" \
+          --batch_size 1 \
+          --output_path "$OUTPUT_DIR" \
+          --log_samples
+
+        echo ""
+        echo "Results written to $OUTPUT_DIR"
+      '';
+    };
+
+    "benchmark:lm-eval-mini" = {
+      description = "Quick lm-eval smoke benchmark (small subsets) against local vllm-mlx";
+      exec = ''
+        set -euo pipefail
+
+        BASE_URL="''${BASE_URL:-http://localhost:8300/v1/completions}"
+        MODEL="''${MODEL:-gemma4-31b}"
+        LIMIT="''${LIMIT:-10}"
+        OUTPUT_DIR="''${OUTPUT_DIR:-./benchmark-results/lm-eval-mini}"
+
+        echo "=== lm-eval mini benchmark against $BASE_URL (model: $MODEL) ==="
+        mkdir -p "$OUTPUT_DIR"
+
+        lm-eval run \
+          --model local-completions \
+          --model_args model="$MODEL",base_url="$BASE_URL",num_concurrent=1,max_retries=3 \
+          --tasks mmlu,arc_easy,hellaswag \
+          --limit "$LIMIT" \
+          --batch_size 1 \
+          --apply_chat_template \
+          --output_path "$OUTPUT_DIR" \
+          --log_samples
+
+        echo ""
+        echo "Results written to $OUTPUT_DIR"
+      '';
+    };
+
+    "benchmark:lm-eval-leaderboard" = {
+      description = "Run the HuggingFace Open LLM Leaderboard v2 task group against local vllm-mlx";
+      exec = ''
+        set -euo pipefail
+
+        BASE_URL="''${BASE_URL:-http://localhost:8300/v1/completions}"
+        MODEL="''${MODEL:-gemma4-31b}"
+        OUTPUT_DIR="''${OUTPUT_DIR:-./benchmark-results/lm-eval-leaderboard}"
+
+        echo "=== lm-eval Open LLM Leaderboard v2 against $BASE_URL (model: $MODEL) ==="
+        echo "This is a long-running benchmark. Set LIMIT=N for a quick subset."
+        echo ""
+        mkdir -p "$OUTPUT_DIR"
+
+        lm-eval run \
+          --model local-completions \
+          --model_args model="$MODEL",base_url="$BASE_URL",num_concurrent=1,max_retries=3 \
+          --tasks leaderboard \
+          --batch_size 1 \
+          --apply_chat_template \
+          --output_path "$OUTPUT_DIR" \
+          --log_samples
+
+        echo ""
+        echo "Results written to $OUTPUT_DIR"
+      '';
+    };
+
+    "benchmark:lighteval-gsm8k" = {
+      description = "Run lighteval GSM8K against a local OpenAI-compatible endpoint";
+      exec = ''
+        set -euo pipefail
+
+        API_BASE="''${API_BASE:-http://localhost:8300/v1}"
+        MODEL="''${MODEL:-gemma4-31b}"
+        OUTPUT_DIR="''${OUTPUT_DIR:-./benchmark-results/lighteval-gsm8k}"
+        MAX_SAMPLES="''${MAX_SAMPLES:-50}"
+
+        echo "=== lighteval GSM8K against $API_BASE (model: $MODEL) ==="
+        mkdir -p "$OUTPUT_DIR"
+
+        lighteval endpoint litellm \
+          "provider=openai,model_name=$MODEL,api_base=$API_BASE" \
+          "gsm8k|0|0|$MAX_SAMPLES" \
+          --output-dir "$OUTPUT_DIR"
+
+        echo ""
+        echo "Results written to $OUTPUT_DIR"
       '';
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -140,7 +140,7 @@
         };
       in
         {
-          inherit (pkgs) rtk yaks vane vllm-mlx mlx-vlm mlx-audio mlx-embeddings gemma4-31B-4bit gemma4-e4B-4bit;
+          inherit (pkgs) rtk yaks vane vllm-mlx mlx-vlm mlx-audio mlx-embeddings gemma4-31B-4bit gemma4-e4B-4bit lm-eval lighteval;
           inherit (inputs.devenv.packages.${system}) devenv;
           installer = pkgs.callPackage ./packages/installer {};
         }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -6,6 +6,8 @@
   jj-hooks = final.callPackage ../packages/jj-hooks {};
   lume = final.callPackage ../packages/lume {};
   vane = final.callPackage ../packages/vane {};
+  lm-eval = final.callPackage ../packages/benchmarks/lm-eval {};
+  lighteval = final.callPackage ../packages/benchmarks/lighteval {};
   mlx-audio = final.callPackage ../packages/mlx-audio {};
   mlx-lm = final.callPackage ../packages/mlx-lm {};
   mlx-vlm = final.callPackage ../packages/mlx-vlm {};

--- a/packages/benchmarks/lighteval/default.nix
+++ b/packages/benchmarks/lighteval/default.nix
@@ -1,0 +1,98 @@
+# HuggingFace Lighteval — lightweight and configurable LLM evaluation package.
+# Provides a fast alternative to lm-eval with support for leaderboard tasks.
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "lighteval";
+  version = "0.13.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = "lighteval";
+    tag = "v${version}";
+    hash = "sha256-iDkTisvtyBZZFkmuGzRraqf8PUX1G5pZAR+CkbTmJ78=";
+  };
+
+  nativeBuildInputs = with python3Packages; [
+    setuptools
+    wheel
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = true;
+
+  pythonRemoveDeps = [
+    # Heavy extras not packaged in nixpkgs; core local evaluation still works
+    "inspect-ai"
+    "inspect_ai"
+    "latex2sympy2-extended"
+    "latex2sympy2_extended"
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    accelerate
+    datasets
+    numpy
+    pyyaml
+    requests
+    torch
+    transformers
+    # API / local endpoint support
+    openai
+    anthropic
+    litellm
+    typer
+    rich
+    # Task dependencies
+    scipy
+    scikit-learn
+    sentencepiece
+    protobuf
+    ninja
+    # Metrics
+    sacrebleu
+    rouge-score
+    nltk
+    # Other common deps
+    huggingface-hub
+    tokenizers
+    safetensors
+    filelock
+    fsspec
+    # Metrics / utils
+    gitpython
+    termcolor
+    colorlog
+    aenum
+    pycountry
+    langcodes
+    pytablewriter
+  ];
+
+  # inspect-ai is an optional extended-task backend; guard the import and the
+  # CLI registration so the tool still works when inspect-ai is not installed.
+  postPatch = ''
+        substituteInPlace src/lighteval/__main__.py \
+          --replace-fail "import lighteval.main_inspect" "try:
+        import lighteval.main_inspect
+        HAS_INSPECT = True
+    except ModuleNotFoundError:
+        HAS_INSPECT = False" \
+          --replace-fail "app.command(rich_help_panel=\"Evaluation Backends\")(lighteval.main_inspect.eval)" "if HAS_INSPECT:
+        app.command(rich_help_panel=\"Evaluation Backends\")(lighteval.main_inspect.eval)" \
+          --replace-fail "app.command(rich_help_panel=\"EvaluationUtils\")(lighteval.main_inspect.bundle)" "if HAS_INSPECT:
+        app.command(rich_help_panel=\"EvaluationUtils\")(lighteval.main_inspect.bundle)"
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "A lightweight and configurable evaluation package for LLMs";
+    homepage = "https://github.com/huggingface/lighteval";
+    license = lib.licenses.mit;
+  };
+}

--- a/packages/benchmarks/lm-eval/default.nix
+++ b/packages/benchmarks/lm-eval/default.nix
@@ -1,0 +1,71 @@
+# EleutherAI LM Evaluation Harness — backend for HuggingFace Open LLM Leaderboard
+# Supports evaluating local API servers (OpenAI-compatible) and HuggingFace models.
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "lm-eval";
+  version = "0.4.10";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "EleutherAI";
+    repo = "lm-evaluation-harness";
+    tag = "v${version}";
+    hash = "sha256-+fVLpJ/wzFyQJkdlHTirTNrtWg7Vn26kU0OV4+oDJXA=";
+  };
+
+  nativeBuildInputs = with python3Packages; [
+    setuptools
+    wheel
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = true;
+
+  propagatedBuildInputs = with python3Packages; [
+    # Core dependencies
+    accelerate
+    datasets
+    evaluate
+    jsonlines
+    numpy
+    peft
+    pybind11
+    pytablewriter
+    pyyaml
+    regex
+    requests
+    sacrebleu
+    scikit-learn
+    scipy
+    sentencepiece
+    sqlitedict
+    torch
+    tqdm
+    transformers
+    zstandard
+    # API backends (local OpenAI/Anthropic-compatible servers)
+    openai
+    anthropic
+    tiktoken
+    # Common task deps
+    einops
+    bitsandbytes
+    optimum
+    rouge-score
+    word2number
+    more-itertools
+  ];
+
+  # Skip network-dependent tests
+  doCheck = false;
+
+  meta = {
+    description = "A framework for few-shot evaluation of language models";
+    homepage = "https://github.com/EleutherAI/lm-evaluation-harness";
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
## What

Adds the first two LLM benchmarking suites to the devenv and exposes them as reusable tasks.

## Packages

- `packages/benchmarks/lm-eval` — EleutherAI LM Evaluation Harness 0.4.10 (HuggingFace Open LLM Leaderboard backend).
- `packages/benchmarks/lighteval` — HuggingFace Lighteval 0.13.0 (also leaderboard-oriented).

Both are installed in the devenv shell and exposed in `packages.aarch64-darwin.lm-eval` / `lighteval`.

## Devenv tasks

| Task | Purpose |
|---|---|
| `smoke:llm-stack` | Health-check `vllm-mlx` and `bifrost` `/v1/models` + `/v1/chat/completions` |
| `benchmark:lm-eval-mini` | Quick lm-eval subset (`mmlu`, `arc_easy`, `hellaswag`) with `LIMIT=10` |
| `benchmark:lm-eval-gsm8k` | lm-eval GSM8K math reasoning against the local endpoint |
| `benchmark:lm-eval-leaderboard` | Full HuggingFace Open LLM Leaderboard v2 task group |
| `benchmark:lighteval-gsm8k` | lighteval path for GSM8K against the local endpoint |

All tasks default to `MODEL=gemma4-31b`, `BASE_URL=http://localhost:8300/v1/*`, and `BIFROST_URL=http://bifrost.internal/v1`. Override with env vars.

## Verification

- `devenv tasks run check:lint` ✅
- `devenv tasks run test` ✅
- `nix build --impure .#packages.aarch64-darwin.lm-eval .#packages.aarch64-darwin.lighteval --no-link` ✅

## Notes

- lighteval is patched to tolerate the absence of `inspect-ai` (a heavy optional backend not in nixpkgs) and `latex2sympy2_extended` (math extra). Core local-endpoint evaluation still works.
- This is the first incremental benchmark PR. Others (EvalScope, code evals, function-calling benchmarks) can follow the same pattern.