### PR TITLE
fix(vllm-mlx): enable system KV cache for MLLM text routing with RotatingKVCache models

### DIFF
--- a/packages/vllm-mlx/snapshot-rotating-kv-cache.patch
+++ b/packages/vllm-mlx/snapshot-rotating-kv-cache.patch
@@ -75,3 +75,42 @@
  
      @classmethod
      def _probe_system_kv_cache_support(cls, model: Any, route: str) -> bool:
+@@ -503,36 +519,36 @@
+                         # Under bounded-KV serving (max_kv_size > 0) make_prompt_cache
+                         # returns RotatingKVCache for models without a custom
+                         # make_cache; probing with default args would mis-classify that
+                         # path as snapshot-safe.
+                         try:
+-                            from mlx_lm.models.cache import KVCache, make_prompt_cache
++                            from mlx_lm.models.cache import make_prompt_cache
+ 
+                             probe_cache = make_prompt_cache(
+                                 self._text_model, max_kv_size=self._max_kv_size or None
+                             )
+                             self._supports_system_kv_cache = bool(probe_cache) and all(
+-                                isinstance(c, KVCache) for c in probe_cache
++                                self._cache_class_is_system_snapshot_safe(c) for c in probe_cache
+                             )
+                             if not self._supports_system_kv_cache:
+                                 cache_types = sorted(
+                                     {type(c).__name__ for c in probe_cache}
+                                 )
+                                 logger.info(
+                                     "System KV cache snapshot disabled for MLLM "
+                                     "text routing: TextModel returned non-KVCache "
+                                     "entries (%s); _stream_generate_text will use "
+                                     "the uncached path",
+                                     cache_types,
+                                 )
+                         except Exception as e:
+                             logger.debug(
+                                 "MLLM TextModel KV cache support probe failed "
+                                 "(%s); disabling snapshot path",
+                                 e,
+                             )
+                             self._supports_system_kv_cache = False
+ 
+                         has_mtp = (
+                             hasattr(self._text_model, "mtp")
+                             and self._text_model.mtp is not None
+                         )


### PR DESCRIPTION
## Problem

Gemma 4 models are loaded as MLLM (multimodal) because their weights include vision components. For text-only requests, vllm-mlx builds a parallel **TextModel** and probes its KV cache for snapshot safety.

The MLLM text routing probe hardcoded  — it did NOT recognize  as snapshot-safe, even though our  already teaches  to handle it.

**Result:** . Every single pi turn re-prefilled the entire ~97K-character system prompt + conversation history from scratch on a 31B model, taking 7–10 minutes. Pi's 10-minute timeout + retry config caused a queue pile-up of redundant prefills, making the system sluggish.

## Fix

Replace the hardcoded  check with  — the same method the pure-LLM path already uses. This method (patched in this repo) recognizes  as safe when meta_state is captured/restored alongside array state.

## Verification

- {} ✅
- {} ✅ (all 28 nix-unit tests + vllm-mlx-finish-reason)
- All 3 patches (, , ) apply cleanly in sequence on upstream v0.4.0
- Built and deployed locally; verified fix present in 

## Related

- Complements #673 (emit-terminal-finish-chunk) — both needed for working Gemma 4 + tool calls
- The death spiral diagnosis is detailed in the PR discussion