### PR TITLE
feat(desktop): install Obsidian via home-manager with Syncthing vault sync

### DIFF
--- a/hosts/megamanx/default.nix
+++ b/hosts/megamanx/default.nix
@@ -19,6 +19,8 @@
     // {
       skills.superpowersPath = inputs.superpowers;
 
+      obsidian.vaults = ["personal"];
+
       # Extra role beyond workstation archetype
       roles.entertainment.enable = true;
 

--- a/hosts/wweaver/default.nix
+++ b/hosts/wweaver/default.nix
@@ -28,6 +28,8 @@
       };
       onepassword.sudoPasswordRef = "op://Employee/wweaver Sudo Password/password";
 
+      obsidian.vaults = ["personal"];
+
       # Roles beyond developer-laptop-darwin archetype (homebrew, desktop, entertainment already set)
       roles.developer.enable = true;
       roles.workstation.enable = true;

--- a/modules/common/obsidian.nix
+++ b/modules/common/obsidian.nix
@@ -1,0 +1,56 @@
+# myConfig.obsidian options — owned here, consumed by modules/home-manager/obsidian.nix
+# (loaded conditionally via modules/common/users.nix) and set by
+# modules/roles/desktop.nix.
+{lib, ...}: {
+  options.myConfig.obsidian = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable Obsidian note-taking app via home-manager";
+    };
+
+    vaultRoot = lib.mkOption {
+      type = lib.types.str;
+      default = "~/Documents/vaults";
+      description = ''
+        Root directory for all Obsidian vaults. Each vault name in
+        `myConfig.obsidian.vaults` becomes a subdirectory here.
+      '';
+    };
+
+    vaults = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      example = ["personal" "work"];
+      description = ''
+        Names of Obsidian vaults on this machine. Each name creates a vault at
+        `<vaultRoot>/<name>` and a corresponding Syncthing folder.
+      '';
+    };
+
+    syncAllVaults = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Sync all known vault names via Syncthing regardless of whether Obsidian
+        is enabled. Intended for backup servers or machines that should mirror
+        every vault without running Obsidian itself.
+
+        When false (default), only vaults listed in `myConfig.obsidian.vaults`
+        are synced. When true, the machine participates in syncing all vault
+        folder IDs it knows about.
+      '';
+    };
+
+    allVaults = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      example = ["personal" "work"];
+      description = ''
+        Exhaustive list of all vault names that exist across every machine.
+        Only used when `syncAllVaults = true` to register Syncthing folders
+        for vaults not listed in `myConfig.obsidian.vaults`.
+      '';
+    };
+  };
+}

--- a/modules/common/users.nix
+++ b/modules/common/users.nix
@@ -83,6 +83,7 @@ with lib; let
           ++ optional config.myConfig.pi.enable ../../modules/home-manager/pi-coding-agent.nix
           ++ optional ((config.myConfig.vane.openaiBaseUrlOpnixItem or null) != null) ../../modules/home-manager/vane-secrets.nix
           ++ optional config.myConfig.zellij.enable ../../modules/home-manager/zellij.nix
+          ++ optional config.myConfig.obsidian.enable ../../modules/home-manager/obsidian.nix
           ++ optional config.myConfig.agent-skills.enable ../../modules/home-manager/skills/install.nix
           ++ optional config.myConfig.email-agent.enable ../../modules/home-manager/email-agent.nix
           ++ optional config.myConfig.email-backup.enable ../../modules/home-manager/email-backup.nix

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -16,6 +16,7 @@
     ./common/charm.nix
     ./common/syncthing.nix
     ./common/zellij.nix
+    ./common/obsidian.nix
     ./common/agent-user.nix
 
     # Home-manager shared settings

--- a/modules/home-manager/foundation.nix
+++ b/modules/home-manager/foundation.nix
@@ -7,12 +7,42 @@
   myConfig,
   earthsong,
   ...
-}: {
+}: let
+  obsCfg = myConfig.obsidian;
+
+  # Vaults to register as Syncthing folders:
+  # - Always include vaults this machine runs Obsidian for.
+  # - When syncAllVaults = true, also include any vaults in allVaults that
+  #   aren't already covered (for backup/mirror machines without Obsidian).
+  syncedVaultNames = lib.unique (
+    obsCfg.vaults
+    ++ (lib.optionals obsCfg.syncAllVaults obsCfg.allVaults)
+  );
+
+  # Build syncthing folder entries: one per synced vault.
+  # path uses the same vaultRoot as obsidian.nix; id is stable across machines.
+  syncthingVaultFolders = lib.listToAttrs (
+    map (name: {
+      inherit name;
+      value = {
+        path = "${obsCfg.vaultRoot}/${name}";
+        id = "obsidian-${name}";
+        label = "Obsidian: ${name}";
+      };
+    })
+    syncedVaultNames
+  );
+
+  hasSyncedVaults = syncedVaultNames != [];
+in {
   # Syncthing for file synchronization
   services.syncthing = lib.mkIf myConfig.syncthing.enable {
     enable = true;
     overrideDevices = false;
-    overrideFolders = false;
+    # Override folders only when we have Nix-managed vault folders, so manually
+    # added folders are preserved on machines with no vaults configured.
+    overrideFolders = hasSyncedVaults;
+    settings.folders = lib.mkIf hasSyncedVaults syncthingVaultFolders;
   };
 
   # jj-hooks: runs pre-commit/prek/lefthook/hk hooks against jj bookmark

--- a/modules/home-manager/obsidian.nix
+++ b/modules/home-manager/obsidian.nix
@@ -1,0 +1,28 @@
+{
+  osConfig,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = osConfig.myConfig.obsidian;
+
+  # Build a programs.obsidian.vaults attrset from the vault name list.
+  # Each vault gets target = "<vaultRoot>/<name>" (tilde is expanded by HM).
+  vaultAttrs = lib.listToAttrs (
+    map (name: {
+      inherit name;
+      value = {
+        target = "${cfg.vaultRoot}/${name}";
+      };
+    })
+    cfg.vaults
+  );
+in {
+  config = lib.mkIf cfg.enable {
+    programs.obsidian = {
+      enable = true;
+      package = pkgs.obsidian;
+      vaults = vaultAttrs;
+    };
+  };
+}

--- a/modules/roles/desktop.nix
+++ b/modules/roles/desktop.nix
@@ -19,6 +19,7 @@ in {
             # Tracked: libuv kqueue.c:279 errno == EINTR
             # super-productivity
           ];
+          myConfig.obsidian.enable = true;
         }
         (lib.mkIf (!isDarwin) {
           environment.systemPackages = with pkgs; [

--- a/tests/stubs.nix
+++ b/tests/stubs.nix
@@ -184,6 +184,7 @@ in rec {
     ../modules/common/charm.nix
     ../modules/common/syncthing.nix
     ../modules/common/zellij.nix
+    ../modules/common/obsidian.nix
     hostPlatformStub
     envStub
     broadStub


### PR DESCRIPTION
## Summary

Installs Obsidian via home-manager's `programs.obsidian` module (available since HM 2026-04-22, covered by our pinned HM) rather than a Homebrew cask. Vaults are declared in Nix and automatically registered as Syncthing folders.

## Changes

### New options: `myConfig.obsidian`

| Option | Default | Description |
|--------|---------|-------------|
| `enable` | `false` | Install Obsidian via home-manager |
| `vaultRoot` | `~/Documents/vaults` | Root directory for all vaults |
| `vaults` | `[]` | Vault names — each gets an Obsidian vault + Syncthing folder |
| `syncAllVaults` | `false` | Sync `allVaults` regardless of Obsidian (for backup servers) |
| `allVaults` | `[]` | Exhaustive cross-machine vault list (used with `syncAllVaults`) |

### Sync behaviour
- Every vault in `vaults` automatically gets a Syncthing folder (`id = obsidian-<name>`)
- `syncAllVaults = true` + `allVaults` lets a backup/NAS machine mirror all vaults without running Obsidian
- `overrideFolders` is only set to `true` when Nix-managed folders exist, preserving manually-added folders on machines with no vaults

### Files
- `modules/common/obsidian.nix` — option declarations
- `modules/home-manager/obsidian.nix` — `programs.obsidian` wiring
- `modules/home-manager/foundation.nix` — Syncthing folder generation
- `modules/common/users.nix` — conditional HM module import
- `modules/default.nix` — import obsidian option module
- `modules/roles/desktop.nix` — `myConfig.obsidian.enable = true`
- `hosts/wweaver`: `vaults = ["personal"]`
- `hosts/megamanx`: `vaults = ["personal"]`