### PR TITLE
chore(gitignore): ignore subagent runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ tmp
 profiling/
 *.profile.json
 *.profile.md
+
+# Subagent runtime artifacts
+.pi-subagents/


### PR DESCRIPTION
Adds .pi-subagents/ to .gitignore so agent delegation artifacts are not accidentally committed.