### PR TITLE
refactor(ci): merge test-foundation + validate-auxiliary, remove duplicate cache

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -371,8 +371,7 @@ jobs:
       - build-nixos
       - build-nixos-arm
       - discover-targets
-      - test-foundation
-      - validate-auxiliary
+      - test-and-validate
     if: always()
     steps:
       - name: Download staging cache
@@ -390,10 +389,8 @@ jobs:
              needs.build-nixos.result == 'skipped') &&
             (needs.build-nixos-arm.result == 'success' ||
              needs.build-nixos-arm.result == 'skipped') &&
-            (needs.test-foundation.result == 'success' ||
-             needs.test-foundation.result == 'skipped') &&
-            (needs.validate-auxiliary.result == 'success' ||
-             needs.validate-auxiliary.result == 'skipped')
+            (needs.test-and-validate.result == 'success' ||
+             needs.test-and-validate.result == 'skipped')
           }}
         run: |
           echo "Builds succeeded - committing new derivation hashes to cache"
@@ -411,26 +408,8 @@ jobs:
              needs.build-nixos.result == 'skipped') &&
             (needs.build-nixos-arm.result == 'success' ||
              needs.build-nixos-arm.result == 'skipped') &&
-            (needs.test-foundation.result == 'success' ||
-             needs.test-foundation.result == 'skipped') &&
-            (needs.validate-auxiliary.result == 'success' ||
-             needs.validate-auxiliary.result == 'skipped')
-          }}
-        uses: actions/cache@v4
-        with:
-          path: .drv-cache
-          key: drv-${{ github.ref }}-${{ github.sha }}
-      - name: Save derivation cache
-        if: >
-          ${{
-            (needs.build-darwin.result == 'success' ||
-             needs.build-darwin.result == 'skipped') &&
-            (needs.build-nixos.result == 'success' ||
-             needs.build-nixos.result == 'skipped') &&
-            (needs.test-foundation.result == 'success' ||
-             needs.test-foundation.result == 'skipped') &&
-            (needs.validate-auxiliary.result == 'success' ||
-             needs.validate-auxiliary.result == 'skipped')
+            (needs.test-and-validate.result == 'success' ||
+             needs.test-and-validate.result == 'skipped')
           }}
         uses: actions/cache@v4
         with:
@@ -443,8 +422,7 @@ jobs:
           DARWIN_RESULT="${{ needs.build-darwin.result }}"
           NIXOS_RESULT="${{ needs.build-nixos.result }}"
           NIXOS_ARM_RESULT="${{ needs.build-nixos-arm.result }}"
-          TEST_FOUNDATION_RESULT="${{ needs.test-foundation.result }}"
-          VALIDATE_AUX_RESULT="${{ needs.validate-auxiliary.result }}"
+          TEST_AND_VALIDATE_RESULT="${{ needs.test-and-validate.result }}"
           DARWIN_CHANGED='${{ needs.discover-targets.outputs.darwin-changed }}'
           NIXOS_CHANGED='${{ needs.discover-targets.outputs.nixos-changed }}'
           NIXOS_ARM_CHANGED='${{ needs.discover-targets.outputs.nixos-arm-changed }}'
@@ -464,23 +442,13 @@ jobs:
           echo "$SUMMARY configs changed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           # Report validation results
-          echo "### Validation" >> $GITHUB_STEP_SUMMARY
-          if [ "$VALIDATE_AUX_RESULT" = "success" ]; then
-            echo "✅ Auxiliary validation passed" >> $GITHUB_STEP_SUMMARY
-          elif [ "$VALIDATE_AUX_RESULT" = "skipped" ]; then
-            echo "⏭️ Auxiliary validation skipped" >> $GITHUB_STEP_SUMMARY
+          echo "### Tests & Validation" >> $GITHUB_STEP_SUMMARY
+          if [ "$TEST_AND_VALIDATE_RESULT" = "success" ]; then
+            echo "✅ Tests and validation passed" >> $GITHUB_STEP_SUMMARY
+          elif [ "$TEST_AND_VALIDATE_RESULT" = "skipped" ]; then
+            echo "⏭️ Tests and validation skipped" >> $GITHUB_STEP_SUMMARY
           else
-            echo "❌ Auxiliary validation failed" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-          # Report test results
-          echo "### Tests" >> $GITHUB_STEP_SUMMARY
-          if [ "$TEST_FOUNDATION_RESULT" = "success" ]; then
-            echo "✅ Foundation tests passed" >> $GITHUB_STEP_SUMMARY
-          elif [ "$TEST_FOUNDATION_RESULT" = "skipped" ]; then
-            echo "⏭️ Foundation tests skipped" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ Foundation tests failed" >> $GITHUB_STEP_SUMMARY
+            echo "❌ Tests and validation failed" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ "$DARWIN_CHANGED" = "[]" ] && [ "$NIXOS_CHANGED" = "[]" ]; then
@@ -501,14 +469,9 @@ jobs:
             echo "❌ NixOS (ARM) builds failed" >> $GITHUB_STEP_SUMMARY
             ALL_SUCCESS=false
           fi
-          if [ "$TEST_FOUNDATION_RESULT" != "success" ] \
-            && [ "$TEST_FOUNDATION_RESULT" != "skipped" ]; then
-            echo "❌ Foundation tests failed" >> $GITHUB_STEP_SUMMARY
-            ALL_SUCCESS=false
-          fi
-          if [ "$VALIDATE_AUX_RESULT" != "success" ] \
-            && [ "$VALIDATE_AUX_RESULT" != "skipped" ]; then
-            echo "❌ Auxiliary validation failed" >> $GITHUB_STEP_SUMMARY
+          if [ "$TEST_AND_VALIDATE_RESULT" != "success" ] \
+            && [ "$TEST_AND_VALIDATE_RESULT" != "skipped" ]; then
+            echo "❌ Tests and validation failed" >> $GITHUB_STEP_SUMMARY
             ALL_SUCCESS=false
           fi
           if [ "$ALL_SUCCESS" = "true" ]; then
@@ -516,9 +479,11 @@ jobs:
           else
             exit 1
           fi
-  # Validate auxiliary components (only when nix files changed)
-  validate-auxiliary:
-    name: Validate Shared Components
+  # Run foundation tests and auxiliary validation in a single job.
+  # Both need identical setup (Nix + Cachix + devenv) and run on the same
+  # runner, so merging them saves ~2.5 minutes of redundant setup per PR.
+  test-and-validate:
+    name: Tests & Validation
     runs-on: ubuntu-latest
     needs: [lint, changes]
     if: >
@@ -552,38 +517,6 @@ jobs:
         run: devenv tasks run validate:disko
       - name: Validate installation script
         run: devenv tasks run validate:install-script
-  # Run foundation tests (only when nix files changed)
-  test-foundation:
-    name: Foundation Tests
-    runs-on: ubuntu-latest
-    needs: [lint, changes]
-    if: >
-      ${{
-        needs.changes.outputs.nix-files == 'true' ||
-        needs.changes.outputs.workflows == 'true'
-      }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v21
-        with:
-          extra-conf: |
-            experimental-features = nix-command flakes
-            sandbox = false
-            access-tokens = ${{ env.NIX_ACCESS_TOKENS }}
-      - name: Cachix (read-only)
-        uses: cachix/cachix-action@v15
-        with:
-          name: funkymonkeymonk
-          skipPush: true
-      - name: Install devenv.sh (pinned to flake.lock nixpkgs)
-        run: |
-          NIXPKGS_OWNER=$(jq -r '.nodes.nixpkgs.locked.owner' flake.lock)
-          NIXPKGS_REPO=$(jq -r '.nodes.nixpkgs.locked.repo' flake.lock)
-          NIXPKGS_REV=$(jq -r '.nodes.nixpkgs.locked.rev' flake.lock)
-          nix profile add --accept-flake-config \
-            "github:${NIXPKGS_OWNER}/${NIXPKGS_REPO}/${NIXPKGS_REV}#devenv"
       - name: Run foundation tests
         env:
           SKIP_CONFIG_EVAL: "true"


### PR DESCRIPTION
- Combine 'Foundation Tests' and 'Validate Shared Components' into one job (saves ~2.5m redundant setup)
- Remove duplicate 'Save derivation cache' step in build-report
- Updates build-report needs, conditions, and summary output