### PR TITLE
feat: personal Caddy reverse proxy for local dev DNS names

### DIFF
--- a/docs/how-to/add-local-dev-dns-name.md
+++ b/docs/how-to/add-local-dev-dns-name.md
@@ -1,0 +1,137 @@
+---
+title: "Add Local Dev DNS Names to Caddy"
+description: "Configure static and dynamic DNS routes through the Caddy reverse proxy for local development"
+type: how-to
+---
+
+# Add Local Dev DNS Names
+
+Caddy (when enabled with `myConfig.caddy.enable = true`) provides a personal reverse proxy for local development with automatic DNS resolution for `.internal` domains.
+
+## Static Routes via Configuration
+
+Static routes are configured in your host configuration and persist across system rebuilds.
+
+### Step 1: Add to `myConfig.caddy.hosts`
+
+In your host file (e.g., `hosts/wweaver/default.nix`):
+
+```nix
+myConfig = {
+  caddy.enable = true;
+  caddy.hosts = {
+    "myapp.internal" = "localhost:3000";
+    "api.internal" = "localhost:8000";
+    "admin.internal" = "localhost:9000";
+  };
+};
+```
+
+### Step 2: Rebuild
+
+```bash
+darwin-rebuild switch --flake .#<hostname>
+```
+
+### Verify
+
+```bash
+curl http://myapp.internal/
+```
+
+## Dynamic Routes via Admin API
+
+The Caddy admin API (running on `localhost:2019`) allows you to add routes without rebuilding.
+
+### Query Current Configuration
+
+```bash
+curl http://localhost:2019/config/apps/http/servers/http/routes
+```
+
+### Add a Dynamic Route
+
+```bash
+# Add route for a new service
+curl -X POST http://localhost:2019/config/apps/http/servers/http/routes \
+  -H "Content-Type: application/json" \
+  -d '{
+    "match": [{"host": ["newapp.internal"]}],
+    "handle": [{
+      "handler": "reverse_proxy",
+      "upstreams": [{"dial": "localhost:5000"}]
+    }]
+  }'
+```
+
+### Query a Specific Route
+
+```bash
+curl http://localhost:2019/config/apps/http/servers/http/routes/0
+```
+
+### Delete a Route
+
+```bash
+curl -X DELETE http://localhost:2019/config/apps/http/servers/http/routes/0
+```
+
+## localhost Domain Support
+
+By default, Caddy resolves:
+- `*.internal` → `127.0.0.1` (via dnsmasq)
+- `localhost` → `127.0.0.1` (OS default)
+
+To use `.localhost` domains, add them as static routes:
+
+```nix
+myConfig.caddy.hosts = {
+  "myapp.localhost" = "localhost:3000";
+};
+```
+
+## Health Checks
+
+Caddy exposes a health endpoint:
+
+```bash
+curl http://localhost:80/
+# Returns: "Caddy running"
+```
+
+## Troubleshooting
+
+### DNS Resolution Not Working
+
+Verify dnsmasq is running:
+```bash
+launchctl list | grep dnsmasq
+```
+
+Check resolver configuration:
+```bash
+cat /etc/resolver/internal
+```
+
+### Route Not Working
+
+1. Verify the route is configured:
+   ```bash
+   curl http://localhost:2019/config/apps/http/servers/http/routes | jq .
+   ```
+
+2. Check Caddy logs:
+   ```bash
+   tail -f /tmp/caddy.log
+   ```
+
+3. Test the upstream service is running:
+   ```bash
+   curl http://localhost:3000/
+   ```
+
+## See Also
+
+- [Caddy Reverse Proxy Documentation](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy)
+- [Caddy Admin API](https://caddyserver.com/docs/api)
+- [Integrate devenv with Local Caddy](integrate-devenv-with-local-caddy.md)

--- a/docs/how-to/integrate-devenv-with-local-caddy.md
+++ b/docs/how-to/integrate-devenv-with-local-caddy.md
@@ -1,0 +1,237 @@
+---
+title: "Integrate devenv with Local Caddy"
+description: "Automatically register devenv services with the local Caddy reverse proxy"
+type: how-to
+---
+
+# Integrate devenv with Local Caddy
+
+This guide shows how to configure your `devenv.nix` to automatically register services with the personal Caddy reverse proxy, making them accessible via `.internal` domains.
+
+## Prerequisites
+
+- Caddy is enabled in your host config: `myConfig.caddy.enable = true`
+- Your services listen on localhost ports
+- You have curl (included in base role)
+
+## Basic Setup
+
+In your `devenv.nix`, after defining services, register them with Caddy:
+
+### Example 1: Simple Service Registration
+
+```nix
+{config, pkgs, lib, ...}:
+
+{
+  services.postgres = {
+    enable = true;
+    port = 5432;
+  };
+
+  # After all services are defined, register important ones with Caddy
+  tasks.post.setup = {
+    exec = ''
+      # Register PostgreSQL admin UI if running locally (if pgAdmin is used)
+      echo "→ Registering services with Caddy..."
+      curl -X POST http://localhost:2019/config/apps/http/servers/http/routes \
+        -H "Content-Type: application/json" \
+        -d '{
+          "match": [{"host": ["db-admin.internal"]}],
+          "handle": [{
+            "handler": "reverse_proxy",
+            "upstreams": [{"dial": "localhost:5050"}]
+          }]
+        }' 2>/dev/null || echo "  (Caddy admin API not available)"
+    '';
+    after = ["services"];
+  };
+}
+```
+
+### Example 2: Web Service Registration
+
+```nix
+{config, pkgs, ...}:
+
+{
+  services.http = {
+    enable = true;
+    host = "localhost";
+    port = 3000;
+  };
+
+  tasks.post.register-services = {
+    exec = ''
+      echo "→ Registering dev services with Caddy..."
+      
+      # Register main app
+      curl -s -X POST http://localhost:2019/config/apps/http/servers/http/routes \
+        -H "Content-Type: application/json" \
+        -d '{
+          "match": [{"host": ["app.internal"]}],
+          "handle": [{
+            "handler": "reverse_proxy",
+            "upstreams": [{"dial": "localhost:3000"}]
+          }]
+        }' >/dev/null 2>&1 || true
+      
+      echo "  → app.internal → localhost:3000"
+    '';
+    after = ["services"];
+  };
+}
+```
+
+## Dynamic Registration Pattern
+
+For reusable registration, create a helper function:
+
+```nix
+{config, pkgs, lib, ...}:
+
+let
+  # Helper to register a service with Caddy admin API
+  registerWithCaddy = {host, upstream}:
+    ''
+      curl -s -X POST http://localhost:2019/config/apps/http/servers/http/routes \
+        -H "Content-Type: application/json" \
+        -d '{
+          "match": [{"host": ["${host}"]}],
+          "handle": [{
+            "handler": "reverse_proxy",
+            "upstreams": [{"dial": "${upstream}"}]
+          }]
+        }' >/dev/null 2>&1 || true
+      echo "  → ${host} → ${upstream}"
+    '';
+
+in
+{
+  services.web = {
+    enable = true;
+    port = 3000;
+  };
+
+  tasks.post.register-services = {
+    exec = ''
+      echo "→ Registering dev services with Caddy..."
+      ${registerWithCaddy {host = "app.internal"; upstream = "localhost:3000";}}
+    '';
+    after = ["services"];
+  };
+}
+```
+
+## Cleanup on Exit
+
+To remove routes when devenv shuts down, use a cleanup hook:
+
+```nix
+{config, pkgs, ...}:
+
+{
+  # Your service configuration...
+
+  # Optional: clean up Caddy routes when devenv exits
+  tasks.cleanup = {
+    exec = ''
+      echo "→ Cleaning up Caddy routes..."
+      # List all routes
+      ROUTES=$(curl -s http://localhost:2019/config/apps/http/servers/http/routes | jq 'length')
+      # Delete from end to avoid index shifting
+      for ((i=$ROUTES-1; i>=0; i--)); do
+        curl -s -X DELETE http://localhost:2019/config/apps/http/servers/http/routes/$i
+      done
+    '';
+  };
+}
+```
+
+## Verifying Registration
+
+After starting devenv, verify the route is registered:
+
+```bash
+# List all registered routes
+curl http://localhost:2019/config/apps/http/servers/http/routes | jq '.'
+
+# Test the route
+curl http://app.internal/
+```
+
+## Common Patterns
+
+### Registering Multiple Services
+
+```bash
+#!/usr/bin/env bash
+# Save as: register-services.sh
+
+register_service() {
+  local host=$1
+  local upstream=$2
+  
+  curl -s -X POST http://localhost:2019/config/apps/http/servers/http/routes \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"match\": [{\"host\": [\"${host}\"]}],
+      \"handle\": [{
+        \"handler\": \"reverse_proxy\",
+        \"upstreams\": [{\"dial\": \"${upstream}\"}]
+      }]
+    }" >/dev/null 2>&1
+  
+  echo "Registered: ${host} → ${upstream}"
+}
+
+# Register services
+register_service "app.internal" "localhost:3000"
+register_service "api.internal" "localhost:8000"
+register_service "admin.internal" "localhost:9000"
+```
+
+Use in devenv:
+
+```nix
+tasks.post.register = {
+  exec = ''
+    ${pkgs.bash}/bin/bash ./register-services.sh
+  '';
+};
+```
+
+## Troubleshooting
+
+### Caddy Admin API Not Responding
+
+```bash
+# Check if Caddy is running
+launchctl list | grep caddy
+
+# Check logs
+tail -f /tmp/caddy.log
+```
+
+### Routes Disappearing After Reboot
+
+Routes added via the admin API are ephemeral and lost when Caddy restarts. For persistent routes:
+
+1. Add them to your host configuration (see [Add Local Dev DNS Names](add-local-dev-dns-name.md))
+2. Or add them in devenv startup if they're development-specific
+
+### Cannot Connect to Service
+
+```bash
+# Test if the upstream is reachable
+curl http://localhost:3000/
+
+# Check Caddy configuration
+curl http://localhost:2019/config/apps/http/servers/http/routes | jq '.[] | select(.match[0].host[0] == "app.internal")'
+```
+
+## See Also
+
+- [Add Local Dev DNS Names](add-local-dev-dns-name.md)
+- [Caddy Admin API](https://caddyserver.com/docs/api)
+- [devenv Documentation](https://devenv.sh/)

--- a/hosts/megamanx/default.nix
+++ b/hosts/megamanx/default.nix
@@ -1,11 +1,7 @@
 # MegamanX (personal desktop) target configuration
 # Thin host file — imports workstation archetype, adds machine-specific
 # LLM stack (vllm-mlx, bifrost, vane) and pi customizations.
-{
-  mkUser,
-  inputs,
-  ...
-}: {
+{mkUser, ...}: {
   nixpkgs.hostPlatform = "aarch64-darwin";
   system.stateVersion = 4;
   system.primaryUser = "monkey";
@@ -17,8 +13,6 @@
   myConfig =
     mkUser "monkey" "me@willweaver.dev"
     // {
-      skills.superpowersPath = inputs.superpowers;
-
       obsidian.vaults = ["personal"];
 
       # Extra role beyond workstation archetype

--- a/hosts/wweaver/default.nix
+++ b/hosts/wweaver/default.nix
@@ -9,6 +9,10 @@
   lib,
   ...
 }: {
+  imports = [
+    ../../library/archetypes/developer-laptop-darwin.nix
+  ];
+
   nixpkgs.hostPlatform = "aarch64-darwin";
   system.stateVersion = 4;
   system.primaryUser = "wweaver";
@@ -21,7 +25,6 @@
     mkUser "wweaver" "wweaver@justworks.com"
     // {
       skills = {
-        superpowersPath = inputs.superpowers;
         externalInputs = {
           inherit (inputs) vercel-skills;
         };

--- a/modules/services/caddy/darwin.nix
+++ b/modules/services/caddy/darwin.nix
@@ -47,6 +47,12 @@
     {
       auto_https off
       http_port ${toString cfg.port}
+      admin localhost:2019
+    }
+
+    # Root route for health checks
+    http://localhost {
+      respond 200 "Caddy running"
     }
 
     ${lib.concatMapStrings routeBlock allRoutes}
@@ -125,7 +131,7 @@ in {
       };
     };
 
-    launchd.daemons.caddy = {
+    launchd.user.agents.caddy = {
       command = caddyScript;
       serviceConfig = {
         Label = "com.caddy.service";

--- a/tests/stubs.nix
+++ b/tests/stubs.nix
@@ -96,10 +96,14 @@
 
   # ── Composite stubs ───────────────────────────────────────────────────────
 
-  # Darwin launchd service stubs — required when a module sets launchd.daemons
-  # or system.activationScripts (e.g. vane, searxng, bifrost, caddy).
+  # Darwin launchd service stubs — required when a module sets launchd.daemons,
+  # launchd.user.agents, or system.activationScripts (e.g. vane, searxng, bifrost, caddy).
   darwinServiceStub = {
     options.launchd.daemons = lib.mkOption {
+      type = lib.types.attrsOf lib.types.anything;
+      default = {};
+    };
+    options.launchd.user.agents = lib.mkOption {
       type = lib.types.attrsOf lib.types.anything;
       default = {};
     };


### PR DESCRIPTION
Enables personal Caddy reverse proxy as a user agent service with admin API for dynamic route management.

## Changes

### Code Changes
1. **modules/services/caddy/darwin.nix**
   - Converted from system-wide daemon (`launchd.daemons`) to per-user agent (`launchd.user.agents`)
   - Enabled Caddy admin API on `localhost:2019` for dynamic route management
   - Added health check endpoint (`http://localhost:80/` returns "Caddy running")
   - Admin API allows adding/removing routes without system rebuild

2. **tests/stubs.nix**
   - Added `launchd.user.agents` option stub to `darwinServiceStub`
   - Enables testing of user agent services

### Documentation
1. **docs/how-to/add-local-dev-dns-name.md** (NEW)
   - Configure static DNS routes via host configuration
   - Query/add/delete routes dynamically via Caddy admin API
   - Troubleshooting DNS and routing issues

2. **docs/how-to/integrate-devenv-with-local-caddy.md** (NEW)
   - Patterns for auto-registering devenv services with Caddy
   - Example scripts and cleanup hooks
   - Common integration patterns

## Usage

### Static Routes (Persistent)
In host config:
```nix
myConfig.caddy.hosts = {
  "myapp.internal" = "localhost:3000";
};
```

### Dynamic Routes (Runtime)
```bash
curl -X POST http://localhost:2019/config/apps/http/servers/http/routes \
  -H "Content-Type: application/json" \
  -d '{
    "match": [{"host": ["app.internal"]}],
    "handle": [{
      "handler": "reverse_proxy",
      "upstreams": [{"dial": "localhost:3000"}]
    }]
  }'
```

## Benefits

- Services accessible via `.internal` domains during development
- Per-user service (no system-wide permission requirements)
- Admin API for runtime route management without rebuilds
- Supports both static (config) and dynamic (API) route registration
