### PR TITLE
refactor(skills): remove redundant developer role, add pi to general-purpose skills

### DIFF
--- a/modules/home-manager/skills/internal/writing-skills/SKILL.md
+++ b/modules/home-manager/skills/internal/writing-skills/SKILL.md
@@ -35,7 +35,7 @@ Every skill must be registered in `modules/home-manager/skills/manifest.nix`:
 ```nix
 "skill-name" = {
   description = "Same as SKILL.md description";
-  roles = ["developer" "opencode" "claude" "pi"];  # Add pi for general-purpose skills
+  roles = ["opencode" "claude" "pi"];  # Add pi for general-purpose skills
   source = {
     type = "internal";
     path = ./internal/skill-name;
@@ -45,9 +45,10 @@ Every skill must be registered in `modules/home-manager/skills/manifest.nix`:
 ```
 
 **Role guidelines:**
-- `"pi"` — add to general-purpose skills (debugging, tdd, writing-plans, etc.)
-- `"workstation"` — work-specific skills (infra-investigation, vendor-eval, etc.)
-- `"opencode"`, `"claude"` — agent-specific skills
+- `"opencode"`, `"claude"`, `"pi"` — agent roles; a skill needs at least one of these to ever load, and skills load identically for every agent enabled on a given host (agent-specific gating happens elsewhere, not via these tags)
+- `"pi"` — add unless the skill is genuinely tied to opencode/claude-specific tooling (Task tool syntax, slash commands, etc.); most technique/reference skills are agent-agnostic and should include it
+- `"workstation"`, `"creative"` — machine-class tags for skills tied to a specific role bundle beyond "has an AI assistant" (e.g. `innersource-pr-haiku` for work contexts, `brainstorming` for creative work)
+- Do **not** add `"developer"` — every host with an AI-assistant role enabled also has `developer` enabled in practice, making it redundant; omitting it keeps the actual gating role explicit
 - Keep roles minimal; agents load all matching skills
 
 ### Progressive Disclosure

--- a/modules/home-manager/skills/manifest.nix
+++ b/modules/home-manager/skills/manifest.nix
@@ -4,7 +4,7 @@
   # Internal skills - defined in this repository
   "writing-skills" = {
     description = "Use when creating new skills, editing existing skills, or verifying skills work before deployment in this repository";
-    roles = ["developer" "creative" "opencode" "claude" "pi"];
+    roles = ["creative" "opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/writing-skills;
@@ -14,7 +14,7 @@
 
   "diataxis-docs" = {
     description = "Use when updating, rewriting, or auditing documentation to follow the Diataxis framework";
-    roles = ["developer" "creative" "opencode" "claude"];
+    roles = ["creative" "opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/diataxis-docs;
@@ -24,7 +24,7 @@
 
   "nix-opnix-secrets" = {
     description = "Use when managing 1Password secrets via Nix on nix-darwin. Covers mkOpnixSecretsGeneric, programs.onepassword-secrets, activation script ordering, and runtime patching of config files";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/nix-opnix-secrets;
@@ -34,7 +34,7 @@
 
   "nix-adding-services" = {
     description = "Use when adding a new service to this Nix flake. Covers the full lifecycle: package from source (Node/Rust/Python), service module, options, secrets, home-manager config, tests, target wiring, and validation";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/nix-adding-services;
@@ -44,7 +44,7 @@
 
   "nix-darwin-launchd-debugging" = {
     description = "Use when debugging nix-darwin launchd services that fail to start, exit with non-zero, or don't reload on switch. Covers EX_CONFIG, $HOME expansion trap, daemon vs user.agent, and manual plist reloading";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/nix-darwin-launchd-debugging;
@@ -54,7 +54,7 @@
 
   "nix-hf-models" = {
     description = "Use when pre-downloading HuggingFace models into the Nix store for local inference. Covers hf download CLI, fixed-output derivations, hash computation, and CDN/auth issues";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/nix-hf-models;
@@ -78,7 +78,7 @@
   # Based on @coreyja/jj from https://github.com/coreyja/dotfiles/tree/main/.claude/skills/jj
   "jj" = {
     description = "Use Jujutsu (jj) for version control. Treats pushed commits as immutable; every PR update adds a single new commit on top of the remote tip (no force pushes). Covers workflow, commits, bookmarks with Conventional Branch naming, pushing to GitHub, merge-based sync, stacked PRs, and workspaces for multi-project isolation";
-    roles = ["developer" "opencode" "claude"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./external/jj;
@@ -94,7 +94,7 @@
   # Ralph Loop specification skills
   "ralph-specs" = {
     description = "Use when planning features for autonomous AI implementation, converting ideas into Ralph Loop PRDs, or breaking work into atomic user stories for unattended agent execution";
-    roles = ["developer" "opencode" "claude"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/ralph-specs;
@@ -104,7 +104,7 @@
 
   "prd-review" = {
     description = "Use when reviewing a PRD before or during Ralph Loop execution, checking story completion status, or validating story structure and dependencies in a prd.json file";
-    roles = ["developer" "opencode" "claude"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/prd-review;
@@ -114,7 +114,7 @@
 
   "refining-specs" = {
     description = "Use when a specification has open questions requiring research, technical decisions, or user input to resolve";
-    roles = ["developer" "opencode" "claude"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/refining-specs;
@@ -124,7 +124,7 @@
 
   "yak-shaving" = {
     description = "Use when tracking, planning, implementing, or reviewing work using yx (yaks) with the autonomous /shave loop, or when multiple agents need to coordinate on shared tasks";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/yak-shaving;
@@ -139,7 +139,7 @@
 
   "iterating-nix-embedded-scripts" = {
     description = "Use when iterating on shell scripts embedded in Nix modules via writeShellScriptBin, writeShellApplication, writeScriptBin, or writeText — avoids slow build/switch cycles for every edit";
-    roles = ["developer" "opencode" "claude"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/iterating-nix-embedded-scripts;
@@ -149,7 +149,7 @@
 
   zellij = {
     description = "Zellij terminal multiplexer — creating KDL layouts, managing sessions via CLI, and running commands without disrupting the user's workspace";
-    roles = ["developer" "opencode" "claude"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/zellij;
@@ -160,7 +160,7 @@
   # Personal skills - managed in this repository
   "creating-user-manual" = {
     description = "Use when creating a personal user manual, manager README, or working-with-me document. Use when someone wants to document their working style, communication preferences, or collaboration patterns for colleagues";
-    roles = ["developer" "opencode" "claude"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/creating-user-manual;
@@ -170,7 +170,7 @@
 
   "devenv" = {
     description = "Use when working with devenv developer environments. Covers setup, packages, scripts, tasks, processes, services, git-hooks, and file generation. Use when initializing devenv, adding packages, configuring services like postgres/redis, running processes, or troubleshooting devenv issues";
-    roles = ["developer" "opencode" "claude"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/devenv;
@@ -190,7 +190,7 @@
 
   "open-url-new-window" = {
     description = "Use when the user asks to open a URL in a new browser window (not a new tab), or when opening documentation/references on macOS without disrupting their current browser session";
-    roles = ["developer" "opencode" "claude"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/open-url-new-window;
@@ -205,7 +205,7 @@
   # its own writing-skills skill covering the same ground).
   "brainstorming" = {
     description = "Use when creating or developing, before writing code or implementation plans - refines rough ideas into fully-formed designs through collaborative questioning, alternative exploration, and incremental validation. Don't use during clear 'mechanical' processes";
-    roles = ["developer" "creative" "opencode" "claude" "pi"];
+    roles = ["creative" "opencode" "claude" "pi"];
     source = {
       type = "superpowers";
       skillName = "brainstorming";
@@ -215,7 +215,7 @@
 
   "condition-based-waiting" = {
     description = "Use when tests have race conditions, timing dependencies, or inconsistent pass/fail behavior - replaces arbitrary timeouts with condition polling to wait for actual state changes, eliminating flaky tests from timing guesses";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "superpowers";
       skillName = "condition-based-waiting";
@@ -225,7 +225,7 @@
 
   "defense-in-depth" = {
     description = "Use when invalid data causes failures deep in execution, requiring validation at multiple system layers - validates at every layer data passes through to make bugs structurally impossible";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "superpowers";
       skillName = "defense-in-depth";
@@ -235,7 +235,7 @@
 
   "root-cause-tracing" = {
     description = "Use when errors occur deep in execution and you need to trace back to find the original trigger - systematically traces bugs backward through call stack, adding instrumentation when needed, to identify source of invalid data or incorrect behavior";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "superpowers";
       skillName = "root-cause-tracing";
@@ -245,7 +245,7 @@
 
   "test-driven-development" = {
     description = "Use when implementing any feature or bugfix, before writing implementation code - write the test first, watch it fail, write minimal code to pass; ensures tests actually verify behavior by requiring failure first";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "superpowers";
       skillName = "test-driven-development";
@@ -255,7 +255,7 @@
 
   "testing-anti-patterns" = {
     description = "Use when writing or changing tests, adding mocks, or tempted to add test-only methods to production code - prevents testing mock behavior, production pollution with test-only methods, and mocking without understanding dependencies";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "superpowers";
       skillName = "testing-anti-patterns";
@@ -265,7 +265,7 @@
 
   "verification-before-completion" = {
     description = "Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "superpowers";
       skillName = "verification-before-completion";
@@ -275,7 +275,7 @@
 
   "receiving-code-review" = {
     description = "Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "superpowers";
       skillName = "receiving-code-review";
@@ -285,7 +285,7 @@
 
   "executing-plans" = {
     description = "Use when partner provides a complete implementation plan to execute in controlled batches with review checkpoints - loads plan, reviews critically, executes tasks in batches, reports for review between batches";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "superpowers";
       skillName = "executing-plans";
@@ -298,7 +298,7 @@
   # native Task tool / @mention subagent support.
   "dispatching-parallel-agents" = {
     description = "Use when facing 3+ independent failures that can be investigated without shared state or dependencies - dispatches multiple agents to investigate and fix independent problems concurrently";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "superpowers";
       skillName = "dispatching-parallel-agents";
@@ -308,7 +308,7 @@
 
   "subagent-driven-development" = {
     description = "Use when executing implementation plans with independent tasks in the current session - dispatches fresh subagent for each task with code review between tasks, enabling fast iteration with quality gates";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "superpowers";
       skillName = "subagent-driven-development";
@@ -320,7 +320,7 @@
   # they contained git-specific commands, patched to jj equivalents.
   "writing-plans" = {
     description = "Use when design is complete and you need detailed implementation tasks for engineers with zero codebase context - creates comprehensive implementation plans with exact file paths, complete code examples, and verification steps assuming engineer has minimal domain knowledge";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/writing-plans;
@@ -330,7 +330,7 @@
 
   "requesting-code-review" = {
     description = "Use when completing tasks, implementing major features, or before merging to verify work meets requirements - dispatches a code-reviewer subagent to review implementation against plan or requirements before proceeding";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/requesting-code-review;
@@ -340,7 +340,7 @@
 
   "systematic-debugging" = {
     description = "Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes - four-phase framework (root cause investigation, pattern analysis, hypothesis testing, implementation) that prevents guess-and-check debugging";
-    roles = ["developer" "opencode" "claude" "pi"];
+    roles = ["opencode" "claude" "pi"];
     source = {
       type = "internal";
       path = ./internal/systematic-debugging;


### PR DESCRIPTION
Finishes the role-scoping TODO from the previous skills audit (#415).

## Investigation

Before touching anything, verified whether narrowing roles actually changes behavior:

- On `wweaver` and `MegamanX` (the only two real hosts with an AI-assistant role enabled), `developer` always co-occurs with `opencode`/`claude`/`pi` — confirmed via a live `nix eval` diff that stripping `developer` from every skill changes the resolved skill set on `wweaver` by exactly **zero** skills.
- On `MegamanX` (pi-only, no opencode/claude), **10 skills were loading only because of the `developer` tag**, since they lacked a `pi` tag: `creating-user-manual`, `devenv`, `diataxis-docs`, `iterating-nix-embedded-scripts`, `jj`, `open-url-new-window`, `prd-review`, `ralph-specs`, `refining-specs`, `zellij`. Verified by content inspection that none of these are opencode/claude-specific — all are general technique/reference skills — so added `pi` to each rather than leaving the gap.
- With `pi` added to those 10, removing `developer` from all 31 skills is a verified no-op on every host in this repo (`wweaver`, `MegamanX`, `darwin-server`, `type-darwin-server`, `zero`) **except one**: `innersource-pr-haiku`, tagged `[developer, workstation]`, would stop loading on `darwin-server`/`zero` (developer but not workstation).

## Deferred

Left `innersource-pr-haiku`'s roles untouched — investigating it surfaced a real framing problem: `workstation` means "developer machine form-factor" in this repo, not "work context." `wweaver` is a work laptop and `MegamanX` is personal, but both get `workstation.enable = true` from the same shared archetype. This deserves its own dedicated session rather than a quick patch here.

## Changes

- Removed `"developer"` from every skill's `roles` in `modules/home-manager/skills/manifest.nix` (31 skills)
- Added `"pi"` to the 10 skills identified above
- Updated the `writing-skills` skill's own manifest-registration guidance to reflect the new convention: default to `[opencode, claude, pi]`, never `developer`

## Testing

- `check:lint` — passes
- `test:eval` — passes
- Targeted checks: `skills-manifest`, `skills-role-filtering`, `skills-autoload-content`, `skills-autoload-filtering`, `all-role-tests`, `nix-unit-tests` (27/27) — all pass
- Live-verified via `nix eval` diff: `wweaver`'s resolved skill set is byte-identical before/after (31 skills, no change)
- Live-verified via `system:switch`: both `~/.config/opencode/skills/` and `~/.pi/agent/skills/` deploy the same 31 skills, no orphans